### PR TITLE
WIP: fix: add consumables

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -92,6 +92,10 @@ const ROLLTYPES = Object.freeze({
   Disadvantage: {key: 'Disadvantage', formula: "3d6kl2"}
 });
 
+const CONSUMABLES = Object.freeze([
+  "air", "drugs", "food", "fuel", "magazine", "power_cell", "other"
+]);
+
 const DIFFICULTIES = Object.freeze({
   CE: {
     Simple: {mod: 6, target: 2},
@@ -114,6 +118,7 @@ const DIFFICULTIES = Object.freeze({
 
 export const TWODSIX = {
   CHARACTERISTICS: CHARACTERISTICS,
+  CONSUMABLES: CONSUMABLES,
   VARIANTS: VARIANTS,
   ROLLTYPES: ROLLTYPES,
   DIFFICULTIES: DIFFICULTIES,

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -36,6 +36,15 @@ export default function registerHandlebarsHelpers():void {
     }
   });
 
+  Handlebars.registerHelper('twodsix_localizeConsumable', (type) => {
+    return game.i18n.localize(`TWODSIX.Items.Consumable.Types.${type}`);
+  });
+
+  Handlebars.registerHelper('twodsix_refillText', (subtype, quantity) => {
+    const refillWord = ["magazine", "power_cell"].includes(subtype) ? "Reload" : "Refill";
+    return `${game.i18n.localize(`TWODSIX.Actor.Items.${refillWord}`)} (${quantity - 1})`;
+  });
+
   Handlebars.registerHelper('twodsix_skillTotal', (actor, characteristic, value) => {
     const actorData = actor.data;
     const characteristicElement = actorData.characteristics[getKeyByValue(TWODSIX.CHARACTERISTICS, characteristic)];
@@ -99,32 +108,31 @@ export default function registerHandlebarsHelpers():void {
   });
 
   //From https://discord.com/channels/732325252788387980/732328233630171188/790507540818690068
-  //Not used yet
-  // Handlebars.registerHelper("iff", function (v1, operator, v2, options) {
-  //   switch (operator) {
-  //     case '==':
-  //       return (v1 == v2) ? options.fn(this) : options.inverse(this);
-  //     case '===':
-  //       return (v1 === v2) ? options.fn(this) : options.inverse(this);
-  //     case '!=':
-  //       return (v1 != v2) ? options.fn(this) : options.inverse(this);
-  //     case '!==':
-  //       return (v1 !== v2) ? options.fn(this) : options.inverse(this);
-  //     case '<':
-  //       return (v1 < v2) ? options.fn(this) : options.inverse(this);
-  //     case '<=':
-  //       return (v1 <= v2) ? options.fn(this) : options.inverse(this);
-  //     case '>':
-  //       return (v1 > v2) ? options.fn(this) : options.inverse(this);
-  //     case '>=':
-  //       return (v1 >= v2) ? options.fn(this) : options.inverse(this);
-  //     case '&&':
-  //       return (v1 && v2) ? options.fn(this) : options.inverse(this);
-  //     case '||':
-  //       return (v1 || v2) ? options.fn(this) : options.inverse(this);
-  //     default:
-  //       return options.inverse(this);
-  //   }
-  // });
+  Handlebars.registerHelper("iff", function (v1, operator, v2, options) {
+    switch (operator) {
+      case '==':
+        return (v1 == v2) ? options.fn(this) : options.inverse(this);
+      case '===':
+        return (v1 === v2) ? options.fn(this) : options.inverse(this);
+      case '!=':
+        return (v1 != v2) ? options.fn(this) : options.inverse(this);
+      case '!==':
+        return (v1 !== v2) ? options.fn(this) : options.inverse(this);
+      case '<':
+        return (v1 < v2) ? options.fn(this) : options.inverse(this);
+      case '<=':
+        return (v1 <= v2) ? options.fn(this) : options.inverse(this);
+      case '>':
+        return (v1 > v2) ? options.fn(this) : options.inverse(this);
+      case '>=':
+        return (v1 >= v2) ? options.fn(this) : options.inverse(this);
+      case '&&':
+        return (v1 && v2) ? options.fn(this) : options.inverse(this);
+      case '||':
+        return (v1 || v2) ? options.fn(this) : options.inverse(this);
+      default:
+        return options.inverse(this);
+    }
+  });
 
 }

--- a/src/module/hooks/deleteItem.ts
+++ b/src/module/hooks/deleteItem.ts
@@ -1,0 +1,12 @@
+import TwodsixActor from "../entities/TwodsixActor";
+import TwodsixItem from "../entities/TwodsixItem";
+
+Hooks.on('deleteOwnedItem', async (actor:TwodsixActor, itemData) => {
+  if (itemData.type === "consumable") {
+    actor.items.filter((item:TwodsixItem) => item.type !== "skills").forEach(async (item:TwodsixItem) => {
+      if (item.data.data.consumables.includes(itemData._id) || item.data.data.useConsumableForAttack === itemData._id) {
+        await item.removeConsumable(itemData._id);
+      }
+    });
+  }
+});

--- a/src/module/hooks/updateItem.ts
+++ b/src/module/hooks/updateItem.ts
@@ -1,0 +1,7 @@
+import TwodsixActor from "../entities/TwodsixActor";
+
+Hooks.on('preUpdateOwnedItem', async (actor:TwodsixActor, oldItem: Record<string,any>, updateData: Record<string,any>) => {
+  if (updateData.type && oldItem.type === "weapon" && updateData.type !== "weapon" && oldItem.data.useConsumableForAttack) {
+    updateData["data.useConsumableForAttack"] = "";
+  }
+});

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -1,5 +1,7 @@
 import {AbstractTwodsixItemSheet} from "./AbstractTwodsixItemSheet";
 import {TWODSIX} from "../config";
+import TwodsixItem from "../entities/TwodsixItem";
+import { getDataFromDropEvent, getItemDataFromDropData } from "../utils/sheetUtils";
 
 /**
  * Extend the basic ItemSheet with some very simple modifications
@@ -13,7 +15,8 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       classes: ["twodsix", "sheet", "item"],
       submitOnClose: true,
       submitOnChange: true,
-      tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description"}]
+      tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description"}],
+      dragDrop: [{dropSelector: null}]
     });
   }
 
@@ -40,7 +43,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       DIFFICULTIES: TWODSIX.DIFFICULTIES[game.settings.get('twodsix', 'difficultyListUsed')]
     };
     data.data.config = TWODSIX;
-
+    data.data.isOwned = this.item.isOwned;
     return data;
   }
 
@@ -66,6 +69,114 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       return;
     }
 
+    html.find('.consumable-create').on('click', this._onCreateConsumable.bind(this));
+    html.find('.consumable-edit').on('click', this._onEditConsumable.bind(this));
+    html.find('.consumable-delete').on('click', this._onDeleteConsumable.bind(this));
+    html.find('.consumable-use-consumable-for-attack').on('change', this._onChangeUseConsumableForAttack.bind(this));
     this.handleContentEditable(html);
+  }
+
+  private getConsumable(event:Event):TwodsixItem {
+    const li = $(event.currentTarget).parents(".consumable");
+    return this.item.actor.getOwnedItem(li.data("consumableId"));
+  }
+
+  private _onEditConsumable(event:Event):void {
+    this.getConsumable(event).sheet.render(true);
+  }
+
+  private async _onDeleteConsumable(event:Event):Promise<void> {
+    const consumable = this.getConsumable(event);
+    const bodyTextTemplate = game.i18n.localize("TWODSIX.Items.Consumable.RemoveConsumableFrom");
+    const consumableNameString = `"<strong>${consumable.name}</strong>"`;
+    const body = bodyTextTemplate.replace("_CONSUMABLE_NAME_", consumableNameString).replace("_ITEM_NAME_", this.item.name);
+
+    await Dialog.confirm({
+      title: game.i18n.localize("TWODSIX.Items.Consumable.RemoveConsumable"),
+      content: `<div class="remove-consumable">${body}<br><br></div>`,
+      yes: async () => await this.item.removeConsumable(consumable._id),
+      no: () => {
+        //Nothing
+      },
+    });
+  }
+
+  private async _onCreateConsumable():Promise<void> {
+    if (!this.item.isOwned) {
+      console.error(`Twodsix | Consumables can only be created for owned items`);
+      return;
+    }
+    const template = 'systems/twodsix/templates/items/dialogs/create-consumable.html';
+    const html = await renderTemplate(template, {
+      consumables: TWODSIX.CONSUMABLES
+    });
+    new Dialog({
+      title: `${game.i18n.localize("TWODSIX.Items.Items.New")} ${game.i18n.localize("TWODSIX.itemTypes.consumable")}`,
+      content: html,
+      buttons: {
+        ok: {
+          label: game.i18n.localize("TWODSIX.Create"),
+          callback: async (buttonHtml:JQuery) => {
+            const max = parseInt(buttonHtml.find('.consumable-max').val() as string, 10) || 0;
+            const data = {
+              name: buttonHtml.find('.consumable-name').val(),
+              type: "consumable",
+              data: {
+                subtype: buttonHtml.find('.consumable-subtype').val(),
+                quantity: parseInt(buttonHtml.find('.consumable-quantity').val() as string, 10) || 0,
+                currentCount: max,
+                max: max,
+              }
+            };
+            const newConsumable = await this.item.actor.createOwnedItem(data) as TwodsixItem;
+            await this.item.addConsumable(newConsumable._id);
+          }
+        },
+        cancel: {
+          label: game.i18n.localize("Cancel")
+        }
+      },
+      default: 'ok',
+    }).render(true);
+  }
+
+  private _onChangeUseConsumableForAttack(event:Event):void {
+    this.item.update({"data.useConsumableForAttack": $(event.currentTarget).val()});
+  }
+
+  private static check(cond:boolean, err:string) {
+    if(cond) {
+      throw new Error(game.i18n.localize(`TWODSIX.Errors.${err}`));
+    }
+  }
+
+  protected async _onDrop(event:DragEvent):Promise<boolean | any> {
+    event.preventDefault();
+    try {
+      TwodsixItemSheet.check(!this.item.isOwned, "OnlyOwnedItems");
+      TwodsixItemSheet.check(this.item.type === "skills", "SkillsConsumables");
+
+      const data = getDataFromDropEvent(event);
+
+      TwodsixItemSheet.check(!data, "DraggingSomething");
+      TwodsixItemSheet.check(data.type !== "Item", "OnlyDropItems");
+
+      const itemData = await getItemDataFromDropData(data);
+
+      TwodsixItemSheet.check(itemData.type !== "consumable", "OnlyDropConsumables");
+
+      // If the dropped item has the same actor as the current item let's just use the same id.
+      let itemId: string;
+      if (this.item.actor.getOwnedItem(itemData._id)) {
+        itemId = itemData._id;
+      } else {
+        const newItem = await this.item.actor.createEmbeddedEntity("OwnedItem", itemData);
+        itemId = newItem._id;
+      }
+      await this.item.addConsumable(itemId);
+    } catch (err) {
+      console.error(`Twodsix | ${err}`);
+      ui.notifications.error(err);
+    }
   }
 }

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -70,30 +70,10 @@ Hooks.once('init', async function () {
 
   registerSettings();
 
-  const templatePaths = [
-    //TODO Set up so the templates are instead loaded during build (or possibly during startup?), using all html files in the templates folder
-    "systems/twodsix/templates/actors/actor-sheet.html",
-    "systems/twodsix/templates/actors/parts/actor/actor-finances.html",
-    "systems/twodsix/templates/actors/parts/actor/actor-info.html",
-    "systems/twodsix/templates/actors/parts/actor/actor-items.html",
-    "systems/twodsix/templates/actors/parts/actor/actor-notes.html",
-    "systems/twodsix/templates/actors/parts/actor/actor-skills.html",
-    "systems/twodsix/templates/actors/ship-sheet.html",
-    "systems/twodsix/templates/actors/parts/ship/ship-cargo.html",
-    "systems/twodsix/templates/actors/parts/ship/ship-crew.html",
-    "systems/twodsix/templates/actors/parts/ship/ship-notes.html",
-    "systems/twodsix/templates/actors/parts/ship/ship-storage.html",
-    "systems/twodsix/templates/items/parts/common-parts.html",
-    "systems/twodsix/templates/items/armor-sheet.html",
-    "systems/twodsix/templates/items/augment-sheet.html",
-    "systems/twodsix/templates/items/equipment-sheet.html",
-    "systems/twodsix/templates/items/item-sheet.html",
-    "systems/twodsix/templates/items/junk-sheet.html",
-    "systems/twodsix/templates/items/skills-sheet.html",
-    "systems/twodsix/templates/items/storage-sheet.html",
-    "systems/twodsix/templates/items/tool-sheet.html",
-    'systems/twodsix/templates/chat/damage-message.html'
-  ];
+  const templatePaths = require.context("../static/templates", true, /\.html$/).keys().map(fileName => {
+    return "systems/twodsix/templates" + fileName.substring(1);
+  });
+
   await loadTemplates(templatePaths);
 
   // All other hooks are found in the module/hooks directory, and should be in the system.json esModules section.

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -1,9 +1,10 @@
 //MUST match what's in the template.json (or, at least not contradict it). TODO Should build this from the template.json I guess
-export type TwodsixItemType = "equipment" | "weapon" | "armor" | "augment" | "storage" | "tool" | "junk" | "skills";
+export type TwodsixItemType = "equipment" | "weapon" | "armor" | "augment" | "storage" | "tool" | "junk" | "skills" | "consumable";
 
 export interface TwodsixItemData extends ItemData {
   type:TwodsixItemType;
   hasOwner:boolean;
+  _id:string;
 }
 
 export type CharacteristicType =

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -47,6 +47,8 @@
         "AUGMENTS": "AUGMENTS",
         "Ammo": "Ammo",
         "Armor": "Armor",
+        "CONSUMABLES": "Consumables",
+        "Count": "Count",
         "CreateItem": "Create Item",
         "Damage": "Damage",
         "DeleteItem": "Delete Item",
@@ -57,7 +59,10 @@
         "Name": "Name",
         "Qty": "Qty",
         "Range": "Range",
+        "Refill": "Refill",
+        "Reload": "Reload",
         "ShortDescr": "Short Descr",
+        "Subtype": "Type",
         "TL": "TL",
         "WEAPONS": "WEAPONS",
         "Weight": "Wt"
@@ -99,6 +104,7 @@
         "Type": "Roll type"
       }
     },
+    "Create": "Create",
     "Handlebars": {
       "CantShowCharacteristic": "You need to reselect the characteristic for all skills marked with XXX. Sorry..."
     },
@@ -137,6 +143,7 @@
         "AssignJunk": "Assign Junk",
         "AssignTool": "Assign Tool",
         "AssignWeapon": "Assign Weapon",
+        "AssignConsumable": "Assign Consumable",
         "Inventory": "Inventory",
         "ItemType": "Type",
         "MoveStorage": "Move Storage",
@@ -159,6 +166,23 @@
       "Tool": {
         "Bonus": "Bonus"
       },
+      "Consumable": {
+        "Types": {
+          "air": "Air",
+          "drugs": "Drugs",
+          "food": "Food",
+          "fuel": "Fuel",
+          "magazine": "Magazine",
+          "power_cell": "Power Cell",
+          "other": "Other"
+        },
+        "Size": "Size",
+        "Subtype": "Type",
+        "Count": "Count",
+        "DropConsumablesHere": "You can drop consumables here.",
+        "RemoveConsumable": "Remove consumable",
+        "RemoveConsumableFrom": "Remove consumable _CONSUMABLE_NAME_ from _ITEM_NAME_?"
+      },
       "Weapon": {
         "Ammo": "Ammo",
         "Damage": "Damage",
@@ -168,7 +192,9 @@
         "weaponType": "Weapon Type",
         "damageType": "Damage Type",
         "rateOfFire": "Rate of Fire/Auto X",
-        "recoil": "Recoil"
+        "recoil": "Recoil",
+        "UseAsAmmunitionForAttack": "Use as ammunition for attack",
+        "MagazineCost": "Magazine/Power Cell Cost"
       }
     },
     "Migration": {
@@ -308,6 +334,7 @@
     "CloseAndCreateNew": "Close and create new",
     "Copy": "Copy",
     "Yes": "Yes",
+    "Name": "Name",
     "itemTypes": {
       "equipment": "equipment",
       "weapon": "weapon",
@@ -317,13 +344,24 @@
       "tool": "tool",
       "junk": "junk",
       "skills": "skills",
-      "skill": "skill"
+      "skill": "skill",
+      "consumable": "consumable"
     },
     "Errors": {
       "NoSkillForSkillRoll": "You tried to perform a skill roll without specifying a skill",
       "NoCharacteristicForRoll": "You tried to perform a characteristics roll without specifying a characteristic",
       "NoROFForAttack": "Rate of fire must be specified for this attack",
-      "NoDamageForWeapon": "This weapon has not specified the damage it does"
+      "NoDamageForWeapon": "This weapon has not specified the damage it does",
+      "TooFewToReload": "Too few _NAME_ to _REFILL_ACTION_",
+      "NoAmmo": "You are out of ammunition. You need to reload before shooting!",
+      "OnlyOwnedItems": "Can only drop to items that are owned by an actor",
+      "SkillsConsumables": "Skills can't have consumables",
+      "DraggingSomething": "Dragging something that can't be dragged",
+      "OnlyDropItems": "You can only drop items",
+      "OnlyDropConsumables": "Only consumables can be dropped on an item.",
+      "DropFailedWith": "Drop failed with _ERROR_MSG_",
+      "CouldNotFindItem": "Could not find an item with id: _ITEM_ID_",
+      "DraggedCompendiumIsNotItem": "The dragged compendium object is not an item."
     }
   },
   "VeryDifficult": "Very Difficult"

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -610,7 +610,7 @@ a.notes-tab.active {
 
 .items-weapons {
   display: grid;
-  grid-template-columns: 1em 12em 1.5em 1.5em 3.5em 3em 4em 3em 3em;
+  grid-template-columns: 1em 14em 1.5em 1.5em 3.5em 3em 5em 3em;
   gap: 1px 1px;
   grid-template-areas: '. . . . .';
 }
@@ -644,6 +644,13 @@ a.notes-tab.active {
 .items-equipment {
   display: grid;
   grid-template-columns: 1em 12em 1.5em 2.5em 13em 3em;
+  gap: 1px 1px;
+  grid-template-areas: '. . . . .';
+}
+
+.items-consumable {
+  display: grid;
+  grid-template-columns: 1em 15em 5em 2.5em 6.5em 3em;
   gap: 1px 1px;
   grid-template-areas: '. . . . .';
 }
@@ -1580,6 +1587,10 @@ a:hover {
   margin-top: 0.5em;
 }
 
+.form-section {
+  margin-top: 0.5em;
+}
+
 .item-range {
   margin-top: 0.5em;
 }
@@ -1627,6 +1638,66 @@ a:hover {
 
 .tabs .item.active {
   text-shadow: 0 0 10px #00e5ff !important;
+}
+
+/* ------ Item page - Consumables ------ */
+.consumable-row {
+  width: 100%;
+  height: 30px;
+}
+
+.consumable-row .wrapper {
+  float: right;
+}
+
+.consumable-row .refill-button {
+  width: 100px;
+  height: 20px;
+  border-radius: 10px;
+  line-height: normal;
+  cursor: pointer;
+  margin-top: 0px;
+  margin-left: 5px;
+}
+
+.consumable-row .consumable-count {
+  margin-left: 5px;
+}
+
+.consumable-row .refill-button[disabled], .combined-buttons button[disabled]  {
+  cursor: default;
+}
+
+.consumable-row .combined-buttons {
+  width: 40px;
+  font-size: 0em;
+}
+
+.consumable-row .combined-buttons button {
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  padding: 0;
+  line-height: normal;
+  cursor: pointer;
+}
+
+.consumable-row .left-button {
+  border-radius: 10px 0px 0px 10px;
+}
+
+.consumable-row .right-button {
+  border-left: 0px solid #000;
+  border-radius: 0px 10px 10px 0px;
+}
+
+.item-sheet .form-consumable-count {
+  width: 50px;
+  text-align: center;
+}
+
+.remove-consumable {
+  text-align: center;
 }
 
 /*--- Chat Log ---*/

--- a/static/template.json
+++ b/static/template.json
@@ -275,7 +275,7 @@
     }
   },
   "Item": {
-    "types": ["equipment", "weapon", "armor", "augment", "storage", "tool", "junk", "skills"],
+    "types": ["equipment", "weapon", "armor", "augment", "storage", "tool", "junk", "skills", "consumable"],
     "templates": {
       "gearTemplate": {
         "name": "",
@@ -286,6 +286,7 @@
         "weight": 0,
         "price": "",
         "traits": [],
+        "consumables": [],
         "equipped": {
           "weight": 0
         },
@@ -305,6 +306,7 @@
       "damageBonus": 0,
       "magazineSize": 0,
       "ammo": 0,
+      "useConsumableForAttack": "",
       "magazineCost": 0,
       "type": "weapon",
       "location": ["inventory", "storage"],
@@ -346,6 +348,14 @@
       "key": "key",
       "difficulty": "Average",
       "rolltype": "Normal"
+    },
+    "consumable": {
+      "templates": ["gearTemplate"],
+      "currentCount": 0,
+      "max": 0,
+      "type": "consumable",
+      "subtype": "other",
+      "location": ["inventory", "storage"]
     }
   }
 }

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -1,0 +1,17 @@
+<div class="consumable-row" data-consumable-id="{{_id}}">
+  <div class="wrapper">
+    {{name}}:
+    {{#with data}}
+    <span class="consumable-count">
+      <span>{{currentCount}}/{{max}}</span>
+      <span class="combined-buttons">
+        <button class="left-button adjust-consumable" {{#iff currentCount "===" 0}}disabled{{/iff}} data-value="1">-</button>
+        <button class="right-button adjust-consumable" {{#iff currentCount "===" max}}disabled{{/iff}} data-value="-1">+</button>
+      </span>
+    </span>
+    <button {{#iff currentCount "===" max}}disabled{{/iff}} class="refill-button">
+      {{twodsix_refillText subtype quantity}}
+    </button>
+    {{/with}}
+  </div>
+</div>

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -12,7 +12,6 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Range"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Damage"}}</span>
-      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Ammo"}}</span>
       <span class="item-name centre"><a class="item-control item-create" title='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="weapon"><i
         class="fas fa-plus"></i></a></span>
     </div>
@@ -32,8 +31,7 @@
             {{else}}
             <span class="item-name centre">{{data.range}}</span>
             {{/if}}
-            <span class="item-name centre roll-damage">{{twodsix_limitLength data.damage 5}}</span>
-            <span class="item-name centre">{{data.ammo}}</span>
+            <span class="item-name centre roll-damage">{{twodsix_limitLength data.damage 8}}</span>
             <span class="item-controls centre">
               <a class="item-control item-edit" title='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fas fa-edit"></i></a>
               <a class="item-control item-delete" title='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fas fa-trash"></i></a>
@@ -57,6 +55,9 @@
           {{/if}}
         </li>
       </ol>
+      {{#each item.data.consumableData as |consumableData|}}
+      {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
+      {{/each}}
     </div>
     {{/each}}
   </div>
@@ -94,6 +95,9 @@
           </span>
         </li>
       </ol>
+      {{#each item.data.consumableData as |consumableData|}}
+      {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
+      {{/each}}
     </div>
     {{/each}}
   </div>
@@ -130,6 +134,9 @@
           </span>
         </li>
       </ol>
+      {{#each item.data.consumableData as |consumableData|}}
+      {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
+      {{/each}}
     </div>
     {{/each}}
   </div>
@@ -164,7 +171,53 @@
             </span>
         </li>
       </ol>
+      {{#each item.data.consumableData as |consumableData|}}
+      {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
+      {{/each}}
     </div>
     {{/each}}
   </div>
+</div>
+
+ <!---- Consumables ---->
+ <div>
+    <span class="pusher"></span>
+    <span class="item-title">{{localize "TWODSIX.Actor.Items.CONSUMABLES"}}</span>
+    <div class="items-consumable gear-header">
+      <span></span>
+      <span class="item-name">{{localize "TWODSIX.Actor.Items.Name"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Count"}}</span>
+      <span class="item-name centre">
+        <a class="item-control item-create" title='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable">
+          <i class="fas fa-plus"></i>
+        </a>
+      </span>
+    </div>
+
+  {{#each actor.consumable as |item id|}}
+  <div class="item gear">
+    <ol class="ol-no-indent">
+      <li class="item flexrow" data-item-id="{{item._id}}">
+          <span class="items-consumable">
+            <span class="mini-dice rollable" title="{{twodsix_invertSkillRollShiftClick}}">
+              <img data-label="{{item.name}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/>
+            </span>
+            <span class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
+            <span class="item-name centre">{{twodsix_localizeConsumable data.subtype}}</span>
+            <span class="item-name centre">{{data.quantity}}</span>
+            <span class="item-name centre">{{data.currentCount}}/{{data.max}}</span>
+            <span class="item-controls centre">
+              <a class="item-control item-edit" title='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fas fa-edit"></i></a>
+              <a class="item-control item-delete" title='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fas fa-trash"></i></a>
+            </span>
+          </span>
+      </li>
+    </ol>
+    {{#each item.data.consumableData as |consumableData|}}
+    {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
+    {{/each}}
+  </div>
+  {{/each}}
 </div>

--- a/static/templates/items/armor-sheet.html
+++ b/static/templates/items/armor-sheet.html
@@ -43,5 +43,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/augment-sheet.html
+++ b/static/templates/items/augment-sheet.html
@@ -39,5 +39,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/consumable-sheet.html
+++ b/static/templates/items/consumable-sheet.html
@@ -1,0 +1,50 @@
+<form class="{{cssClass}}" autocomplete="off">
+  <div class="item-sheet">
+    {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
+
+    <div class="form-section">
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
+        <input type="number" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
+      </label>
+    </div>
+
+    <div class="form-section">
+      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Count"}}
+        <div>
+          <input class="form-consumable-count" name="data.currentCount" type="number" value="{{data.currentCount}}" data-dtype="Number">
+          /
+          <input class="form-consumable-count" name="data.max" type="number" value="{{data.max}}" data-dtype="Number">
+        </div>
+      </label>
+    </div>
+    <div class="form-section">
+      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Subtype"}}
+        <select name="data.subtype" value={{data.subtype}}>
+          {{#select data.subtype}}
+          {{#each data.config.CONSUMABLES as |consumable|}}
+          <option value="{{consumable}}">{{twodsix_localizeConsumable consumable}}</option>
+          {{/each}}
+          {{/select}}
+        </select>
+      </label>
+    </div>
+
+    <div class="form-section">
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
+        <input type="number" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
+      </label>
+    </div>
+
+    <div class="form-section">
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
+        <input type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
+      </label>
+    </div>
+
+    <div class="form-section">
+      <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
+      <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
+    </div>
+    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
+  </div>
+</form>

--- a/static/templates/items/dialogs/create-consumable.html
+++ b/static/templates/items/dialogs/create-consumable.html
@@ -1,0 +1,24 @@
+<div class="form-group form-section">
+  <label>{{localize "TWODSIX.Items.Consumable.Subtype"}}
+    <select class="consumable-subtype">
+      {{#each consumables as |consumable|}}
+        <option value="{{consumable}}">{{twodsix_localizeConsumable consumable}}</option>
+      {{/each}}
+    </select>
+  </label>
+</div>
+<div class="form-group form-section">
+  <label>{{localize "TWODSIX.Name"}}
+    <input type="text" class="consumable-name">
+  </label>
+</div>
+<div class="form-group form-section">
+  <label>{{localize "TWODSIX.Items.Equipment.Quantity"}}
+    <input type="number" class="consumable-quantity" data-dtype="Number">
+  </label>
+</div>
+<div class="form-group form-section">
+  <label>{{localize "TWODSIX.Items.Consumable.Size"}}
+    <input type="number" class="consumable-max" data-dtype="Number">
+  </label>
+</div>

--- a/static/templates/items/equipment-sheet.html
+++ b/static/templates/items/equipment-sheet.html
@@ -24,5 +24,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/item-sheet.html
+++ b/static/templates/items/item-sheet.html
@@ -34,5 +34,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/junk-sheet.html
+++ b/static/templates/items/junk-sheet.html
@@ -24,5 +24,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/parts/common-parts.html
+++ b/static/templates/items/parts/common-parts.html
@@ -25,8 +25,9 @@
           <option value="weapon">{{localize "TWODSIX.Items.Items.AssignWeapon"}}</option>
           <option value="armor">{{localize "TWODSIX.Items.Items.AssignArmor"}}</option>
           <option value="equipment">{{localize "TWODSIX.Items.Items.AssignEquipment"}}</option>
-          <option value="storage">{{localize "TWODSIX.Items.Items.AssignTool"}}</option>
-          <option value="storage">{{localize "TWODSIX.Items.Items.AssignJunk"}}</option>
+          <option value="consumable">{{localize "TWODSIX.Items.Items.AssignConsumable"}}</option>
+          <option value="tool">{{localize "TWODSIX.Items.Items.AssignTool"}}</option>
+          <option value="junk">{{localize "TWODSIX.Items.Items.AssignJunk"}}</option>
           <option value="storage">{{localize "TWODSIX.Items.Items.MoveStorage"}}</option>
         {{/select}}
       </select>

--- a/static/templates/items/parts/consumables-part.html
+++ b/static/templates/items/parts/consumables-part.html
@@ -1,0 +1,45 @@
+{{#if data.isOwned}}
+<div class="form-section">
+  {{localize "TWODSIX.Actor.Items.CONSUMABLES"}}: <br>
+  <table>
+    <thead>
+      <tr>
+        <td>{{localize "TWODSIX.Actor.Items.Name"}}</td>
+        <td>{{localize "TWODSIX.Actor.Items.Subtype"}}</td>
+        <td>{{localize "TWODSIX.Actor.Items.Qty"}}</td>
+        <td>{{localize "TWODSIX.Actor.Items.Count"}}</td>
+        <td class="centre">
+          <a class="consumable-create" title='{{localize "TWODSIX.Actor.Items.CreateItem"}}'>
+            <i class="fas fa-plus"></i>
+          </a>
+        </td>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each data.consumableData as |consumable|}}
+      <tr class="consumable" data-consumable-id="{{consumable._id}}">
+        <td>{{consumable.name}}</td>
+        <td>{{twodsix_localizeConsumable consumable.data.subtype}}</td>
+        <td>{{consumable.data.quantity}}</td>
+        <td>{{consumable.data.currentCount}}/{{consumable.data.max}}</td>
+        <td class="centre">
+          <a class="consumable-edit" title='{{localize "TWODSIX.Actor.Items.EditItem"}}'>
+            <i class="fas fa-edit"></i>
+          </a>
+          <a class="consumable-delete" title='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'>
+            <i class="fas fa-trash"></i>
+          </a>
+        </td>
+      </tr>
+      {{/each}}
+      {{#unless data.consumableData}}
+      <tr>
+        <td colspan="5">
+          {{localize "TWODSIX.Items.Consumable.DropConsumablesHere"}}
+        </td>
+      </tr>
+      {{/unless}}
+    </tbody>
+  </table>
+</div>
+{{/if}}

--- a/static/templates/items/storage-sheet.html
+++ b/static/templates/items/storage-sheet.html
@@ -24,5 +24,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/tool-sheet.html
+++ b/static/templates/items/tool-sheet.html
@@ -30,5 +30,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/weapon-sheet.html
+++ b/static/templates/items/weapon-sheet.html
@@ -4,40 +4,45 @@
       data-actor-id="{{actor._id}}">
   <div class="item-sheet">
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
+    <div class="form-section">
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.MagazineCost"}}
+        <input type="number" name="data.magazineCost" value="{{data.magazineCost}}">
+      </label>
+    </div>
 
     <div class="item-damage">
-      <label for="data.damage" class="resource-label">{{localize "TWODSIX.Items.Weapon.Damage"}}
-        <input id="data.damage" type="text" name="data.damage" value="{{data.damage}}">
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Damage"}}
+        <input type="text" name="data.damage" value="{{data.damage}}">
       </label>
     </div>
 
     <div class="item-range">
       {{#if data.settings.ShowRangeBandAndHideRange}}
-      <label for="data.rangeBand" class="resource-label">{{localize "TWODSIX.Items.Weapon.rangeBand"}}
-        <input id="data.rangeBand" type="text" name="data.rangeBand" value="{{data.rangeBand}}">
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.rangeBand"}}
+        <input type="text" name="data.rangeBand" value="{{data.rangeBand}}">
       </label>
       {{else}}
-      <label for="data.range" class="resource-label">{{localize "TWODSIX.Items.Weapon.Range"}}
-        <input id="data.range" type="text" name="data.range" value="{{data.range}}">
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Range"}}
+        <input type="text" name="data.range" value="{{data.range}}">
       </label>
       {{/if}}
     </div>
 
     <div class="item-ammo">
-      <label for="data.ammo" class="resource-label">{{localize "TWODSIX.Items.Weapon.Ammo"}}
-        <input id="data.ammo" type="text" name="data.ammo" value="{{data.ammo}}" data-dtype="Number"/>
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Ammo"}}
+        <input type="text" name="data.ammo" value="{{data.ammo}}">
       </label>
     </div>
 
     <div class="item-qty">
-      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
-        <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
+        <input type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
       </label>
     </div>
 
     <div class="item-weight">
-      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
-        <input id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
+        <input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
       </label>
     </div>
 
@@ -77,8 +82,8 @@
     {{/if}}
 
     <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
+        <input type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
       </label>
     </div>
 
@@ -86,5 +91,20 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
+    {{#if data.isOwned}}
+    <div class="item-form-section">
+      <label>{{localize "TWODSIX.Items.Weapon.UseAsAmmunitionForAttack"}}
+        <select class="consumable-use-consumable-for-attack">
+          <option value="">---</option>
+          {{#select data.useConsumableForAttack}}
+          {{#each data.consumableData as |consumable|}}
+          <option value="{{consumable._id}}">{{consumable.name}}</option>
+          {{/each}}
+          {{/select}}
+        </select>
+      </label>
+    </div>
+    {{/if}}
   </div>
 </form>

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -43,7 +43,8 @@ module.exports = (env, argv) => {
           ]
 
         },
-        {test: /\.(png|svg|jpg|gif|woff|woff2|eot|ttf|otf)$/, use: ['url-loader?limit=100000']}
+        {test: /\.(png|svg|jpg|gif|woff|woff2|eot|ttf|otf)$/, use: ['url-loader?limit=100000']},
+        {test: /\.html$/, use: ['file-loader']}
       ],
     },
     plugins: [


### PR DESCRIPTION
Note, this PR is against the development branch so that it can be tested!

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
There are no consumables so ammo has to be handled manually


* **What is the new behavior (if this is a feature change)?**
It adds an item called consumables and let's one attach those to other items (not skills though). An item can have any number of consumables, and for weapons one can set one of the attached consumables as being consumed when attacking. Consumables have their own section in the items list of the character sheet and show up under the attached item for increasing/decreasing it. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Fix #212