### PR TITLE
Update TwodsixDiceRoll.ts to Fix Effect Calculation for Critical

### DIFF
--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -93,13 +93,13 @@ export class TwodsixDiceRoll {
     let effect = this.roll.total - this.settings.difficulty.target;
     if (this.isNaturalCritSuccess()) {
       console.log(`Got a natural 12 with Effect ${effect}!`);
-      if (effect >= 0 && game.settings.get('twodsix', 'criticalNaturalAffectsEffect')) {
+      if (effect < 0 && game.settings.get('twodsix', 'criticalNaturalAffectsEffect')) {
         console.log("Setting Effect to 0 due to natural 12!");
         effect = 0;
       }
     } else if (this.isNaturalCritFail()) {
       console.log(`Got a natural 2 with Effect ${effect}!`);
-      if (effect < 0 && game.settings.get('twodsix', 'criticalNaturalAffectsEffect')) {
+      if (effect >= 0 && game.settings.get('twodsix', 'criticalNaturalAffectsEffect')) {
         console.log("Setting Effect to -1 due to natural 2!");
         effect = -1;
       }


### PR DESCRIPTION
This fixes the calculation of the effect when critical are rolled

* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a bug fix for critical rolls


* **What is the current behavior?** (You can also link to an open issue here)
Addresses
https://github.com/xdy/twodsix-foundryvtt/issues/471


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
I have not been able to validate the change works!