### PR TITLE
Fix: old UWP translator had truncated the trade codes

### DIFF
--- a/user_macros/UWP Translator/UWP Translator.js
+++ b/user_macros/UWP Translator/UWP Translator.js
@@ -145,7 +145,7 @@ function get_TradeC(profile) {
     let atmo = hexToBase10(profile[2]);
     let hydro = hexToBase10(profile[3]);
     let pop = hexToBase10(profile[4]);
-    // let techL = hexToBase10(profile[7]);
+    let techL = hexToBase10(profile[7]);
 
     if (atmo > 3 && atmo < 10 && hydro > 3 && hydro < 9 && pop > 4 && pop < 8) {
       rtext += `Ag - Agricultural, `;
@@ -154,7 +154,70 @@ function get_TradeC(profile) {
     if (size === 0 && atmo === 0 && hydro === 0) {
       rtext += `Asteroid, `;
     }
+    if (pop === 0) {
+      rtext += 'Ba - Barren, ';
+    }
 
+    if (atmo > 1 && hydro === 0) {
+      rtext += 'De - Desert, ';
+    }
+
+    if (atmo > 9 && hydro > 0) {
+      rtext += 'Fl - Non-water Fluid Oceans, ';
+    }
+
+    if ((atmo === 5 || atmo === 6 || atmo === 8) && hydro > 3 && hydro < 10 && pop > 3 && pop < 9) {
+      rtext += 'Ga - Garden, ';
+    }
+
+    if (pop > 8) {
+      rtext += 'Hi - High Population, ';
+    }
+
+    if (techL > 11) {
+      rtext += 'Ht - High Technology, ';
+    }
+
+    if (atmo < 2 && hydro > 0) {
+      rtext += 'Ic - Ice Capped, ';
+    }
+
+    if ((atmo < 3 || atmo === 4 || atmo === 7 || atmo === 9) && pop > 8) {
+      rtext += 'In - Industrial, ';
+    }
+
+    if (pop > 0 && pop < 4) {
+      rtext += 'Lo - Low Population, ';
+    }
+
+    if (techL < 6) {
+      rtext += 'Lt - Low Technology, ';
+    }
+
+    if (atmo < 4 && hydro < 4 && pop > 5) {
+      rtext += 'Na - Non Agricultural, ';
+    }
+
+    if (pop > 3 && pop < 7) {
+      rtext += 'Ni - Non Industrial, ';
+    }
+
+    if (atmo > 1 && atmo < 6 && hydro < 4) {
+      rtext += 'Po - Poor, ';
+    }
+
+    if ((atmo === 6 || atmo === 8) && pop > 5 && pop < 9) {
+      rtext += 'Ri - Rich, ';
+    }
+
+    if (hydro === 10) {
+      rtext += 'Wa - Water World, ';
+    }
+
+    if (atmo === 0) {
+      rtext += 'Va - Vacuum, ';
+    }
+    
     // Get rid of extra coma and space
     if (rtext.length > 0) {
       rtext = rtext.slice(0, -2);


### PR DESCRIPTION
File was missing some lines

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix of the old version of the UWP translator macro - some of the trade code function was cut out.


* **What is the current behavior?** (You can also link to an open issue here)
Missing many trade codes


* **What is the new behavior (if this is a feature change)?**
Now does the full CL trade codes - restores full function


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
