### PR TITLE
fix: make ship hull avaialble as token bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "data:copy": "ts-node src/scripts/data_copy.ts",
     "data:reset": "npm run build && ts-node src/scripts/data_reset.ts -f",
     "data:license": "cp foundry/foundry_dev_data/Config/license.json foundry/license.json",
-    "server": "node foundry/foundryvtt/resources/app/main.js --dataPath=foundry/foundry_dev_data --adminKey=foundry"
+    "server": "node foundry/foundryvtt/resources/app/main.js --dataPath=foundry/foundry_dev_data --adminKey=foundry",
+    "migration:create": "ts-node src/scripts/create_migration.ts"
   },
   "author": "",
   "license": "",

--- a/src/migrations/2021_02_10_10_10-old_migrations.ts
+++ b/src/migrations/2021_02_10_10_10-old_migrations.ts
@@ -1,0 +1,211 @@
+import TwodsixItem from "../module/entities/TwodsixItem";
+import { TwodsixItemData, UpdateData } from "src/types/twodsix";
+import TwodsixActor from "../module/entities/TwodsixActor";
+
+/**
+ * New style migrations should look at the object instead of the version to figure out what needs to be done.
+ * E.g. if a field is missing, add it with a default value. If a field has been renamed, check if the old one exists, and if so, copy over the data to the new field and delete the old one.
+ * A lot of old migrations have been removed, look in git history if you want to take a look at them.
+ */
+
+class Migration {
+
+  public static async buildUntrainedSkill(actor):Promise<TwodsixItem> {
+    if (actor.data.data.untrainedSkill) {
+      return;
+    }
+    const data = {
+      "name": game.i18n.localize("TWODSIX.Actor.Skills.Untrained"),
+      "type": "skills",
+      "flags": {'twodsix.untrainedSkill': true}
+    };
+    return await actor.createOwnedItem(data) as TwodsixItem;
+  }
+
+  private static async migrateActorData(actor:TwodsixActor):Promise<UpdateData> {
+    const updateData:UpdateData = <UpdateData>{};
+
+    let untrainedSkill;
+    if (actor.data.type == "traveller") {
+      untrainedSkill = actor.getOwnedItem(actor.data.data.untrainedSkill) as TwodsixItem;
+      if (!untrainedSkill) {
+        untrainedSkill = await Migration.buildUntrainedSkill(actor);
+        updateData['data.untrainedSkill'] = untrainedSkill._id;
+      }
+    }
+
+    //TODO Get rid of the untrainedSkill passing
+    await this.migrateActorItems(actor, untrainedSkill);
+
+    return updateData;
+  }
+
+  private static async migrateActorItems(actor:TwodsixActor, untrainedSkill:TwodsixItem=null) {
+    //Handle any items that are on the actor
+    const actorItems = actor.data["items"];
+    const toUpdate = [];
+    for (const i of actorItems) {
+      toUpdate.push(mergeObject(i, this.migrateItemData(i, actor, untrainedSkill)));
+    }
+    await actor.updateEmbeddedEntity("OwnedItem", toUpdate);
+  }
+
+  private static migrateItemData(item:TwodsixItemData, actor:TwodsixActor = null, untrainedSkill:TwodsixItem=null):UpdateData {
+    const updateData:UpdateData = <UpdateData>{};
+
+    if (item.type === 'skills') { //0.6.82
+      updateData['data.rolltype'] = item.data.rolltype || 'Normal';
+      if (typeof item.data.value ===  "string") { // 0.7.8
+        updateData['data.value'] = parseInt(item.data.value, 10);
+      }
+    }
+
+    if (actor &&  actor.data.type === "traveller") {
+      if (item.type !== 'skills') {
+        if (!item.data.skill) { //0.6.84
+          updateData['data.skill'] = untrainedSkill._id;
+        }
+      }
+    }
+
+    return updateData;
+  }
+
+
+  private static async migrateSceneData(scene:EntityData):Promise<{ tokens }> {
+    const tokens = duplicate(scene["tokens"]);
+    return {
+      tokens: tokens.map(t => {
+        const token = new Token(t);
+        if (!token.actor) {
+          t.actorId = null;
+          t.actorData = {};
+        } else if (!t.actorLink) {
+          const updateData = Migration.migrateActorData(<TwodsixActor>token.actor);
+          t.actorData = mergeObject(token.data.actorData, updateData);
+        }
+        return t;
+      })
+    };
+  }
+
+  private static async migrateCompendium(pack:{ metadata:{ entity; }; migrate:() => any; getContent:() => any; updateEntity:(arg0:any) => any; collection; }):Promise<void> {
+    const entity = pack.metadata.entity;
+    if (!['Actor', 'Item', 'Scene'].includes(entity)) {
+      return;
+    }
+
+    if (pack["locked"]) {
+      //Not much we can, or probably should, do.
+      return;
+    }
+
+    await pack.migrate();
+    const content = await pack.getContent();
+
+    const promises = [];
+    for (const actor of content) {
+      try {
+        let updateData = null;
+        switch (entity) {
+          case 'Item':
+            updateData = Migration.migrateItemData(actor.data, actor);
+            break;
+          case 'Actor':
+            updateData = Migration.migrateActorData(actor);
+            break;
+          case 'Scene':
+            updateData = Migration.migrateSceneData(actor.data);
+            break;
+        }
+        if (updateData && !isObjectEmpty(updateData)) {
+          expandObject(updateData);
+          updateData._id = actor._id;
+          promises.push(pack.updateEntity(updateData));
+          console.log(`Migrating ${entity} entity ${actor.name} in Compendium ${pack.collection}`);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    await Promise.all(promises);
+
+    console.log(`Migrated all ${entity} entities from Compendium ${pack.collection}`);
+  }
+
+  /**
+   * A general migration to remove all fields from the data model which are flagged with a _deprecated tag
+   * @private
+   */
+  static _migrateRemoveDeprecated(itemData:TwodsixItemData, updateData:UpdateData):void {
+    const flat = flattenObject(itemData.data);
+    // console.warn('flat', flat);
+    // Identify objects to deprecate
+    const toDeprecate = Object.entries(flat)
+      .filter((e) => e[0].endsWith('_deprecated') && e[1] === true)
+      .map((e) => {
+        const path = e[0].split('.');
+        path.pop();
+        return path.join('.');
+      });
+
+    // Remove them
+    for (const k of toDeprecate) {
+      const parts = k.split('.');
+      parts[parts.length - 1] = '-=' + parts[parts.length - 1];
+      updateData[`data.${parts.join('.')}`] = null;
+    }
+
+    //TODO Do as follows to remove a key in a migration.
+    //entity.update({ '-=key.to.remove': null });
+  }
+
+  static async migrateWorld():Promise<void> {
+    game.packs.filter(p => {
+      return (p.metadata.package === 'twodsix') && ['Actor', 'Item', 'Scene'].includes(p.metadata.entity);
+    });
+
+    ui.notifications.info(game.i18n.format("TWODSIX.Migration.DoNotClose", {version: game.system.data.version}), {permanent: true});
+
+    game.actors.entities.map(async actor => {
+      try {
+        const updateData = await Migration.migrateActorData(<TwodsixActor>actor);
+        if (!isObjectEmpty(updateData)) {
+          console.log(`Migrating Actor ${actor.name}`);
+          await actor.update(updateData, {enforceTypes: false});
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+
+    game.items.entities.map(async item => {
+      try {
+        const updateData = await Migration.migrateItemData(<TwodsixItemData>item.data);
+        if (!isObjectEmpty(updateData)) {
+          console.log(`Migrating Item ${item.name}`);
+          await item.update(updateData, {enforceTypes: false});
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+
+    let scene:any;
+    for (scene of game.scenes) {
+      try {
+        const updateData = await Migration.migrateSceneData(scene.data);
+        if (!isObjectEmpty(updateData)) {
+          console.log(`Migrating Scene ${scene.name}`);
+          await scene.update(updateData, {enforceTypes: false});
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  }
+}
+
+export async function migrate():Promise<void> {
+  await Migration.migrateWorld();
+}

--- a/src/migrations/2021_02_10_10_20-ship_stats.ts
+++ b/src/migrations/2021_02_10_10_20-ship_stats.ts
@@ -1,0 +1,133 @@
+import TwodsixActor from "../module/entities/TwodsixActor";
+
+class ActorUpdater {
+  needsConfirmation = false;
+  originalValues:Record<string,any> = {};
+  updateData:Record<string,any> = {};
+  actor: TwodsixActor;
+  fieldType:Record<string,string> = {};
+  removeFields:Record<string,null> = {};
+
+  constructor(actor: TwodsixActor) {
+    this.actor = actor;
+  }
+
+  public updateFieldWithNumber(key: string, value: any): void {
+    this.originalValues[key] = value;
+    this.fieldType[key] = "number";
+    let bestGuess = parseFloat(value);
+
+    if (isNaN(bestGuess)) {
+      bestGuess = 0;
+      this.needsConfirmation = true;
+    } else if (bestGuess == parseInt(value, 10)) {
+      bestGuess = parseInt(value, 10);
+    }
+    this.updateData[key] = bestGuess;
+  }
+
+  public updateFieldWithText(key:string, value:string):void {
+    this.updateData[key] = value;
+    this.fieldType[key] = "text";
+  }
+
+  public updateFieldWithObject(key:string, value:any):void {
+    this.updateData[key] = value;
+    this.fieldType[key] = "object";
+  }
+
+
+
+  removeField(key:string) {
+    this.removeFields[`data.-=${key}`] = null;
+  }
+
+  private showDialog(resolve: (arg0: Record<string,any>) => void) {
+    const inputFields = Object.entries(this.updateData).map(([key, value]) => {
+      if (this.fieldType[key] === "object") {
+        return "";
+      }
+      const originalValue = [undefined, ""].includes(this.originalValues[key])  ? "not set" : this.originalValues[key];
+      return `<label>${key.substring(5)} (previous value: ${originalValue})<input type="${this.fieldType[key]}" name="${key}" value="${value}"></label>`;
+    }).join("");
+    let confirmed = false;
+    new Dialog({
+      title: "Please confirm the data migration",
+      content: `<div>Some data could not be automatically migrated to the new version, please confirm and/or modify the data.</div><br><br><h3>${this.actor.name}</h3>` + inputFields,
+      buttons: {
+        ok: {
+          label: "ok",
+          callback: (buttonHtml) => {
+            confirmed = true;
+            $(buttonHtml).find("input").each((i, html) => {
+              switch(this.fieldType[html.name]) {
+                case "number":
+                  this.updateData[html.name] = Number(html.value);
+                  break;
+                case "text":
+                default:
+                  this.updateData[html.name] = html.value;
+                  break;
+              }
+            });
+            resolve(Object.assign(this.updateData, this.removeFields));
+          }
+        }
+      },
+      default: 'ok',
+      close: () => {
+        if (!confirmed) {
+          this.showDialog(resolve);
+        }
+      },
+    }).render(true);
+  }
+
+  public async getUpdateData():Promise<Record<string,any>> {
+    if (this.needsConfirmation) {
+      return new Promise(this.showDialog.bind(this));
+    } else {
+      return Promise.resolve(Object.assign(this.updateData, this.removeFields));
+    }
+  }
+}
+
+export async function migrate():Promise<void> {
+  await Promise.all(TwodsixActor.collection.map(async (actor:TwodsixActor) => {
+    if (actor.data.type == "ship") {
+      const actorUpdater = new ActorUpdater(actor);
+      const ship = actor.data.data.ship;
+      if (ship) {
+        actorUpdater.updateFieldWithNumber("data.maintenanceCost", ship.maintenance_cost);
+        actorUpdater.updateFieldWithText("data.cargo", ship.cargo);
+        actorUpdater.updateFieldWithText("data.notes", ship.notes);
+        actorUpdater.updateFieldWithObject("data.crew", ship.crew);
+
+        actorUpdater.updateFieldWithNumber("data.reqPower.systems", ship.reqPower["systems"]);
+        actorUpdater.updateFieldWithNumber("data.reqPower.m-drive", ship.reqPower["m-drive"]);
+        actorUpdater.updateFieldWithNumber("data.reqPower.j-drive", ship.reqPower["j-drive"]);
+        actorUpdater.updateFieldWithNumber("data.reqPower.sensors", ship.reqPower["sensors"]);
+        actorUpdater.updateFieldWithNumber("data.reqPower.weapons", ship.reqPower["weapons"]);
+
+        actorUpdater.updateFieldWithNumber("data.shipStats.hull.value", ship.shipStats.hullCurrent);
+        actorUpdater.updateFieldWithNumber("data.shipStats.hull.max", ship.shipStats.hull);
+        actorUpdater.updateFieldWithNumber("data.shipStats.fuel.value", ship.shipStats.fuelCurrent);
+        actorUpdater.updateFieldWithNumber("data.shipStats.fuel.max", ship.shipStats.fuel);
+        actorUpdater.updateFieldWithNumber("data.shipStats.power.value", ship.shipStats.powerCurrent);
+        actorUpdater.updateFieldWithNumber("data.shipStats.power.max", ship.shipStats.power);
+
+        actorUpdater.removeField("ship");
+      }
+
+      if (actor.data.data.ship_value !== undefined) {
+        actorUpdater.updateFieldWithText("data.shipValue", actor.data.data.ship_value);
+        actorUpdater.removeField("ship_value");
+      }
+
+      const updateData = await actorUpdater.getUpdateData();
+      if (Object.keys(updateData).length) {
+        await actor.update(updateData);
+      }
+    }
+  }));
+}

--- a/src/module/hooks/ready.ts
+++ b/src/module/hooks/ready.ts
@@ -1,4 +1,4 @@
-import {Migration} from "../migration";
+import migrateWorld from "../migration";
 import {createItemMacro} from "../utils/createItemMacro";
 
 Hooks.once("ready", async function () {
@@ -19,20 +19,14 @@ Hooks.once("ready", async function () {
 
   // Determine whether a system migration is required and feasible
 
-  const systemVersion = game.system.data.version;
-  let worldVersion = null;
-  if (game.settings.settings.has("twodsix.systemMigrationVersion")) {
-    worldVersion = await game.settings.get("twodsix", "systemMigrationVersion");
-    if (worldVersion == "null" || worldVersion == "") {
-      worldVersion = null;
-    }
+  let worldVersion = await game.settings.get("twodsix", "systemMigrationVersion");
+  if (worldVersion == "null" || worldVersion == null) {
+    worldVersion = "";
   }
 
-  const needMigration = worldVersion === null || isNewerVersion(systemVersion, worldVersion);
-
   // Perform the migration
-  if (needMigration && game.user.isGM) {
-    await Migration.migrateWorld();
+  if (game.user.isGM) {
+    await migrateWorld(worldVersion);
   }
 
   // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to

--- a/src/module/migration.ts
+++ b/src/module/migration.ts
@@ -1,204 +1,25 @@
-import {TwodsixItemData, UpdateData} from "../types/twodsix";
-import TwodsixActor from "./entities/TwodsixActor";
-import TwodsixItem from "./entities/TwodsixItem";
 
-/**
- * New style migrations should look at the object instead of the version to figure out what needs to be done.
- * E.g. if a field is missing, add it with a default value. If a field has been renamed, check if the old one exists, and if so, copy over the data to the new field and delete the old one.
- * A lot of old migrations have been removed, look in git history if you want to take a look at them.
- */
-export class Migration {
 
-  private static async migrateActorData(actor:TwodsixActor):Promise<UpdateData> {
-    const updateData:UpdateData = <UpdateData>{};
+const migrations = {};
 
-    let untrainedSkill;
-    if (actor.data.type == "traveller") {
-      untrainedSkill = actor.getUntrainedSkill();
-      if (!untrainedSkill) {
-        untrainedSkill = await actor.buildUntrainedSkill();
-        updateData['data.untrainedSkill'] = untrainedSkill._id;
-      }
+// this is a way of importing att of the files in the migrations folder and assign them to a property of an object.
+require.context("../migrations", false, /\.ts$/).keys().forEach((fileName => {
+  const newFileName = fileName.substring(2);
+  import("../migrations/" + newFileName).then((migration) => {
+    migrations[newFileName.split("-")[0]] = migration;
+  });
+}));
+
+
+export default async function migrateWorld(version:string):Promise<void> {
+  await Promise.all(Object.keys(migrations).sort().map(async migrationName => {
+    if (migrationName > version) {
+      console.log("Migrating", migrationName);
+      await migrations[migrationName].migrate();
+      console.log("Done migrating", migrationName);
+      await game.settings.set("twodsix", "systemMigrationVersion", migrationName);
     }
-
-    //TODO Get rid of the untrainedSkill passing
-    await this.migrateActorItems(actor, untrainedSkill);
-
-    return updateData;
-  }
-
-  private static async migrateActorItems(actor:TwodsixActor, untrainedSkill:TwodsixItem=null) {
-    //Handle any items that are on the actor
-    const actorItems = actor.data["items"];
-    const toUpdate = [];
-    for (const i of actorItems) {
-      toUpdate.push(mergeObject(i, this.migrateItemData(i, actor, untrainedSkill)));
-    }
-    await actor.updateEmbeddedEntity("OwnedItem", toUpdate);
-  }
-
-  private static migrateItemData(item:TwodsixItemData, actor:TwodsixActor = null, untrainedSkill:TwodsixItem=null):UpdateData {
-    const updateData:UpdateData = <UpdateData>{};
-
-    if (item.type === 'skills') { //0.6.82
-      updateData['data.rolltype'] = item.data.rolltype || 'Normal';
-      if (typeof item.data.value ===  "string") { // 0.7.8
-        updateData['data.value'] = parseInt(item.data.value, 10);
-      }
-    }
-
-    if (actor &&  actor.data.type === "traveller") {
-      if (item.type !== 'skills') {
-        if (!item.data.skill) { //0.6.84
-          updateData['data.skill'] = untrainedSkill._id;
-        }
-      }
-    }
-
-    return updateData;
-  }
-
-
-  private static async migrateSceneData(scene:EntityData):Promise<{ tokens }> {
-    const tokens = duplicate(scene["tokens"]);
-    return {
-      tokens: tokens.map(t => {
-        const token = new Token(t);
-        if (!token.actor) {
-          t.actorId = null;
-          t.actorData = {};
-        } else if (!t.actorLink) {
-          const updateData = Migration.migrateActorData(<TwodsixActor>token.actor);
-          t.actorData = mergeObject(token.data.actorData, updateData);
-        }
-        return t;
-      })
-    };
-  }
-
-  private static async migrateCompendium(pack:{ metadata:{ entity; }; migrate:() => any; getContent:() => any; updateEntity:(arg0:any) => any; collection; }):Promise<void> {
-    const entity = pack.metadata.entity;
-    if (!['Actor', 'Item', 'Scene'].includes(entity)) {
-      return;
-    }
-
-    if (pack["locked"]) {
-      //Not much we can, or probably should, do.
-      return;
-    }
-
-    await pack.migrate();
-    const content = await pack.getContent();
-
-    const promises = [];
-    for (const actor of content) {
-      try {
-        let updateData = null;
-        switch (entity) {
-          case 'Item':
-            updateData = Migration.migrateItemData(actor.data, actor);
-            break;
-          case 'Actor':
-            updateData = Migration.migrateActorData(actor);
-            break;
-          case 'Scene':
-            updateData = Migration.migrateSceneData(actor.data);
-            break;
-        }
-        if (updateData && !isObjectEmpty(updateData)) {
-          expandObject(updateData);
-          updateData._id = actor._id;
-          promises.push(pack.updateEntity(updateData));
-          console.log(`Migrating ${entity} entity ${actor.name} in Compendium ${pack.collection}`);
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    }
-    await Promise.all(promises);
-
-    console.log(`Migrated all ${entity} entities from Compendium ${pack.collection}`);
-  }
-
-  /**
-   * A general migration to remove all fields from the data model which are flagged with a _deprecated tag
-   * @private
-   */
-  static _migrateRemoveDeprecated(itemData:TwodsixItemData, updateData:UpdateData):void {
-    const flat = flattenObject(itemData.data);
-    // console.warn('flat', flat);
-    // Identify objects to deprecate
-    const toDeprecate = Object.entries(flat)
-      .filter((e) => e[0].endsWith('_deprecated') && e[1] === true)
-      .map((e) => {
-        const path = e[0].split('.');
-        path.pop();
-        return path.join('.');
-      });
-
-    // Remove them
-    for (const k of toDeprecate) {
-      const parts = k.split('.');
-      parts[parts.length - 1] = '-=' + parts[parts.length - 1];
-      updateData[`data.${parts.join('.')}`] = null;
-    }
-
-    //TODO Do as follows to remove a key in a migration.
-    //entity.update({ '-=key.to.remove': null });
-  }
-
-  static async migrateWorld():Promise<void> {
-    const packs = game.packs.filter(p => {
-      return (p.metadata.package === 'twodsix') && ['Actor', 'Item', 'Scene'].includes(p.metadata.entity);
-    });
-
-    ui.notifications.info(game.i18n.format("TWODSIX.Migration.DoNotClose", {version: game.system.data.version}), {permanent: true});
-
-    const actorMigrations = game.actors.entities.map(async actor => {
-      try {
-        const updateData = await Migration.migrateActorData(<TwodsixActor>actor);
-        if (!isObjectEmpty(updateData)) {
-          console.log(`Migrating Actor ${actor.name}`);
-          await actor.update(updateData, {enforceTypes: false});
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    });
-
-    const itemMigrations = game.items.entities.map(async item => {
-      try {
-        const updateData = await Migration.migrateItemData(<TwodsixItemData>item.data);
-        if (!isObjectEmpty(updateData)) {
-          console.log(`Migrating Item ${item.name}`);
-          await item.update(updateData, {enforceTypes: false});
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    });
-
-    const sceneMigrations = [];
-    let scene:any;
-    for (scene of game.scenes) {
-      try {
-        const updateData = await Migration.migrateSceneData(scene.data);
-        if (!isObjectEmpty(updateData)) {
-          console.log(`Migrating Scene ${scene.name}`);
-          await scene.update(updateData, {enforceTypes: false});
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    }
-
-    const packMigrations = packs.map(async pack => {
-      await Migration.migrateCompendium(pack);
-    });
-
-    await Promise.all([...actorMigrations, ...itemMigrations, ...sceneMigrations, ...packMigrations]);
-
-    await game.settings.set("twodsix", "systemMigrationVersion", game.system.data.version);
-    ui.notifications.info(game.i18n.format("TWODSIX.Migration.Completed", {version: game.system.data.version}), {permanent: true});
-  }
+  }));
+  console.log("Done with all migrations");
 }
+

--- a/src/scripts/create_migration.ts
+++ b/src/scripts/create_migration.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+
+const migrationName =  process.argv[2];
+if (!migrationName) {
+  console.log("You need to supply a name for the migration");
+  process.exit(1);
+}
+
+const tmpDate = new Date();
+const date = (new Date(tmpDate.toUTCString())).toISOString().replaceAll(/-|:|T/ig, "_").split(".")[0];
+
+const templateString = "export async function migrate():Promise<void> {\n\n}";
+
+fs.writeFileSync(`src/migrations/${date}_${migrationName}.ts`, templateString);
+console.log(`Succesfully created migration: src/migrations/${date}-${migrationName}.ts`);

--- a/static/template.json
+++ b/static/template.json
@@ -114,23 +114,32 @@
       },
       "notes": "",
       "cargo": "",
-      "maintenance_cost": "",
-      "ship_value": "",
+      "maintenanceCost": 0,
+      "shipValue": "",
       "reqPower": {
-        "systems": "",
-        "m-drive": "",
-        "j-drive": "",
-        "sensors": "",
-        "weapons": ""
+        "systems": 0,
+        "m-drive": 0,
+        "j-drive": 0,
+        "sensors": 0,
+        "weapons": 0
       },
       "other": "",
       "shipStats": {
-        "hull": "0",
-        "hullCurrent": "0",
-        "fuel": "0",
-        "fuelCurrent": "0",
-        "power": "0",
-        "powerCurrent": "0",
+        "hull": {
+          "value": 0,
+          "min": 0,
+          "max": 0
+        },
+        "fuel": {
+          "value": 0,
+          "min": 0,
+          "max": 0
+        },
+        "power": {
+          "value": 0,
+          "min": 0,
+          "max": 0
+        },
         "armor": {
           "name": "",
           "weight": "",

--- a/static/templates/actors/parts/ship/ship-cargo.html
+++ b/static/templates/actors/parts/ship/ship-cargo.html
@@ -1,4 +1,4 @@
   <div class="cargo-wrapper">
     <span class="item-title">SHIP CARGO</span>
-    <div contenteditable="true" data-edit="data.ship.cargo">{{{data.ship.cargo}}}</div>
+    <div contenteditable="true" data-edit="data.cargo">{{{data.cargo}}}</div>
   </div>

--- a/static/templates/actors/parts/ship/ship-crew.html
+++ b/static/templates/actors/parts/ship/ship-crew.html
@@ -3,61 +3,61 @@
 
     <div>
       <span class="item-title">CAPTAIN</span>
-      <input type="text" value="{{data.ship.crew.captain}}" name="data.ship.crew.captain"/>
+      <input type="text" value="{{data.crew.captain}}" name="data.crew.captain"/>
     </div>
 
     <div>
       <span class="item-title">PILOT</span>
-      <input type="text" value="{{data.ship.crew.pilot}}" name="data.ship.crew.pilot"/>
+      <input type="text" value="{{data.crew.pilot}}" name="data.crew.pilot"/>
     </div>
 
     <div>
       <span class="item-title">ASTROGATOR</span>
-      <input type="text" value="{{data.ship.crew.astrogator}}" name="data.ship.crew.astrogator"/>
+      <input type="text" value="{{data.crew.astrogator}}" name="data.crew.astrogator"/>
     </div>
 
     <div>
       <span class="item-title">MAINTENANCE</span>
-      <input type="text" value="{{data.ship.crew.maintenance}}" name="data.ship.crew.maintenance"/>
+      <input type="text" value="{{data.crew.maintenance}}" name="data.crew.maintenance"/>
     </div>
 
     <div>
       <span class="item-title">MEDIC</span>
-      <input type="text" value="{{data.ship.crew.medic}}" name="data.ship.crew.medic"/>
+      <input type="text" value="{{data.crew.medic}}" name="data.crew.medic"/>
     </div>
 
     <div>
       <span class="item-title">STEWARD</span>
-      <input type="text" value="{{data.ship.crew.steward}}" name="data.ship.crew.steward"/>
+      <input type="text" value="{{data.crew.steward}}" name="data.crew.steward"/>
     </div>
 
     <div>
       <span class="item-title">ADMIN</span>
-      <input type="text" value="{{data.ship.crew.admin}}" name="data.ship.crew.admin"/>
+      <input type="text" value="{{data.crew.admin}}" name="data.crew.admin"/>
     </div>
 
     <div>
       <span class="item-title">BROKER</span>
-      <input type="text" value="{{data.ship.crew.broker}}" name="data.ship.crew.broker"/>
+      <input type="text" value="{{data.crew.broker}}" name="data.crew.broker"/>
     </div>
 
     <div>
       <span class="item-title">OTHER</span>
-      <input type="text" value="{{data.ship.crew.other}}" name="data.ship.crew.other"/></div>
+      <input type="text" value="{{data.crew.other}}" name="data.crew.other"/></div>
 
     <div>
       <span class="item-title">ENGINEER(S)</span>
-      <div contenteditable="true" data-edit="data.ship.crew.engineer">{{{data.ship.crew.engineer}}}</div>
+      <div contenteditable="true" data-edit="data.crew.engineer">{{{data.crew.engineer}}}</div>
     </div>
 
     <div>
       <span class="item-title">GUNNER(S)</span>
-      <div contenteditable="true" data-edit="data.ship.crew.gunner">{{{data.ship.crew.gunner}}}</div>
+      <div contenteditable="true" data-edit="data.crew.gunner">{{{data.crew.gunner}}}</div>
     </div>
 
     <div>
       <span class="item-title">MARINE(S)</span>
-      <div contenteditable="true" data-edit="data.ship.crew.marine">{{{data.ship.crew.marine}}}</div>
+      <div contenteditable="true" data-edit="data.crew.marine">{{{data.crew.marine}}}</div>
     </div>
   </div>
 </div>

--- a/static/templates/actors/parts/ship/ship-notes.html
+++ b/static/templates/actors/parts/ship/ship-notes.html
@@ -1,4 +1,4 @@
 <div class="cargo-wrapper">
   <span class="item-title">SHIP NOTES</span>
-  <div contenteditable="true" data-edit="data.ship.notes">{{#if data.ship.notes}}{{{data.ship.notes}}}{{/if}}</div>
+  <div contenteditable="true" data-edit="data.notes">{{#if data.notes}}{{{data.notes}}}{{/if}}</div>
 </div>

--- a/static/templates/actors/ship-sheet.html
+++ b/static/templates/actors/ship-sheet.html
@@ -2,7 +2,7 @@
   <img class="ship-mask-bg" src="./systems/twodsix/assets/ship/Interface-Overlay-2.svg" alt="?"/>
   <div class="ship-container">
     <div class="ship_image">
-      <img class="ship-img" src="{{actor.img}}" data-edit="img" title="{{actor.ship.name}}" alt='{{localize "TWODSIX.Actor.ShipImage"}}'/>
+      <img class="ship-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" alt='{{localize "TWODSIX.Actor.ShipImage"}}'/>
     </div>
     <div class="ship-name">
       <input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}' onClick="this.select();"/>
@@ -10,12 +10,12 @@
     {{#unless limited}}
     <div class="ship-info">
       <div class="ship-state-grid">
-        <div class="ship-hull"><span>Ship Hull</span><input type="text" value="{{data.ship.shipStats.hullCurrent}}" name="data.ship.shipStats.hullCurrent" placeholder="0"/>
-          <input type="text" value="{{data.ship.shipStats.hull}}" name="data.ship.shipStats.hull" placeholder="0"/></div>
-        <div class="ship-fuel"><span>Fuel</span><input type="text" value="{{data.ship.shipStats.fuelCurrent}}" name="data.ship.shipStats.fuelCurrent" placeholder="0"/>
-          <input type="text" value="{{data.ship.shipStats.fuel}}" name="data.ship.shipStats.fuel" placeholder="0"/></div>
+        <div class="ship-hull"><span>Ship Hull</span><input type="number" value="{{data.shipStats.hull.value}}" name="data.shipStats.hull.value" placeholder="0"/>
+          <input type="number" value="{{data.shipStats.hull.max}}" name="data.shipStats.hull.max" placeholder="0"/></div>
+        <div class="ship-fuel"><span>Fuel</span><input type="number" value="{{data.shipStats.fuel.value}}" name="data.shipStats.fuel.value" placeholder="0"/>
+          <input type="number" value="{{data.shipStats.fuel.max}}" name="data.shipStats.fuel.max" placeholder="0"/></div>
         <div class="ship-maintenance"><span>Maintenance P/M</span>
-          <input type="text" value="{{data.ship.maintenance_cost}}" name="data.ship.maintenance_cost" placeholder="0"/>
+          <input type="text" value="{{data.maintenance_cost}}" name="data.maintenance_cost" placeholder="0"/>
         </div>
 
       </div>
@@ -23,15 +23,15 @@
     <div class="ship-power-management"><h3>Power Management</h3>
       <div class="ship-power"><label>Power</label>
         <span class="power-now">USED</span>
-        <input class="power-current" type="text" value="{{data.ship.shipStats.powerCurrent}}" name="data.ship.shipStats.powerCurrent" placeholder="0"/>
-        <input class="power-total" type="text" value="{{data.ship.shipStats.power}}" name="data.ship.shipStats.power" placeholder="0"/><span class="power-max">MAX</span>
+        <input class="power-current" type="number" value="{{data.shipStats.power.value}}" name="data.shipStats.power.value" placeholder="0"/>
+        <input class="power-total" type="number" value="{{data.shipStats.power.max}}" name="data.shipStats.power.max" placeholder="0"/><span class="power-max">MAX</span>
       </div>
       <div class="power-grid">
-        <div class="ship-systems"><label>Systems</label><input type="text" value="{{data.ship.reqPower.systems}}" name="data.ship.reqPower.systems" placeholder="0"/></div>
-        <div class="ship-m-drive"><label>M-Drive</label><input type="text" value="{{data.ship.reqPower.m-drive}}" name="data.ship.reqPower.m-drive" placeholder="0"/></div>
-        <div class="ship-j-drive"><label>J-Drive</label><input type="text" value="{{data.ship.reqPower.j-drive}}" name="data.ship.reqPower.j-drive" placeholder="0"/></div>
-        <div class="ship-sensors"><label>Sensors</label><input type="text" value="{{data.ship.reqPower.sensors}}" name="data.ship.reqPower.sensors" placeholder="0"/></div>
-        <div class="ship-weapons">Weapons<input type="text" value="{{data.ship.reqPower.weapons}}" name="data.ship.reqPower.weapons" placeholder="0"></div>
+        <div class="ship-systems"><label>Systems</label><input type="number" value="{{data.reqPower.systems}}" name="data.reqPower.systems" placeholder="0"/></div>
+        <div class="ship-m-drive"><label>M-Drive</label><input type="number" value="{{data.reqPower.m-drive}}" name="data.reqPower.m-drive" placeholder="0"/></div>
+        <div class="ship-j-drive"><label>J-Drive</label><input type="number" value="{{data.reqPower.j-drive}}" name="data.reqPower.j-drive" placeholder="0"/></div>
+        <div class="ship-sensors"><label>Sensors</label><input type="number" value="{{data.reqPower.sensors}}" name="data.reqPower.sensors" placeholder="0"/></div>
+        <div class="ship-weapons">Weapons<input type="number" value="{{data.reqPower.weapons}}" name="data.reqPower.weapons" placeholder="0"></div>
       </div>
     </div>
     {{/unless}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Previously token bars were broken for ships.


* **What is the new behavior (if this is a feature change)?**
This commit fixes a bug where all ship properties were incorrectly stored under a "ship" property and changes the format of hull, power, and fuel to be compatible with the token bars.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
There's a migration that might need manual interference. However the user receives a dialog so they have some control themselves


* **Other information**:
* Fix #289
