### PR TITLE
Skill rolltype default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3254,7 +3254,7 @@
       "dev": true
     },
     "foundry-vtt-types": {
-      "version": "git+https://github.com/kmoschcau/foundry-vtt-types.git#3dfc6979f28974909c345678745ce5e58256e6ec",
+      "version": "git+https://github.com/kmoschcau/foundry-vtt-types.git#df6784fd367b4757bd88353ff501ba9d36d3ed2d",
       "from": "git+https://github.com/kmoschcau/foundry-vtt-types.git",
       "dev": true,
       "requires": {

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -1,15 +1,6 @@
 // Namespace TWODSIX Configuration Values
 
-export const TWODSIX = {
-  CHARACTERISTICS: undefined,
-  VARIANTS: undefined,
-  ROLLTYPES: undefined,
-  DIFFICULTIES: undefined,
-  RULESETS: undefined,
-  CRIT: undefined
-};
-
-TWODSIX.CHARACTERISTICS = {
+const CHARACTERISTICS = Object.freeze({
   "strength": "STR",
   "dexterity": "DEX",
   "endurance": "END",
@@ -17,23 +8,23 @@ TWODSIX.CHARACTERISTICS = {
   "education": "EDU",
   "socialStanding": "SOC",
   "psionicStrength": "PSI"
-};
+});
 
 /**
  * Rules variants one can use.
  * Note that only variants that actually have different rules implementations are listed here.
  * @type {Object}
  */
-TWODSIX.VARIANTS = {
+const VARIANTS = Object.freeze({
   "CE": "CE",
   "CEL": "CEL",
-};
+});
 
 //TODO VARIANTS and RULESETS should really be combined/refactored.
 /**
  * Sets of Twodsix settings that best match each supported ruleset.
  */
-TWODSIX.RULESETS = {
+const RULESETS = Object.freeze({
   CE: {
     key: "CE",
     name: "Cepheus Engine",
@@ -93,15 +84,15 @@ TWODSIX.RULESETS = {
     name: "Other",
     settings: {}
   }
-};
+});
 
-TWODSIX.ROLLTYPES = {
-  Advantage: "3d6kh2",
-  Normal: "2d6",
-  Disadvantage: "3d6kl2"
-};
+const ROLLTYPES = Object.freeze({
+  Advantage: {key: 'Advantage', formula: "3d6kh2"},
+  Normal: {key: 'Normal', formula: "2d6"},
+  Disadvantage: {key: 'Disadvantage', formula: "3d6kl2"}
+});
 
-TWODSIX.DIFFICULTIES = {
+const DIFFICULTIES = Object.freeze({
   CE: {
     Simple: {mod: 6, target: 2},
     Easy: {mod: 4, target: 4},
@@ -119,6 +110,15 @@ TWODSIX.DIFFICULTIES = {
     VeryDifficult: {mod: -4, target: 10},
     Formidable: {mod: -6, target: 12},
   }
-};
+});
 
-TWODSIX.CRIT = Object.freeze({"SUCCESS": 1, "FAIL": 2});
+const CRIT = Object.freeze({"SUCCESS": 1, "FAIL": 2});
+
+export const TWODSIX = {
+  CHARACTERISTICS: CHARACTERISTICS,
+  VARIANTS: VARIANTS,
+  ROLLTYPES: ROLLTYPES,
+  DIFFICULTIES: DIFFICULTIES,
+  RULESETS: RULESETS,
+  CRIT: CRIT
+};

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -47,7 +47,13 @@ TWODSIX.RULESETS = {
       termForDisadvantage: "disadvantage",
       absoluteBonusValueForEachTimeIncrement: 1,
       criticalNaturalAffectsEffect: false,
-      absoluteCriticalEffectValue: 99
+      absoluteCriticalEffectValue: 99,
+      ShowLawLevel: true,
+      ShowRangeBandAndHideRange: true,
+      ShowWeaponType: true,
+      ShowDamageType: true,
+      ShowRateOfFire: true,
+      ShowRecoil: true
     }
   },
   CEL: {

--- a/src/module/utils/TwodsixRolls.ts
+++ b/src/module/utils/TwodsixRolls.ts
@@ -15,7 +15,7 @@ export class TwodsixRolls {
     let updatedSettings = settings;
     const template = 'systems/twodsix/templates/chat/throw-dialog.html';
     const dialogData = {
-      rollType: "Normal",
+      rollType: settings.rollType,
       rollTypes: TWODSIX.ROLLTYPES,
       difficulty: getKeyByValue(difficulties, settings.difficulty),
       difficulties: difficulties,
@@ -167,6 +167,7 @@ export class TwodsixRolls {
     }
   }
 
+  //TODO Refactor. This method is *way* too brittle. And long...
   private static async _handleThrows(dataset:DOMStringMap, actor:TwodsixActor, item:TwodsixItem | null, showEffect:boolean, characteristic, skill:TwodsixItem | null, showRollDialog:boolean, numAttacks:number) {
     let rollParts:string[] = [];
     const speaker = ChatMessage.getSpeaker({actor: actor});
@@ -174,10 +175,11 @@ export class TwodsixRolls {
     const rollMode = game.settings.get('core', 'rollMode');
     const difficulty = skill ? difficulties[skill.data.data.difficulty] : difficulties.Average;
     const skillModifier = item?.data?.data?.skillModifier ?? 0;
+    const rollType = skill ? (skill.data.data.rolltype || TWODSIX.ROLLTYPES.Normal.key) : TWODSIX.ROLLTYPES.Normal.key;
 
     let settings:throwSettings = {
       shouldRoll: false,
-      rollType: "Normal",
+      rollType: rollType,
       rollMode: rollMode,
       difficulty: difficulty,
       skillModifier: skillModifier,
@@ -240,13 +242,13 @@ export class TwodsixRolls {
       }
 
       if (settings.rollType && settings.rollType.length > 0) {
-        if (rollParts[0] == '2d6') {
-          rollParts[0] = TWODSIX.ROLLTYPES[settings.rollType];
+        if (rollParts[0] == TWODSIX.ROLLTYPES.Normal.formula) {
+          rollParts[0] = TWODSIX.ROLLTYPES[settings.rollType].formula;
         } else {
-          rollParts.unshift(TWODSIX.ROLLTYPES[settings.rollType]);
+          rollParts.unshift(TWODSIX.ROLLTYPES[settings.rollType].formula);
         }
 
-        if (settings.rollType != 'Normal') {
+        if (settings.rollType != TWODSIX.ROLLTYPES.Normal.key) {
           flavorParts.push(game.i18n.localize("TWODSIX.Rolls.With"));
           flavorParts.push(`${(advantageDisadvantageTerm(settings.rollType))}`);
         }

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -764,6 +764,11 @@ select.select-difficulty {
   margin-left: 1em;
 }
 
+select.select-rolltype {
+  width: 10em;
+  margin-left: 1em;
+}
+
 span.total-output {
   text-align: center;
 }

--- a/static/template.json
+++ b/static/template.json
@@ -1,9 +1,6 @@
 {
   "Actor": {
-    "types": [
-      "traveller",
-      "ship"
-    ],
+    "types": ["traveller", "ship"],
     "traveller": {
       "name": "",
       "homeWorld": "",
@@ -277,16 +274,7 @@
     }
   },
   "Item": {
-    "types": [
-      "equipment",
-      "weapon",
-      "armor",
-      "augment",
-      "storage",
-      "tool",
-      "junk",
-      "skills"
-    ],
+    "types": ["equipment", "weapon", "armor", "augment", "storage", "tool", "junk", "skills"],
     "templates": {
       "gearTemplate": {
         "name": "",
@@ -305,19 +293,12 @@
       }
     },
     "equipment": {
-      "templates": [
-        "gearTemplate"
-      ],
+      "templates": ["gearTemplate"],
       "type": "equipment",
-      "location": [
-        "inventory",
-        "storage"
-      ]
+      "location": ["inventory", "storage"]
     },
     "weapon": {
-      "templates": [
-        "gearTemplate"
-      ],
+      "templates": ["gearTemplate"],
       "range": 0,
       "damage": "3d6",
       "damageBonus": 0,
@@ -325,10 +306,7 @@
       "ammo": 0,
       "magazineCost": 0,
       "type": "weapon",
-      "location": [
-        "inventory",
-        "storage"
-      ],
+      "location": ["inventory", "storage"],
       "lawLevel": 0,
       "rangeBand": "",
       "weaponType": "",
@@ -337,9 +315,7 @@
       "recoil": false
     },
     "armor": {
-      "templates": [
-        "gearTemplate"
-      ],
+      "templates": ["gearTemplate"],
       "armor": 0,
       "secondaryArmor": {
         "value": 0
@@ -348,27 +324,17 @@
         "value": 0
       },
       "type": "armor",
-      "location": [
-        "inventory",
-        "storage"
-      ]
+      "location": ["inventory", "storage"]
     },
     "augment": {
-      "templates": [
-        "gearTemplate"
-      ],
+      "templates": ["gearTemplate"],
       "auglocation": "None",
       "type": "augment",
       "bonus": "stat increase",
-      "location": [
-        "inventory",
-        "storage"
-      ]
+      "location": ["inventory", "storage"]
     },
     "skills": {
-      "templates": [
-        "skillsTemplate"
-      ],
+      "templates": ["skillsTemplate"],
       "name": "Skill Name",
       "value": -3,
       "characteristic": "STR",
@@ -378,7 +344,8 @@
       "subtype": "",
       "reference": "",
       "key": "key",
-      "difficulty": "Average"
+      "difficulty": "Average",
+      "rolltype": "Normal"
     }
   }
 }

--- a/static/templates/items/skills-sheet.html
+++ b/static/templates/items/skills-sheet.html
@@ -47,6 +47,17 @@
         </select>
       </label>
     </div>
+    <div class="item-name left">
+      <label class="resource-label">{{localize "TWODSIX.Chat.Roll.Type"}}
+        <select class="select-rolltype" name="data.rolltype" value={{rolltype}}>
+          {{#select data.rolltype}}
+            {{#each data.config.ROLLTYPES as |label rolltype|}}
+              <option value="{{rolltype}}">{{localize rolltype}}</option>
+            {{/each}}
+          {{/select}}
+        </select>
+      </label>
+    </div>
     <span class="total-output flex1 skill-mod"></span>
     <div class="item-short">
       <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
@@ -60,5 +71,3 @@
     </div>
   </div>
 </form>
-
-


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the ability to set default rolltype for a skill. (Needed for traits, so might as well make it available in the gui).

* **What is the current behavior?** (You can also link to an open issue here)
Rolltype can only be set temporarily.

* **What is the new behavior (if this is a feature change)?**
Adds the ability to set default rolltype for a skill. (Needed for traits, so might as well make it available in the gui).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
n/a