### PR TITLE
fix: change so that Actor creates untrained skill

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -9,14 +9,6 @@ import {TwodsixDiceRoll} from "../utils/TwodsixDiceRoll";
 import TwodsixItem from "./TwodsixItem";
 
 export default class TwodsixActor extends Actor {
-  public static async create(data:Record<string, unknown>, options?:Record<string, unknown>):Promise<Entity> {
-    const actor = await super.create(data, options) as TwodsixActor;
-    if (actor.data.type == "traveller") {
-      await actor.createUntrainedSkill();
-    }
-    return actor;
-  }
-
   /**
    * Augment the basic actor data with additional dynamic data.
    */
@@ -134,7 +126,7 @@ export default class TwodsixActor extends Actor {
     return this.getOwnedItem(this.data.data.untrainedSkill) as TwodsixItem;
   }
 
-  private async createUntrainedSkill() {
+  public async createUntrainedSkill(): Promise<void> {
     const untrainedSkill = await this.buildUntrainedSkill();
     await this.update({"data.untrainedSkill": untrainedSkill._id});
   }

--- a/src/module/hooks/addUntrainedSkill.ts
+++ b/src/module/hooks/addUntrainedSkill.ts
@@ -1,0 +1,7 @@
+import TwodsixActor from "../entities/TwodsixActor";
+
+Hooks.on('createActor', async (actor: TwodsixActor) => {
+  if (actor.data.type == "traveller") {
+    await actor.createUntrainedSkill();
+  }
+});

--- a/src/module/hooks/index.ts
+++ b/src/module/hooks/index.ts
@@ -1,8 +1,0 @@
-//NOTE! *Every* hook must be imported here, or they won't be used!
-import './preCreateActor.ts';
-import './ready.ts';
-import './renderChatMessage.ts';
-import './renderItemSheet.ts';
-import './renderSettingsConfig.ts';
-import './updateHits.ts';
-import './setup.ts';

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -14,7 +14,9 @@ import {TwodsixShipSheet} from "./module/sheets/TwodsixShipSheet";
 import {TwodsixItemSheet} from "./module/sheets/TwodsixItemSheet";
 import registerHandlebarsHelpers from "./module/handlebars";
 import {registerSettings} from "./module/settings";
-import "./module/hooks/index";
+require.context("./module/hooks", false, /\.ts$/).keys().forEach(fileName => {
+  import("./module/hooks/" + fileName.substring(2));
+});
 import {rollItemMacro} from "./module/utils/rollItemMacro";
 
 Hooks.once('init', async function () {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Previously creating a new TwodsixActor did create an untrained skill, however creating an Actor does not create an untrained skill. 


* **What is the new behavior (if this is a feature change)?**
This fix makes it so that an untrained skill is created in both cases.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Fix #328