### PR TITLE
fix: Adds settings for effects of natural 2/12, if a natural 2 or 12 …

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -17,6 +17,7 @@ To get the system closer to Cepheus Light (which should also work fairly well fo
 * Change the initiative formula to just 2d6 (i.e. you need to add the Tactics skill yourself after rolling until I or someone else figures out how to do it automatically).
 * Set skills to not use any characteristic for modifiers.
 * Select CEL style autofire rules and make sure weapons have a single number for their 'Rate of Fire/Auto X' setting.
+* Sets a natural 2/12 to be considered a failure/success regardless of actual Effect.
 
 Reasonably complete compendiums for Cepheus Light exist.
 
@@ -28,6 +29,7 @@ To get the system closer to Cepheus Faster Than Light select 'Cepheus Faster Tha
 * Use the skills and gear from the various 'ce ftl-something' compendiums (supplied by @marvin9257).
 * Change the initiative formula to just 2d6 (i.e. you need to add the Tactics skill yourself after rolling until I or someone else figures out how to do it automatically).
 * Set skills to not use any characteristic for modifiers.
+* Sets a natural 2/12 to be considered a failure/success regardless of actual Effect.
 
 Reasonably complete compendiums for Cepheus Faster Than Light exist.
 
@@ -39,6 +41,7 @@ To get the system closer to MGT2 change the following in the system settings (af
 * Switch to handling difficulties by changing the target number rather than adding/subtracting modifiers.
 * Rename 'advantage' to 'boon' and 'disadvantage' to 'bane'
 * Select CEL style autofire rules and make sure weapons have a single number for their 'Rate of Fire/Auto X' setting.
+* Set "What effect (if above 0) is required for a throw to be considered a critical success/failure (i.e. be colored green/red)." to 6.
 
 Compendiums with skills and gear cannot be included for licensing reasons, so you have to enter those yourself, except that the '2e skills' compendium is sufficiently close that it should be useful, even though it is not based on MGT2. (It is for https://www.drivethrurpg.com/product/207738/Skills-List-2e which is an Open Gaming License Pay What You Want supplement for for Cepheus Engine - which is pretty much the Open Gaming License version of MGT1E - that provides a skill list that is very similar to the one in MGT2.)
 

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -45,7 +45,9 @@ TWODSIX.RULESETS = {
       modifierForZeroCharacteristic: -2,
       termForAdvantage: "advantage",
       termForDisadvantage: "disadvantage",
-      absoluteBonusValueForEachTimeIncrement: 1
+      absoluteBonusValueForEachTimeIncrement: 1,
+      criticalNaturalAffectsEffect: false,
+      absoluteCriticalEffectValue: 99
     }
   },
   CEL: {
@@ -59,7 +61,9 @@ TWODSIX.RULESETS = {
       modifierForZeroCharacteristic: -2,
       termForAdvantage: "advantage",
       termForDisadvantage: "disadvantage",
-      absoluteBonusValueForEachTimeIncrement: 1
+      absoluteBonusValueForEachTimeIncrement: 1,
+      criticalNaturalAffectsEffect: true,
+      absoluteCriticalEffectValue: 99
     }
   },
   CEFTL: {
@@ -73,7 +77,9 @@ TWODSIX.RULESETS = {
       modifierForZeroCharacteristic: -2,
       termForAdvantage: "advantage",
       termForDisadvantage: "disadvantage",
-      absoluteBonusValueForEachTimeIncrement: 1
+      absoluteBonusValueForEachTimeIncrement: 1,
+      criticalNaturalAffectsEffect: true,
+      absoluteCriticalEffectValue: 99
     }
   },
   OTHER: {

--- a/src/module/hooks/renderSettingsConfig.ts
+++ b/src/module/hooks/renderSettingsConfig.ts
@@ -7,7 +7,13 @@ Hooks.on('renderSettingsConfig', async (app, html) => {
 
     // Step through each option and update the corresponding field
     Object.entries(rulesetSettings).forEach(([settingName, value]) => {
-      html.find(`[name="twodsix.${settingName}"]`).val(value);
+      console.log(`${ruleset} ${settingName} = ${value}`);
+      const setting = html.find(`[name="twodsix.${settingName}"]`);
+      if (!setting.is(':checkbox')) {
+        setting.val(value);
+      } else {
+        setting.prop('checked', Boolean(value));
+      }
     });
   });
 });

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -43,6 +43,8 @@ export const registerSettings = function ():void {
   _stringChoiceSetting('autofireRulesUsed', TWODSIX.RULESETS.CE.key, TWODSIX.VARIANTS);
 
   _booleanSetting('showMissingCompendiumWarnings', true);
+  _booleanSetting('criticalNaturalAffectsEffect', false);
+  _numberSetting('absoluteCriticalEffectValue', 99);
 
   //As yet unused
   _numberSetting('maxSkillLevel', 9);

--- a/src/module/utils/TwodsixRolls.ts
+++ b/src/module/utils/TwodsixRolls.ts
@@ -286,46 +286,38 @@ export class TwodsixRolls {
           effect = roll.total - difficulty.target;
         }
 
-
-        /* Builds fine locally, but got this on github action for some reason, so commenting out:
-        *  [tsl] ERROR in /home/runner/work/twodsix-foundryvtt/twodsix-foundryvtt/src/module/utils/TwodsixRolls.ts(255,35)
-        * TS2352: Conversion of type 'object[]' to type 'number[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
-        * Type 'object' is not comparable to type 'number'.
-        * */
-
         //Handle special results
-
         const diceResult = roll.dice[0].results.reduce((total:number, dice) => {
-          return dice["active"] ? total+dice["result"] : total;
+          return dice["active"] ? total + dice["result"] : total;
         }, 0);
 
-        //TODO #168 Uncomment natural 2/12 handling below, once there is a setting to enable it
         if (diceResult === 2) {
           crit = TWODSIX.CRIT.FAIL;
-          console.log("Got a natural 2!");
-          if (0 <= effect) {
-            //effect = -1;
+          console.log(`Got a natural 2 with Effect ${effect}!`);
+          if (effect >= 0 && game.settings.get('twodsix', 'criticalNaturalAffectsEffect')) {
+            console.log("Setting Effect to -1 due to natural 2!");
+            effect = -1;
           }
         } else if (diceResult === 12) {
           crit = TWODSIX.CRIT.SUCCESS;
-          console.log("Got a natural 12!");
-          if (effect < 0) {
-            //effect = 0;
+          console.log(`Got a natural 12 with Effect ${effect}!`);
+          if (effect < 0 && game.settings.get('twodsix', 'criticalNaturalAffectsEffect')) {
+            console.log("Setting Effect to 0 due to natural 12!");
+            effect = 0;
           }
         }
 
-        //TODO #120 Handle critical success/failure once there is a system setting (or two) for it, maybe just show in chat card?
-        const TODO_UNHARDCODEME_ISSUE_120 = 6;
-        if (effect >= TODO_UNHARDCODEME_ISSUE_120) {
+        const CRITICAL_EFFECT_VALUE = game.settings.get('twodsix', 'absoluteCriticalEffectValue');
+        if (effect >= CRITICAL_EFFECT_VALUE) {
           if (!crit) {
             crit = TWODSIX.CRIT.SUCCESS;
+            console.log("Got a critical success due to high Effect");
           }
-          console.log("Got a critical success");
-        } else if (effect <= -TODO_UNHARDCODEME_ISSUE_120) {
+        } else if (effect <= -CRITICAL_EFFECT_VALUE) {
           if (!crit) {
             crit = TWODSIX.CRIT.FAIL;
+            console.log("Got a critical failure due to low Effect");
           }
-          console.log("Got a critical failure");
         }
 
         //And send to chat

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -201,9 +201,17 @@
         "hint": "Leave empty to use default (+/-1). Not currently used.",
         "name": "What bonus/penalty to give per each time increment change in a task."
       },
+      "absoluteCriticalEffectValue": {
+        "hint": "Defaults to 99, which means that effect is ignored.",
+        "name": "What effect is required for a throw to be considered a critical success/failure (i.e. be colored green/red)."
+      },
       "automateDamageRollOnHit": {
         "hint": "checked=Roll damage, modified by effect of skill roll. unchecked=Don't roll damage.",
         "name": "Automatically roll damage on skill rolls that hit (i.e. get effect > 0) with items that do damage?"
+      },
+      "criticalNaturalAffectsEffect": {
+        "hint": "checked=Regardless of success consider a natural 2 to have an effect of -1 and a 12 to have an effect of 0, unchecked=Use normal rules",
+        "name": "Whether a natural 2 or 12 should have special treatment as regards to success/failure."
       },
       "defaultTokenSettings": {
         "hint": "Automatically set advised prototype token settings to newly created Actors.",

--- a/static/lang/sv.json
+++ b/static/lang/sv.json
@@ -201,9 +201,17 @@
         "hint": "Lämna tomt för att använda default (+/-1). Används inte för närvarande.",
         "name": "Vilken bonus/malus som ges för varje tidsintervallsteg."
       },
+      "absoluteCriticalEffectValue": {
+        "hint": "Defaultvärde 99, vilket betyder att effekten ignoreras.",
+        "name": "Den effekt som krävs för att ett slag ska räknas som kritiskt lyckad/misslyckad (dvs färgas röd eller grön)."
+      },
       "automateDamageRollOnHit": {
         "hint": "ikryssat=Rulla skadan, modifierad av färdighetsslagets effekt. urkryssat=rulla inte skadan.",
         "name": "Ska skador på lyckade färdighetsslag (dvs som har effekt >= 0) rullas automatiskt om använd sak kan göra skada?"
+      },
+      "criticalNaturalAffectsEffect": {
+        "hint": "ikryssat=Oavsett om slaget är lyckat räknas en naturlig 2:a som att man fick Effect -1, och en naturlig 12:a som att man fick Effekt 0, urkryssat=använd de vanliga reglerna",
+        "name": "Om en naturlig 2:a eller 12:a ska behandlas speciellt med avseende på om slaget är lyckat/misslyckat."
       },
       "defaultTokenSettings": {
         "hint": "Sätt automatiskt föreslagna defaults för nyskapade spelfigurer",


### PR DESCRIPTION
…should affect Effect, setting for what Effect is considered a critical success or failure. Also adds code supporting that to rolls.

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds settings for 2/12 rolls, greater/less than a certain Effect on a roll.


* **What is the current behavior?** (You can also link to an open issue here)
Partially implemented in #120, this completes it.


* **What is the new behavior (if this is a feature change)?**
The above settings default to 'no special effect'. If turned on, a successful 2 is considered to have an Effect 0 -1 (i.e. failed) and a failed 12 is considered to have an Effect of 0 (i.e. success).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users might have to change their system setting values.


* **Other information**:
n/a