### PR TITLE
new feature: close and create new item in one go fix: close and create new item in one go 

### DIFF
--- a/src/module/hooks/createItem.ts
+++ b/src/module/hooks/createItem.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+Hooks.on('createItem', async (entity, options, userId) => {
+  // Set flag newItem for newly created items so that we can show the "close and create new" button for new items.
+  entity.setFlag('twodsix', 'newItem', true);
+});

--- a/src/module/hooks/renderItemSheet.ts
+++ b/src/module/hooks/renderItemSheet.ts
@@ -1,0 +1,29 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+Hooks.on('renderItemSheet', async (app, html, data) => {
+  const item = game.items.get(data.entity._id);
+
+  // Check if item was just created
+  if (item && item.getFlag('twodsix', 'newItem')) {
+    // Mark item as no longer being new so that it won't show up when opening the item in the future
+    item.unsetFlag('twodsix', 'newItem');
+
+    const closeAndCreateNew = game.i18n.localize("TWODSIX.CloseAndCreateNew");
+    const copyText = game.i18n.localize("TWODSIX.Copy");
+
+    const closeAndCreateBtn = $(`<a title="${closeAndCreateNew}"><i class="fas fa-save"></i> ${closeAndCreateNew}</a>`);
+
+    closeAndCreateBtn.on("click", () => {
+      // close current item sheet
+      item.sheet.close();
+
+      // create new item of same type and show its sheet
+      Item.create({name: `${item.name} (${copyText})`, type: item.type}).then(newItem => {
+        newItem.sheet.render(true);
+      });
+    });
+
+    // insert the new button just before the close button
+    const closeButton = html.closest('.app').find('.header-button.close');
+    closeAndCreateBtn.insertBefore(closeButton);
+  }
+});

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -174,7 +174,7 @@
       "MigrationError0.6.25": "Migration error: Couldn't parse price for ${name}, it was ${price} but is now 0."
     },
     "Modules": {
-      "compendiumFolders":{
+      "compendiumFolders": {
         "missing": "The included compendiums for the various Cepheus variants often use the 'Compendium Folders' module. If you use those, please install the Compendium Folders module in Foundry VTT. Or turn off this warning in System Settings.",
         "disabled": "Please enable the 'Compendium Folders' module in this world if you intend to use the included compendiums. Or turn off this warning in System Settings."
       }
@@ -286,6 +286,8 @@
         "name": "The value that is used for untrained skills."
       }
     },
+    "CloseAndCreateNew": "Close and create new",
+    "Copy": "Copy",
     "Yes": "Yes",
     "itemTypes": {
       "equipment": "equipment",

--- a/static/lang/sv.json
+++ b/static/lang/sv.json
@@ -286,6 +286,8 @@
         "name": "Värdet som används för otränade färdigheter."
       }
     },
+    "CloseAndCreateNew": "Stäng och skapa ny",
+    "Copy": "Kopia",
     "Yes": "Ja",
     "itemTypes": {
       "equipment": "utrustning",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -20,7 +20,7 @@ module.exports = (env, argv) => {
   const config:Configuration = {
     context: __dirname,
     entry: {
-      main: ["./src/twodsix.ts", "./src/module/hooks/ready.ts", "./src/module/hooks/setup.ts", "./src/module/hooks/preCreateActor.ts", "./src/module/hooks/renderChatMessage.ts"]
+      main: ["./src/twodsix.ts", "./src/module/hooks/ready.ts", "./src/module/hooks/setup.ts", "./src/module/hooks/preCreateActor.ts", "./src/module/hooks/createItem.ts", "./src/module/hooks/renderItemSheet.ts", "./src/module/hooks/renderChatMessage.ts"]
     },
     mode: "development",
     module: {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning, so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.)
- [x] Docs have been added / updated (for bug fixes / features) - Not  sure if this is necessary here?


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature
Fixes #105 


* **What is the current behavior?** (You can also link to an open issue here)
Currently adding new items requires several steps. As it sometimes is
desirable to add several items at once this can become tedious.


* **What is the new behavior (if this is a feature change)?**
Adds a button to automatically close the current newly added item and creates a new one.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**: