### PR TITLE
Fix: Issue #67, Skills and items no longer jump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3265,11 +3265,11 @@
       "dev": true
     },
     "foundry-pc-types": {
-      "version": "gitlab:foundry-projects/foundry-pc/foundry-pc-types#5c7f8af606ee075228608bd4791f3cfdad7f8c10",
+      "version": "gitlab:foundry-projects/foundry-pc/foundry-pc-types#6ead51c20f4027a3ed0ce7ab474bb54a645269af",
       "from": "gitlab:foundry-projects/foundry-pc/foundry-pc-types",
       "dev": true,
       "requires": {
-        "@types/jquery": "^3.5.1",
+        "@types/jquery": "^3.3.31",
         "@types/socket.io-client": "^1.4.33",
         "@types/tinymce": "^4.5.24"
       }

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -83,7 +83,8 @@ export class TwodsixActorSheet extends ActorSheet {
             width: 825,
             height: 648,
             resizable: false,
-            tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "skills"}]
+            tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "skills"}],
+            scrollY: [".skills", ".inventory"] 
         });
     }
 

--- a/static/system.json
+++ b/static/system.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/xdy/twodsix-foundryvtt/",
   "manifest": "https://github.com/xdy/twodsix-foundryvtt/releases/latest/download/system.json",
   "download": "https://github.com/xdy/twodsix-foundryvtt/releases/latest/download/twodsix.zip",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Jonas Karlsson (xdy#3735), Kevin Maree (Ultra Kev#9816), Rob (RobCubed #9180)",
   "bugs": "Plenty of them, this is an early alpha...",
   "changelog": "https://raw.githubusercontent.com/xdy/twodsix-foundryvtt/master/CHANGELOG.md",


### PR DESCRIPTION
Bug issue #67 has been fixed, big thank you to Daddi.

Skill list and item list no longer jumps back to top on changes.