### PR TITLE
fix(Combat Tracker): hiding actor makes it opaque instead of completely hidden

### DIFF
--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -593,10 +593,6 @@ a.notes-tab.active {
   text-shadow: none !important;
 }
 
-.hidden {
-  display: none;
-}
-
 .tab[data-tab].active {
   display: block;
   position: relative;


### PR DESCRIPTION
### What?
Removes our custom `.hidden` class that conflicts with base Foundry usage

### Before
Hiding an actor in the Combat Tracker would make the actor completely hidden in the list

### After
Hiding an actor will default to the base behavior of Foundry (currently making the actor opaque to the GM)

### Is this a breaking change?
I do not think so. I could find no usages of this class in the markup or scripts, so I just opted to remove the entire class itself.

Fixes xdy/twodsix-foundryvtt#473