### PR TITLE
fix: switch behavior of skill roll in character sheet

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -46,7 +46,7 @@ To get the system closer to MGT2 change the following in the system settings (af
 Compendiums with skills and gear cannot be included for licensing reasons, so you have to enter those yourself, except that the '2e skills' compendium is sufficiently close that it should be useful, even though it is not based on MGT2. (It is for https://www.drivethrurpg.com/product/207738/Skills-List-2e which is an Open Gaming License Pay What You Want supplement for for Cepheus Engine - which is pretty much the Open Gaming License version of MGT1E - that provides a skill list that is very similar to the one in MGT2.)
 
 ## General features that really should be documented somewhere:
-* A feature that's a bit too well hidden is that if you shift-click on skills or characteristics you get a popup where you can change difficulty, modifiers, used characteristic, etc for this roll only.
+* A feature that's a bit too well hidden is that if you shift-click on skills or characteristics you automatically roll without modifiers with a difficulty of 8. This can be set as the default behavior in the settings.
 * A feature I like (and thus added) but most people seem to not like is to in system settings change to show the Effect of the roll rather than the raw result (by subtracting the target number.)
 * You can connect a skill to any item on a character, with an optional permanent bonus, so you can do 'skill rolls' (often enough weapon attacks) by clicking the item rather than the skill, and get that bonus added automatically.
 * Another feature you need to turn on in system settings if you want to use it is to automatically roll damage for items that have a connected skill, roll a success (i.e. Effect of 0 or greater) and immediately roll damage. (I.e. Weapons.)

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -50,6 +50,14 @@ export default function registerHandlebarsHelpers():void {
     }
   });
 
+  Handlebars.registerHelper('twodsix_invertSkillRollShiftClick', () => {
+    if (game.settings.get('twodsix', 'invertSkillRollShiftClick')) {
+      return game.i18n.localize("TWODSIX.Actor.Skills.InvertedSkillRollTooltip");
+    } else {
+      return game.i18n.localize("TWODSIX.Actor.Skills.SkillRollTooltip");
+    }
+  });
+
   Handlebars.registerHelper('twodsix_hideUntrainedSkills', (value) => {
     return value && (game.settings.get('twodsix', 'hideUntrainedSkills') && value < 0);
   });

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -50,6 +50,8 @@ export const registerSettings = function ():void {
   _numberSetting('maxSkillLevel', 9);
   _numberSetting('absoluteBonusValueForEachTimeIncrement', -1);
 
+  _booleanSetting('invertSkillRollShiftClick', false);
+
   //Must be the last setting in the file
   _stringSetting('systemMigrationVersion', game.system.data.version);
 

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -90,7 +90,9 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
   private async _onRoll(event:Event):Promise<void> {
     event.preventDefault();
     event.stopPropagation();
-    const showThrowDialog = event["shiftKey"];
+
+    const useInvertedShiftClick:boolean = game.settings.get('twodsix', 'invertSkillRollShiftClick');
+    const showThrowDialog:boolean = useInvertedShiftClick ? event["shiftKey"] : !event["shiftKey"];
     const element = event.currentTarget;
     const dataset = element["dataset"];
     const itemId = $(event.currentTarget).parents('.item').data('item-id');

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -75,7 +75,9 @@
         "Modifier": "Modifier",
         "SkillName": "Skill Name",
         "Total": "Total",
-        "Untrained": "Untrained"
+        "Untrained": "Untrained",
+        "SkillRollTooltip": "Shows the skill roll dialog. Shift-clicking rolls a skill check applying no modifier and assumes a difficulty of 8",
+        "InvertedSkillRollTooltip": "Rolls a skill check applying no modifier and assumes a difficulty of 8. Shift-clicking shows the skill roll dialog"
       },
       "Species": "Species",
       "Tabs": {
@@ -296,6 +298,10 @@
       "untrainedSkillValue": {
         "hint": "Change this to match the character's level of the 'Jack of All Trades' (JOAT) skill. If you have JOAT 1, set the value to -2, etc.",
         "name": "The value that is used for untrained skills."
+      },
+      "invertSkillRollShiftClick": {
+        "hint": "When clicking on a skill a dialog for the skill roll typically appears. Shift-clicking is a shortcut for rolling without modifiers witth a dificulty of 8. Checking this box swaps this behavior.",
+        "name": "Invert behavior for shift-clicking for skill rolls"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/sv.json
+++ b/static/lang/sv.json
@@ -75,7 +75,9 @@
         "Modifier": "Mod",
         "SkillName": "Färdighetsnamn",
         "Total": "Totalt",
-        "Untrained": "Otränad"
+        "Untrained": "Otränad",
+        "SkillRollTooltip": "Visar fönstret för färdighetsrullning. Att shift-klicka rullar en färdighetsrullning utan modifiering och antar svårighet 8",
+        "InvertedSkillRollTooltip": "Rullar en färdighetsrullning utan modifiering och antar svårighet 8. Att shift-klicka visar fönstret för färdighetsrullning"
       },
       "Species": "Art",
       "Tabs": {
@@ -296,6 +298,10 @@
       "untrainedSkillValue": {
         "hint": "Ändra detta så det matchar karaktärens 'Jack of All Trades' (JOAT) färdighet, dvs om du har JOAT 1, sätt värdet till -2, etc.",
         "name": "Värdet som används för otränade färdigheter."
+      },
+      "invertSkillRollShiftClick": {
+        "hint": "När man klickar på en färdighet kommer det vanligtvis upp ett fönster för att välja olika alternativ för rullningen. Att shift-klicka är en genväg för att rulla utan modifierare med svårighet 8. Genom att kryssa i denna inställning så inverterar man vad som sker när man shift-klickar.",
+        "name": "Invertera beteendet av att shift-klicka när man vill göra en färdighetsrullning"
       }
     },
     "CloseAndCreateNew": "Stäng och skapa ny",

--- a/static/templates/actors/actor-sheet.html
+++ b/static/templates/actors/actor-sheet.html
@@ -31,7 +31,7 @@
 
       <div class="character-characteristics">
         <div class="stat strength" data-characteristic="strength">
-          <span class="stat-name rollable" data-roll="2d6+{{data.characteristics.strength.mod}}" data-label="{{data.characteristics.strength.shortLabel}}"
+          <span class="stat-name rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{data.characteristics.strength.mod}}" data-label="{{data.characteristics.strength.shortLabel}}"
           >{{localize "TWODSIX.Actor.Characteristics.STR"}} <img src="./systems/twodsix/assets/d6-icon.svg" alt="roll strength"/></span>
 
           <span class="stat-ability"><input type="number" min="0" name="data.characteristics.strength.value"
@@ -45,7 +45,7 @@
         </div>
 
         <div class="stat dexterity" data-characteristic="dexterity">
-          <span class="stat-name rollable" data-roll="2d6+{{data.characteristics.dexterity.mod}}" data-label="{{data.characteristics.dexterity.shortLabel}}"
+          <span class="stat-name rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{data.characteristics.dexterity.mod}}" data-label="{{data.characteristics.dexterity.shortLabel}}"
           >{{localize "TWODSIX.Actor.Characteristics.DEX"}} <img src="./systems/twodsix/assets/d6-icon.svg" alt="roll dexterity"/>
           </span>
 
@@ -60,7 +60,7 @@
         </div>
 
         <div class="stat endurance" data-characteristic="endurance">
-          <span class="stat-name rollable" data-roll="2d6+{{data.characteristics.endurance.mod}}" data-label="{{data.characteristics.endurance.shortLabel}}"
+          <span class="stat-name rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{data.characteristics.endurance.mod}}" data-label="{{data.characteristics.endurance.shortLabel}}"
           >{{localize "TWODSIX.Actor.Characteristics.END"}} <img src="./systems/twodsix/assets/d6-icon.svg" alt="roll endurance"/>
         </span>
 
@@ -75,7 +75,7 @@
         </div>
 
         <div class="stat intelligence" data-characteristic="intelligence">
-          <span class="stat-name rollable" data-roll="2d6+{{data.characteristics.intelligence.mod}}" data-label="{{data.characteristics.intelligence.shortLabel}}"
+          <span class="stat-name rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{data.characteristics.intelligence.mod}}" data-label="{{data.characteristics.intelligence.shortLabel}}"
           >{{localize "TWODSIX.Actor.Characteristics.INT"}} <img src="./systems/twodsix/assets/d6-icon.svg" alt="roll intelligence"/>
         </span>
 
@@ -90,7 +90,7 @@
         </div>
 
         <div class="stat education" data-characteristic="education">
-          <span class="stat-name rollable" data-roll="2d6+{{data.characteristics.education.mod}}" data-label="{{data.characteristics.education.shortLabel}}"
+          <span class="stat-name rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{data.characteristics.education.mod}}" data-label="{{data.characteristics.education.shortLabel}}"
           >{{localize "TWODSIX.Actor.Characteristics.EDU"}} <img src="./systems/twodsix/assets/d6-icon.svg" alt="roll education"/>
         </span>
 
@@ -105,7 +105,7 @@
         </div>
 
         <div class="stat socialStanding" data-characteristic="socialStanding">
-          <span class="stat-name rollable" data-roll="2d6+{{data.characteristics.socialStanding.mod}}" data-label="{{data.characteristics.socialStanding.shortLabel}}"
+          <span class="stat-name rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{data.characteristics.socialStanding.mod}}" data-label="{{data.characteristics.socialStanding.shortLabel}}"
           >{{localize "TWODSIX.Actor.Characteristics.SOC"}} <img src="./systems/twodsix/assets/d6-icon.svg" alt="roll socialStanding"/>
         </span>
 
@@ -120,7 +120,7 @@
         </div>
 
         <div class="special psionicStrength" data-characteristic="psionicStrength">
-          <span class="special-name rollable" data-roll="2d6+{{data.characteristics.psionicStrength.mod}}" data-label="{{data.characteristics.psionicStrength.shortLabel}}"
+          <span class="special-name rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{data.characteristics.psionicStrength.mod}}" data-label="{{data.characteristics.psionicStrength.shortLabel}}"
           >{{localize "TWODSIX.Actor.Characteristics.PSI"}} <img src="./systems/twodsix/assets/d6-icon.svg" alt="roll psionicStrength"/>
         </span>
 

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -22,8 +22,8 @@
       <ol class="ol-no-indent">
         <li class="item flexrow" data-item-id="{{item._id}}">
           <span class="items-weapons">
-            <span class="mini-dice rollable"><img class="rollable" data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
-            <span class="item-name rollable">{{item.name}}</span>
+            <span class="mini-dice rollable" title="{{twodsix_invertSkillRollShiftClick}}"><img class="rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
+            <span class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
             <span class="item-name centre">{{data.techLevel}}</span>
             <span class="item-name centre">{{data.quantity}}</span>
             <span class="item-name centre">{{data.weight}}</span>
@@ -43,7 +43,7 @@
             {{#each (twodsix_burstModes data) as |mode|}}
               <span class="items-weapons-abilities">
                 <span class="item-name">Burst {{mode}}</span>
-                <span class="item-name item-ability rollable" data-rof-bonus="{{twodsix_burstAttackDM mode}}">[+{{twodsix_burstAttackDM mode}} Attack DM]</span>
+                <span class="item-name item-ability rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-rof-bonus="{{twodsix_burstAttackDM mode}}">[+{{twodsix_burstAttackDM mode}} Attack DM]</span>
                 <span class="item-name item-ability roll-damage" data-bonus-damage="{{twodsix_burstBonusDamage mode}}">[+{{twodsix_burstBonusDamage mode}} Damage]</span>
               </span>
             {{/each}}
@@ -52,7 +52,7 @@
             <span class="items-weapons-abilities">
               <span class="item-name">Auto {{data.rateOfFire}}</span>
               <span class="item-name item-ability roll-damage" data-bonus-damage="{{data.rateOfFire}}">[Burst Damage]</span>
-              <span class="item-name item-ability rollable" data-num-attacks="{{data.rateOfFire}}">[Full Auto]</span>
+              <span class="item-name item-ability rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-num-attacks="{{data.rateOfFire}}">[Full Auto]</span>
             </span>
           {{/if}}
         </li>
@@ -81,8 +81,8 @@
       <ol class="ol-no-indent">
         <li class="item flexrow" data-item-id="{{item._id}}">
           <span class="items-armor">
-            <span class="mini-dice rollable"><img class="rollable" data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
-            <span class="item-name rollable">{{item.name}}</span>
+            <span class="mini-dice rollable" title="{{twodsix_invertSkillRollShiftClick}}"><img class="rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
+            <span class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
             <span class="item-name centre">{{data.techLevel}}</span>
             <span class="item-name centre">{{data.quantity}}</span>
             <span class="item-name centre">{{data.weight}}</span>
@@ -117,8 +117,8 @@
       <ol class="ol-no-indent">
         <li class="item flexrow" data-item-id="{{item._id}}">
           <span class="items-augments">
-            <span class="mini-dice rollable"><img class="rollable" data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
-            <span class="item-name rollable">{{item.name}}</span>
+            <span class="mini-dice rollable" title="{{twodsix_invertSkillRollShiftClick}}"><img class="rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
+            <span class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
             <span class="item-name centre">{{data.techLevel}}</span>
             <span class="item-name centre">{{data.quantity}}</span>
             <span class="item-name centre">{{data.bonus}}</span>
@@ -152,8 +152,8 @@
       <ol class="ol-no-indent">
         <li class="item flexrow" data-item-id="{{item._id}}">
             <span class="items-equipment">
-              <span class="mini-dice rollable"><img class="rollable" data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
-              <span class="item-name rollable">{{item.name}}</span>
+              <span class="mini-dice rollable" title="{{twodsix_invertSkillRollShiftClick}}"><img class="rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
+              <span class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
               <span class="item-name centre">{{data.techLevel}}</span>
               <span class="item-name centre">{{data.quantity}}</span>
               <span class="item-name centre">{{data.shortdescr}}</span>

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -19,13 +19,13 @@
     <ol class="ol-no-indent">
       <li class="item flexrow" data-item-id="{{item._id}}">
         <span class="skill-container">
-          <span class="mini-dice centre"><img class="rollable" data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
-          <span class="item-name rollable" data-label="{{item.name}}">{{item.name}}</span>
-          <span class="item-name centre rollable" data-label="{{item.name}}">{{data.value}}</span>
-          <span class="item-name centre rollable" data-label="{{item.name}}" for="skill-modifier">
-            {{twodsix_skillCharacteristic ../actor data.characteristic}}
+          <span class="mini-dice centre">
+            <img class="rollable" data-label="{{item.name}}" title="{{twodsix_invertSkillRollShiftClick}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/>
           </span>
-          <span class="total-output flex1 skill-mod rollable" data-label="{{item.name}}">{{twodsix_skillTotal ../actor data.characteristic data.value}}</span>
+          <span class="item-name rollable" data-label="{{item.name}}" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
+          <span class="item-name centre">{{data.value}}</span>
+          <span class="item-name centre" for="skill-modifier">{{twodsix_skillCharacteristic ../actor data.characteristic}}</span>
+          <span class="total-output flex1 skill-mod">{{twodsix_skillTotal ../actor data.characteristic data.value}}</span>
           <span class="item-controls centre">
             <a class="skl item-control item-edit" title='{{localize "TWODSIX.Actor.Skills.EditItem"}}'><i class="fas fa-edit"></i></a>
             <a class="skl item-control item-delete" title='{{localize "TWODSIX.Actor.Skills.DeleteItem"}}'><i class="fas fa-trash"></i></a>
@@ -43,13 +43,11 @@
     <ol class="ol-no-indent">
       <li class="item flexrow" data-item-id="{{item._id}}">
         <span class="skill-container">
-          <span class="mini-dice centre"><img class="rollable" data-label="Untrained" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
-          <span class="item-name rollable" data-label="Untrained">{{localize "TWODSIX.Actor.Skills.Untrained"}}</span>
-          <span class="item-name centre rollable" data-label="Untrained">{{actor.data.settings.untrainedSkillValue}}</span>
-          <span class="item-name centre rollable" data-label="Untrained" for="skill-modifier">
-            {{localize "TWODSIX.Items.Skills.NONE"}}
-          </span>
-          <span class="total-output flex1 skill-mod rollable" data-label="Untrained">{{actor.data.settings.untrainedSkillValue}}</span>
+          <span class="mini-dice centre"><img class="rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-label="Untrained" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/></span>
+          <span class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}" data-label="Untrained">{{localize "TWODSIX.Actor.Skills.Untrained"}}</span>
+          <span class="item-name centre">{{actor.data.settings.untrainedSkillValue}}</span>
+          <span class="item-name centre" for="skill-modifier">{{localize "TWODSIX.Items.Skills.NONE"}}</span>
+          <span class="total-output flex1 skill-mod">{{actor.data.settings.untrainedSkillValue}}</span>
         </span>
       </li>
     </ol>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Previously the default behavior was to directly roll a skill without modifiers.


* **What is the new behavior (if this is a feature change)?**
This change makes the roll dialog come up as default when clicking on the skill. Shift clicking now does an automatic roll. 
A settings option has been added to revert to the previous behavior for those who prefer that.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
Fix #267