### PR TITLE
fix: Fix trade codes error

### DIFF
--- a/user_macros/Trade Goods Generator/Generate Trade Table v0_8.js
+++ b/user_macros/Trade Goods Generator/Generate Trade Table v0_8.js
@@ -374,6 +374,6 @@ function hexToBase10 (value) {
     case 'G':
       return ('16');
     default:
-      return (value);
+      return (Number(value));
   }
 }

--- a/user_macros/Trade Goods Generator/Generate Trade Table v6.js
+++ b/user_macros/Trade Goods Generator/Generate Trade Table v6.js
@@ -388,6 +388,6 @@ function hexToBase10(value) {
   case 'G':
     return ('16');
   default:
-    return (value);
+    return (Number(value));
   }
 }

--- a/user_macros/UWP Translator/UPP Translator v0_8.js
+++ b/user_macros/UWP Translator/UPP Translator v0_8.js
@@ -71,7 +71,7 @@ function parseCode (profile) {
 
 // Lookup a hex digit from a roll table
 function getUWPparameter (value, tableName) {
-  let item = Number(hexToBase10(value));
+  let item = hexToBase10(value);
   const table = game.tables.contents.find(t => t.name === tableName);
   if (item < table.data.results.size) {
     let details = table.data.results._source[item].text;
@@ -99,7 +99,7 @@ function hexToBase10 (value) {
     case 'G':
       return ('16');
     default:
-      return (value);
+      return (Number(value));
   }
 }
 

--- a/user_macros/UWP Translator/UWP Translator.js
+++ b/user_macros/UWP Translator/UWP Translator.js
@@ -97,7 +97,7 @@ function hexToBase10(value) {
   case 'G':
     return ('16');
   default:
-    return (value);
+    return (Number(value));
   }
 }
 


### PR DESCRIPTION
Convert text values to numbers

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bug fix: trade codes were not generated completely due to tex/number conversion problem

* **What is the current behavior?** (You can also link to an open issue here)

Trade codes incomplete

* **What is the new behavior (if this is a feature change)?**
Trade codes now generated correctly


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
