### PR TITLE
fix: change default value of hits

### DIFF
--- a/static/template.json
+++ b/static/template.json
@@ -10,9 +10,9 @@
         "min": 0
       },
       "hits": {
-        "value": 0,
+        "value": 21,
         "min": 0,
-        "max": 0
+        "max": 21
       },
       "gender": "",
       "radiationDose": {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features) -  not needed


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix/feature


* **What is the current behavior?** (You can also link to an open issue here)
currently the default is 0 for both max and value for hits


* **What is the new behavior (if this is a feature change)?**
Since the str/dex/end are 21 in total the default  hits number should reflect that.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
I  was considering  a migration to change all hit max/value to be 21 but then I thought that it might interfere with if someone manually has set the values of the hits to 0. Definitely can add that if we want to, but thought that it's maybe best to just do this change to new actors.