### PR TITLE
fix: Fix and enhance weapon hotbar macro

### DIFF
--- a/src/module/utils/rollItemMacro.ts
+++ b/src/module/utils/rollItemMacro.ts
@@ -1,11 +1,12 @@
 import TwodsixItem from "../entities/TwodsixItem";
+import { TWODSIX } from "../config";
 
 /**
  * Use a previously created macro.
  * @param {string} itemId
  * @return {Promise}
  */
-export async function rollItemMacro(itemId:string):Promise<void> {
+export async function rollItemMacro(itemId: string): Promise<void> {
   const speaker = ChatMessage.getSpeaker();
   let actor;
   if (speaker.token) {
@@ -14,10 +15,53 @@ export async function rollItemMacro(itemId:string):Promise<void> {
   if (!actor) {
     actor = game.actors.get(speaker.actor);
   }
-  const item:TwodsixItem = actor ? actor.items.find((i) => i._id === itemId) : null;
+  const item: TwodsixItem = actor ? actor.items.find((i) => i._id === itemId) : null;
   if (!item) {
-    ui.notifications.warn(`Your controlled Actor does not have an item with ID ${itemId}`);
+    ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.ActorMissingItem").replace("_ITEM_ID_", itemId));
   } else {
-    await item.skillRoll(false);
+    if (item.data.type != "weapon") {
+      await item.skillRoll(false);
+    } else {
+      if (shouldShowCELAutoFireDialog(item)) {
+        const attackType = await promptForROF();
+        await item.performAttack(attackType, true);
+      } else {
+        await item.performAttack("", true);
+      }
+    }
   }
+}
+
+function shouldShowCELAutoFireDialog(weapon: TwodsixItem): boolean {
+  return (
+    (game.settings.get('twodsix', 'autofireRulesUsed') === TWODSIX.RULESETS.CEL.key) &&
+    (weapon.data.data.rateOfFire > 1)
+  );
+}
+
+async function promptForROF(): Promise<string> {
+  return await new Promise((resolve) => {
+    new Dialog({
+      modal: true,
+      title: game.i18n.localize("TWODSIX.Dialogs.ROFPickerTitle"),
+      content: "",
+      buttons: {
+        single: {
+          label: game.i18n.localize("TWODSIX.Dialogs.ROFSingle"), callback: () => {
+            resolve('');
+          }
+        },
+        burst: {
+          label: game.i18n.localize("TWODSIX.Dialogs.ROFBurst"), callback: () => {
+            resolve('auto-burst');
+          }
+        },
+        full: {
+          label: game.i18n.localize("TWODSIX.Dialogs.ROFFull"), callback: () => {
+            resolve('auto-full');
+          }
+        }
+      }
+    }).render(true);
+  });
 }

--- a/src/module/utils/rollItemMacro.ts
+++ b/src/module/utils/rollItemMacro.ts
@@ -40,9 +40,8 @@ function shouldShowCELAutoFireDialog(weapon: TwodsixItem): boolean {
 }
 
 async function promptForROF(): Promise<string> {
-  return await new Promise((resolve) => {
+  return new Promise((resolve) => {
     new Dialog({
-      modal: true,
       title: game.i18n.localize("TWODSIX.Dialogs.ROFPickerTitle"),
       content: "",
       buttons: {
@@ -61,7 +60,8 @@ async function promptForROF(): Promise<string> {
             resolve('auto-full');
           }
         }
-      }
+      },
+      default: 'single',
     }).render(true);
   });
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -23,6 +23,12 @@
       "CharacterIsDead": "Character is dead",
       "DealDamageTo": "Deal damage to _ACTOR_NAME_"
     },
+    "Dialogs": {
+      "ROFPickerTitle": "Select a rate of fire",
+      "ROFSingle": "Single Fire",
+      "ROFBurst": "Burst Fire",
+      "ROFFull": "Full Auto"
+    },
     "Actor": {
       "Age": "Age",
       "CharacterImage": "Character Image",
@@ -386,6 +392,7 @@
       "DraggedCompendiumIsNotItem": "The dragged compendium object is not an item."
     },
     "Warnings": {
+      "ActorMissingItem": "Your controlled Actor does not have an item with id: _ITEM_ID_",
       "AutoDamageForMultipleTargetsNotImplemented": "Automatically damaging multiple targets (using Auto X) is currently not supported",
       "MaxStatVal": "The value exceededs the maximum stat value",
       "StatValBelowZero": "The value cannot be below zero",


### PR DESCRIPTION
- Now rolls damage as expected
- Dialog text moved to localization file
  - only english translation provided in the PR
- If using CEL rate of fire rules, use hotbar macro prompts for attack type
  - I don't use or currently understand how the CE ROF rules work, so I didn't attempt to implement a dialog for that. It should not be too difficult for someone else to add, though.

Fixes #472

Thanks to @marvin9257 for the initial code to get this started.