### PR TITLE
 fix: add dropdown with settings for rulesets

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -22,6 +22,52 @@ TWODSIX.VARIANTS = {
   "CEL": "CEL",
 };
 
+TWODSIX.RULESETS = {
+  "CE": {
+    "name": "Cepheus Engine",
+    "setttings": {
+      "initiativeFormula": "2d6 + @characteristics.dexterity.mod",
+      "difficultyListUsed": "CE",
+      "difficultiesAsTargetNumber": false,
+      "autofireRulesUsed": "CE",
+      "modifierForZeroCharacteristic": -2,
+      "termForAdvantage": "advantage",
+      "termForDisadvantage": "disadvantage",
+      "absoluteBonusValueForEachTimeIncrement": 1
+    }
+  },
+  "CEL": {
+    "name": "Cepheus Light",
+    "setttings": {
+      "initiativeFormula": "2d6",
+      "difficultyListUsed": "CEL",
+      "difficultiesAsTargetNumber": true,
+      "autofireRulesUsed": "CEL",
+      "modifierForZeroCharacteristic": -2,
+      "termForAdvantage": "advantage",
+      "termForDisadvantage": "disadvantage",
+      "absoluteBonusValueForEachTimeIncrement": 1
+    }
+  },
+  "CEFTL": {
+    "name": "Cepheus Faster Than Light",
+    "setttings": {
+      "initiativeFormula": "2d6",
+      "difficultyListUsed": "CEL",
+      "difficultiesAsTargetNumber": true,
+      "autofireRulesUsed": "CE",
+      "modifierForZeroCharacteristic": -2,
+      "termForAdvantage": "advantage",
+      "termForDisadvantage": "disadvantage",
+      "absoluteBonusValueForEachTimeIncrement": 1
+    }
+  },
+  "OTHER": {
+    "name": "Other",
+    "setttings": {}
+  }
+};
+
 TWODSIX.ROLLTYPES = {
   Advantage: "3d6kh2",
   Normal: "2d6",

--- a/src/module/hooks/renderSettingsConfig.ts
+++ b/src/module/hooks/renderSettingsConfig.ts
@@ -1,0 +1,14 @@
+import {TWODSIX} from "../config";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+Hooks.on('renderSettingsConfig', async (app, html, data) => {
+  html.find('[name="twodsix.ruleset"]').on('change', ev => {
+    const ruleset = ev.target.value;
+    const rulesetSettings = TWODSIX.RULESETS[ruleset].setttings;
+
+    // Step through each option and update the corresponding field
+    Object.entries(rulesetSettings).forEach(([settingName, value]) => {
+      html.find(`[name="twodsix.${settingName}"]`).val(value);
+    });
+  });
+});

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -5,6 +5,11 @@ export const registerSettings = function ():void {
   //Foundry default behaviour related settings
   _booleanSetting('defaultTokenSettings', true);
 
+  const rulesetOptions = Object.entries(TWODSIX.RULESETS).map(([id, ruleset]) => {
+    return [id, ruleset["name"]];
+  });
+  _stringChoiceSetting('ruleset', TWODSIX.RULESETS["CE"].name, Object.fromEntries(rulesetOptions), 'twodsix');
+
   //House rules/variant related settings
   const DEFAULT_INITIATIVE_FORMULA = "2d6 + @characteristics.dexterity.mod";
   _stringSetting('initiativeFormula', DEFAULT_INITIATIVE_FORMULA, 'world', formula => CONFIG.Combat.initiative = {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -193,6 +193,10 @@
       "using": "using {characteristic}"
     },
     "Settings": {
+      "ruleset": {
+        "hint": "This will configure the below settings with the best options for the given ruleset.",
+        "name": "Ruleset"
+      },
       "absoluteBonusValueForEachTimeIncrement": {
         "hint": "Leave empty to use default (+/-1). Not currently used.",
         "name": "What bonus/penalty to give per each time increment change in a task."

--- a/static/lang/sv.json
+++ b/static/lang/sv.json
@@ -193,6 +193,10 @@
       "using": "med {characteristic}"
     },
     "Settings": {
+      "ruleset": {
+        "hint": "Detta kommer att ställa in nedanstående fält med de bästa inställningarna för angiven spelvariant.",
+        "name": "Spelvariant"
+      },
       "absoluteBonusValueForEachTimeIncrement": {
         "hint": "Lämna tomt för att använda default (+/-1). Används inte för närvarande.",
         "name": "Vilken bonus/malus som ges för varje tidsintervallsteg."

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -7,6 +7,7 @@ import MiniCssExtractPlugin from "mini-css-extract-plugin";
 
 //Only a partial type, not sure what else can be in this, and haven't looked into it.
 type FoundryConfig = { dataPath:string, systemName:string };
+const hookDir = './src/module/hooks/';
 
 function getFoundryConfig():FoundryConfig {
   const configPath = path.resolve(process.cwd(), 'foundryconfig.json');
@@ -20,7 +21,7 @@ module.exports = (env, argv) => {
   const config:Configuration = {
     context: __dirname,
     entry: {
-      main: ["./src/twodsix.ts", "./src/module/hooks/ready.ts", "./src/module/hooks/setup.ts", "./src/module/hooks/preCreateActor.ts", "./src/module/hooks/createItem.ts", "./src/module/hooks/renderItemSheet.ts", "./src/module/hooks/renderChatMessage.ts"]
+      main: ["./src/twodsix.ts"].concat(fs.readdirSync(hookDir).map(file => hookDir + file))
     },
     mode: "development",
     module: {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Previously the users needed to reference the documentation in order to set the correct values for a given rulset.


* **What is the new behavior (if this is a feature change)?**
This change adds a dropdown containing supported rulesets and populates the corresponding settings
fields.



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
* Part of #183
