### PR TITLE
fix: Fixed issue with untrained skill not saving

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -147,8 +147,7 @@ export default class TwodsixActor extends Actor {
 
   private async createUntrainedSkill() {
     const untrainedSkill = await this.buildUntrainedSkill();
-    await this.update({"data.untrainedSkill": untrainedSkill.id});
-    this.data.data.untrainedSkill = untrainedSkill._id;
+    await this.update({"data.untrainedSkill": untrainedSkill._id});
   }
 
   public async buildUntrainedSkill():Promise<TwodsixItem> {

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -109,7 +109,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
         itemData.data.value = String(0);
       }
     }
-    itemData.data.skill = this.actor.getUntrainedSkill()._id;
+    itemData.data.skill = this.actor.getUntrainedSkill().id;
     // Finally, create the item!
     return this.actor.createOwnedItem(itemData);
   }

--- a/static/template.json
+++ b/static/template.json
@@ -32,7 +32,7 @@
       "contacts": "",
       "allies": "",
       "enemies": "",
-      "untrainedSkill": null,
+      "untrainedSkill": "",
       "description": "",
       "bio": "",
       "notes": "",


### PR DESCRIPTION
There seemed to be multiple problems. But seemingly the most important
was that the field in the template.json was set to null. This commit
also fixes some _id/id issues