### PR TITLE
fix: damage formulas do not calculate attributes correctly

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -174,7 +174,7 @@ export default class TwodsixItem extends Item {
     }
 
     const damageFormula = this.data.data.damage + (bonusDamage ? "+" + bonusDamage : "");
-    const damageRoll = new Roll(damageFormula, {});
+    const damageRoll = Roll.create(damageFormula, this.actor.data.data);
     // @ts-ignore
     const damage:Roll = await damageRoll.evaluate({async: true}); // async: true will be default in foundry 0.10
     if (showInChat) {


### PR DESCRIPTION
Changing roll formula so that @attr are calculated correctly.

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a bug where attributes in damage roll formulas are not calculated correctly.  For example, an unarmed attack in CL should have the damage formula: max(@characteristics.strength.mod, 1).  However, the strength mod was always 0 because there was no actor reference.


* **What is the current behavior?** (You can also link to an open issue here)

Attributes in damage rolls are not included correctly.

* **What is the new behavior (if this is a feature change)?**

Should work now.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
