### PR TITLE
Update Parser for CE 1001 Characters.js

### DIFF
--- a/user_macros/NPC Parsers/Parser for CE 1001 Characters.js
+++ b/user_macros/NPC Parsers/Parser for CE 1001 Characters.js
@@ -147,12 +147,12 @@ async function getInputText() {
 
     let adjName = translateSkillName(skillName);
 
-    let skillItem = await pack.find(s => s.name === adjName);
+    let skillItem = await pack.find(s => s.name === adjName && s.type==='skills');
 
     // Try to correct a null skillItem
     if (skillItem === null || skillItem === undefined) {
       adjName = compendiumErrors(skillName);
-      skillItem = await pack.find(s => s.name === adjName);
+      skillItem = await pack.find(s => s.name === adjName && s.type==='skills');
     }
 
     // Add new skill if it doesn't exist, pick higher level to add if it does
@@ -253,6 +253,7 @@ function translateSkillName(skillName) {
   case 'Energy Pistol':
   case 'Energy Rifle':
   case 'Shotguns':
+  case 'Shotgun':
   case 'Slug Pistol':
   case 'Slug Rifle':
     switch (compendium) {
@@ -407,5 +408,7 @@ function compendiumErrors(skillName) {
     return ('Melee');
   case 'Demolitions':
     return ('Demolition / Explosives');
+  case 'Shotgun':
+			return ('Gun Combat (Shotguns)');
   }
 }


### PR DESCRIPTION
Fix for skills lookup to only look at type=='skills'

* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
