### PR TITLE
fix: change so that item window size adapts to content

### DIFF
--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -11,8 +11,6 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
   static get defaultOptions():FormApplicationOptions {
     return mergeObject(super.defaultOptions, {
       classes: ["twodsix", "sheet", "item"],
-      width: 520,
-      height: 377,
       submitOnClose: true,
       submitOnChange: true,
       tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description"}]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features) - not needed


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Currently the item windows are smaller than the content and requires scrolling.


* **What is the new behavior (if this is a feature change)?**
This change makes it so that the window size adapts to the content.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Fix #264


I'm not entirely sure if this has any repercussions elsewhere, so please let me know if it has. I've tried opening a bunch of various windows and it all looks good.
The character/ship windows also has the width and height property, however modifying them leads to windows looking bad. 