### PR TITLE
WIP: fix: change renderChatMessage hook to obfuscate hidden rolls properly

### DIFF
--- a/src/module/hooks/renderChatMessage.ts
+++ b/src/module/hooks/renderChatMessage.ts
@@ -10,20 +10,21 @@ Hooks.on('renderChatMessage', (app, html) => {
     });
   }
 
-  if (!damageMessage) {
-    const diceTotal = html.find(".dice-total");
-
-    // Add effect
-    diceTotal.text(`${game.i18n.localize('TWODSIX.Rolls.sum').capitalize()}: ${diceTotal.text()} ${game.i18n.localize('TWODSIX.Rolls.Effect')}: ${app.getFlag("twodsix", "effect")}`);
+  const diceTotal = html.find(".dice-total");
+  if (!damageMessage && diceTotal.length > 0 && app.isContentVisible) {
+    const effect = app.getFlag("twodsix", "effect");
+    if (!isNaN(effect)) {
+      const sumString = game.i18n.localize('TWODSIX.Rolls.sum').capitalize();
+      const effectString = game.i18n.localize('TWODSIX.Rolls.Effect');
+      diceTotal.text(`${sumString}: ${diceTotal.text()} ${effectString}: ${effect}`);
+    }
 
     // Color crits
-    if (diceTotal.length > 0) {
-      const crit = app.getFlag("twodsix", "crit");
-      if (crit && crit == Crit.success) {
-        diceTotal.addClass("crit-success-roll");
-      } else if (crit && crit == Crit.fail) {
-        diceTotal.addClass("crit-fail-roll");
-      }
+    const crit = app.getFlag("twodsix", "crit");
+    if (crit && crit == Crit.success) {
+      diceTotal.addClass("crit-success-roll");
+    } else if (crit && crit == Crit.fail) {
+      diceTotal.addClass("crit-fail-roll");
     }
   }
 });

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -153,7 +153,7 @@ export class TwodsixDiceRoll {
       {
         speaker: ChatMessage.getSpeaker({actor: this.actor}),
         flavor: flavor,
-        rollType: this.settings.rollType,
+        rollMode: this.settings.rollMode,
         flags: {
           "core.canPopout": true,
           "twodsix.crit": this.getCrit(),


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Currently private dice rolls show the effect to everyone instead of obfuscating it. There was also a bug ignoring the user's choice of roll mode in the roll dialog


* **What is the new behavior (if this is a feature change)?**
This change hides the effect and does not colorize the result if the user is not allowed to view it. It also fixes the issue with roll mode.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Fix #321