### PR TITLE
WIP fix: add feature to automatically populate skills for new actors

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -116,11 +116,17 @@ const DIFFICULTIES = Object.freeze({
   }
 });
 
+const DEFAULT_SKILL_COMPENDIUM = Object.freeze({
+  "none": "---",
+  "twodsix.twodsix-custom-skills": "twodsix-custom-skills"
+})
+
 export const TWODSIX = {
   CHARACTERISTICS: CHARACTERISTICS,
   CONSUMABLES: CONSUMABLES,
   VARIANTS: VARIANTS,
   ROLLTYPES: ROLLTYPES,
   DIFFICULTIES: DIFFICULTIES,
-  RULESETS: RULESETS
+  RULESETS: RULESETS,
+  DEFAULT_SKILL_COMPENDIUM: DEFAULT_SKILL_COMPENDIUM
 };

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -37,6 +37,23 @@ export default class TwodsixActor extends Actor {
 
   }
 
+  async _onCreate(data: any, options: any, userId: string) {
+    super._onCreate(data, options, userId);
+    if (this.data.type == "traveller") {
+
+      if (!options.noSkillImport && !game.settings.get('twodsix', 'hideUntrainedSkills')) {
+        const compendium = game.packs.get(game.settings.get('twodsix', 'defaultSkillCompendium'));
+        if (compendium) {
+          const content = await compendium.getContent();
+          // @ts-ignore
+          await this.createEmbeddedEntity("OwnedItem", content.map(skill=>skill.data));
+        }
+      }
+
+      await this.createUntrainedSkill();
+    }
+  }
+
   /**
    * Prepare Character type specific data
    */

--- a/src/module/hooks/addUntrainedSkill.ts
+++ b/src/module/hooks/addUntrainedSkill.ts
@@ -1,7 +1,0 @@
-import TwodsixActor from "../entities/TwodsixActor";
-
-Hooks.on('createActor', async (actor: TwodsixActor) => {
-  if (actor.data.type == "traveller") {
-    await actor.createUntrainedSkill();
-  }
-});

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -45,11 +45,17 @@ export const registerSettings = function ():void {
   _booleanSetting('criticalNaturalAffectsEffect', false);
   _numberSetting('absoluteCriticalEffectValue', 99);
 
+  _stringChoiceSetting(
+    'defaultSkillCompendium',
+    TWODSIX.DEFAULT_SKILL_COMPENDIUM["none"],
+    TWODSIX.DEFAULT_SKILL_COMPENDIUM
+  );
+
+  _booleanSetting('invertSkillRollShiftClick', false);
+
   //As yet unused
   _numberSetting('maxSkillLevel', 9);
   _numberSetting('absoluteBonusValueForEachTimeIncrement', -1);
-
-  _booleanSetting('invertSkillRollShiftClick', false  );
 
   //Must be the last setting in the file
   _stringSetting('systemMigrationVersion', game.system.data.version);

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -329,6 +329,10 @@
       "invertSkillRollShiftClick": {
         "hint": "When clicking on a skill a dialog for the skill roll typically appears. Shift-clicking is a shortcut for rolling without modifiers witth a dificulty of 8. Checking this box swaps this behavior.",
         "name": "Invert behavior for shift-clicking for skill rolls"
+      },
+      "defaultSkillCompendium": {
+        "hint": "This skill compendium will be used to populate newly created actors so that they will have all of those skills. Using the twodsix-custom-skills option uses the twodsix-custom-skills compendium, which is meant for a custom skill set. Please note that if 'Hide all untrained skills' is checked the skills will not be populated.",
+        "name": "Skill list to use for new actors"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/system.json
+++ b/static/system.json
@@ -119,6 +119,13 @@
       "module": "twodsix",
       "path": "./packs/cepheus-atom-actors.db",
       "entity": "Actor"
+    }, {
+      "name": "twodsix-custom-skills",
+      "label": "twodsix-custom-skills",
+      "system": "twodsix",
+      "module": "twodsix",
+      "path": "./packs/twodsix-custom-skills.db",
+      "entity": "Item"
     }
   ],
   "primaryTokenAttribute": "hits",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Previously users had to manually populate actors with skills. It default to not populating automatically. Also a flag, "noSkillImport" has been added as an option that can be passed in when creating a skill to prevent it from populating the skills automatically. 


* **What is the new behavior (if this is a feature change)?**
This feature automatically imports skills from a skill list defined in the
settings.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
yes, noSkillImport must be passed in when creating an actor in order not to populate it. This can be relevant for macros that create NPCs based on external data.


* **Other information**:
