### PR TITLE
Fix item drop

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -11,7 +11,7 @@ export default class TwodsixItem extends Item {
   public static async create(data:Record<string, unknown>, options?:Record<string, unknown>):Promise<Entity> {
     const item = await super.create(data, options) as TwodsixItem;
     item.setFlag('twodsix', 'newItem', true);
-    if (item.data.type ==='weapon' && (item.data.img === "" || item.data.img === "icons/svg/item-bag.svg")) {
+    if (item.data.type ==='weapon' && (item.data.img === "" || item.data.img === foundry.data.ItemData.DEFAULT_ICON)) {
       await item.update({'img': 'systems/twodsix/assets/icons/default_weapon.png'});
     }
     return item;

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -11,7 +11,7 @@ export default class TwodsixItem extends Item {
   public static async create(data:Record<string, unknown>, options?:Record<string, unknown>):Promise<Entity> {
     const item = await super.create(data, options) as TwodsixItem;
     item.setFlag('twodsix', 'newItem', true);
-    if (item.data.type ==='weapon') {
+    if (item.data.type ==='weapon' && (item.data.img === "" || item.data.img === "icons/svg/item-bag.svg")) {
       await item.update({'img': 'systems/twodsix/assets/icons/default_weapon.png'});
     }
     return item;

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -215,9 +215,11 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
 
       //Remove any attached consumables
       // @ts-ignore
-      if(itemData.data.consumables.length > 0) {
-        // @ts-ignore
-        itemData.data.consumables = [];
+      if(itemData.data.consumables !== undefined) {
+        if(itemData.data.consumables.length > 0) {
+          // @ts-ignore
+          itemData.data.consumables = [];
+        }
       }
       
       // Create the owned item (TODO Add to type and remove the two lines below...)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes two bugs introduced in last update related to item drops.
1) Tools items could not be dropped onto character sheet because they did not have attached consumables.
2) The default icon overwrote and custom icon on weapon drop


* **What is the current behavior?** (You can also link to an open issue here)
1) Tools now can be dropped onto sheet and code checks to see whether data.consumables exists first.
2) Weapons drops now respect a custom icon


* **What is the new behavior (if this is a feature change)?**
None


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
