### PR TITLE
fix: consumable bugs

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -25,7 +25,7 @@ export default class TwodsixItem extends Item {
   }
 
   prepareConsumable():void {
-    if (this.data.data.consumables !== undefined && this.data.data.consumables.length > 0) {
+    if (this.data.data.consumables !== undefined && this.data.data.consumables.length > 0 && this.actor != null) {
       this.data.data.consumableData = this.data.data.consumables.map((consumableId:string) => {
         return this.actor.items.filter((item) => item.id === consumableId)[0];
       });
@@ -45,7 +45,7 @@ export default class TwodsixItem extends Item {
 
   public async removeConsumable(consumableId: string):Promise<void> {
     const updatedConsumables = this.data.data.consumables.filter((cId:string) => {
-      return cId !== consumableId;
+      return (cId !== consumableId && cId!==null && this.actor.items.get(cId) !== undefined);
     });
     const updateData = {"data.consumables": updatedConsumables};
     if (this.data.data.useConsumableForAttack === consumableId) {

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -213,6 +213,13 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
         return this._onSortItem(event, itemData);
       }
 
+      //Remove any attached consumables
+      // @ts-ignore
+      if(itemData.data.consumables.length>0) {
+        // @ts-ignore
+        itemData.data.consumables =[];
+      }
+      
       // Create the owned item (TODO Add to type and remove the two lines below...)
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -215,9 +215,9 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
 
       //Remove any attached consumables
       // @ts-ignore
-      if(itemData.data.consumables.length>0) {
+      if(itemData.data.consumables.length > 0) {
         // @ts-ignore
-        itemData.data.consumables =[];
+        itemData.data.consumables = [];
       }
       
       // Create the owned item (TODO Add to type and remove the two lines below...)

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -43,6 +43,16 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
         content: template,
         yes: async () => {
           // @ts-ignore
+          // somehow on hooks isn't wokring when a consumable is deleted  - force the issue
+          if (ownedItem.type === "consumable") {
+            let tempItems = this.actor.items.filter(i => i.type !== "skills");
+            tempItems.forEach( i => {
+              if (i.data.data.consumables.includes(ownedItem.id)  || i.data.data.useConsumableForAttack === ownedItem.id) {
+                 i.removeConsumable(ownedItem.id);
+              }
+            });
+          }
+          
           await this.actor.deleteEmbeddedDocuments("Item", [ownedItem.id]);
           li.slideUp(200, () => this.render(false));
         },

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -96,20 +96,24 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
 
   private async _onDeleteConsumable(event:Event):Promise<void> {
     const consumable = this.getConsumable(event);
-    const bodyTextTemplate = game.i18n.localize("TWODSIX.Items.Consumable.RemoveConsumableFrom");
-    const consumableNameString = `"<strong>${consumable.name}</strong>"`;
-    const body = bodyTextTemplate.replace("_CONSUMABLE_NAME_", consumableNameString).replace("_ITEM_NAME_", this.item.name);
+    if(!consumable) {
+      this.item.removeConsumable("");
+    } else {
+      const bodyTextTemplate = game.i18n.localize("TWODSIX.Items.Consumable.RemoveConsumableFrom");
+      const consumableNameString = `"<strong>${consumable.name}</strong>"`;
+      const body = bodyTextTemplate.replace("_CONSUMABLE_NAME_", consumableNameString).replace("_ITEM_NAME_", this.item.name);
 
-    // @ts-ignore
-    await Dialog.confirm({
-      title: game.i18n.localize("TWODSIX.Items.Consumable.RemoveConsumable"),
-      content: `<div class="remove-consumable">${body}<br><br></div>`,
       // @ts-ignore
-      yes: async () => this.item.removeConsumable(consumable.id),
-      no: () => {
-        //Nothing
-      },
-    });
+      await Dialog.confirm({
+        title: game.i18n.localize("TWODSIX.Items.Consumable.RemoveConsumable"),
+        content: `<div class="remove-consumable">${body}<br><br></div>`,
+        // @ts-ignore
+        yes: async () => this.item.removeConsumable(consumable.id),
+        no: () => {
+          //Nothing
+        },
+      });
+    }
   }
 
   private async _onCreateConsumable():Promise<void> {
@@ -183,8 +187,8 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       if (this.item.actor.items.get(itemData.id)) {
         itemId = itemData.id;
       } else {
-        const newItem = await this.item.actor.createEmbeddedEntity("OwnedItem", itemData);
-        itemId = newItem["id"];
+        const newItem = await this.item.actor.createEmbeddedDocuments("Item", [itemData]);
+        itemId = newItem[0].id;
       }
       // @ts-ignore
       await this.item.addConsumable(itemId);


### PR DESCRIPTION
This commit tries to fix several errors with consumables:
1) not being able to delete phantom consumables
2)  deleting from actor sheet did not delete from item

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fixes to address multiple problems with consumable deleting.


* **What is the current behavior?** (You can also link to an open issue here)
Run errors and phantom consumables that can't be deleted. Tries to address item number #490 


* **What is the new behavior (if this is a feature change)?**

Able to delete phantom consumables and better checking for unlinked consumables when deleting.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

NO

* **Other information**:
Would be nice if someone could check this besides me.  Still need to remove consumable items when dragging to a compendium.  I have not found where to do this in the code. Thanks.