### PR TITLE
Update createItemMacro.ts

### DIFF
--- a/src/module/utils/createItemMacro.ts
+++ b/src/module/utils/createItemMacro.ts
@@ -6,7 +6,7 @@
  * @returns {Promise}
  */
 export async function createItemMacro(item, slot):Promise<void> {
-  const command = `game.twodsix.rollItemMacro("${item.id ? item.id : item.data.id}");`;
+  const command = `game.twodsix.rollItemMacro("${item.id ? item.id : item.data._id}");`;
   let macro = game.macros.entities.find((m) => (m.name === item.name) /*&& (m.data.command === command)*/);
   if (!macro) {
     const itemName = item.name ? item.name : item.data.name;


### PR DESCRIPTION
Fix for an undefined item id when dropping an item from a player sheet.

* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a bug fix for macros not being created properly when dragging and dropping.  This fixes issue #511.


* **What is the current behavior?** (You can also link to an open issue here)
When dropping an item, the item id is currently "undefined".


* **What is the new behavior (if this is a feature change)?**
The item id is correctly add to the macro.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None.


* **Other information**:
A more extensive stylistic edit might be prudent to note that the object item passed to this function is really item.data.  I didn't make these changes.