### PR TITLE
fix: Weapons can now always be rolled by clicking them, default s…

### DIFF
--- a/static/templates/items/parts/common-parts.html
+++ b/static/templates/items/parts/common-parts.html
@@ -33,16 +33,19 @@
     </label>
   </div>
 
-
 {{#if data.owner}}
     <div class="item-skill">
       <label for="data.skill" class="resource-label">{{localize "TWODSIX.Items.Equipment.AssignSkill"}}:
         <select id="data.skill" name="data.skill" value="{{data.skill}}">
           {{#select data.skill}}
-            <option value="">-</option>
+            <option>{{localize "TWODSIX.Actor.Skills.Untrained"}}</option>
             {{#each data.owner.items as |skill|}}
               {{#if (eq skill.type 'skills')}}
-                <option value="{{skill.data._id}}">{{skill.name}}</option>
+                {{#if (twodsix_hideUntrainedSkills item.data.value)}}
+                  <!-- Hiding {{item.name}} -->
+                {{else}}
+                  <option value="{{skill.data._id}}">{{skill.name}}</option>
+                {{/if}}
               {{/if}}
             {{/each}}
           {{/select}}
@@ -69,4 +72,3 @@
     <input id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/>
   </label>
 </div>
-


### PR DESCRIPTION
…kill is 'Unskilled', with the usual penalty for unskilled use (normally -3).

Fixes #281

* **Please check if the PR fulfills these requirements**
- [X] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
See #281


* **What is the new behavior (if this is a feature change)?**
Show Untrained as default (instead of -), and allow use of item with Untrained with the usual penalty.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
n/a