### PR TITLE
Fix:  for game.combats.active

### DIFF
--- a/user_macros/Update Initiative/UpdateInitiative v0_8.js
+++ b/user_macros/Update Initiative/UpdateInitiative v0_8.js
@@ -4,13 +4,13 @@
 // version for FVTT v0.8
 
 async function adjustInitiative () {
-  const fighters = await game.combats.active.data.combatants;
+  const fighters = await game.combat.data.combatants;
   for (const comb of fighters) {
     const tacSkill =
           await comb.actor.data.items.find(item => item.name === 'Tactics');
     if (tacSkill != null && comb.initiative != null) {
       const tacValue = tacSkill.data.data.value + comb.initiative;
-      await game.combats.active.setInitiative(comb.id, tacValue);
+      await game.combat.setInitiative(comb.id, tacValue);
     }
   }
 }


### PR DESCRIPTION
Data for game.combats.active not stable.  Use game.combat instead.  Fix per @ForjaSalvaje.

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix for initiative macro.  Data for game.combats.active not reliable.


* **What is the current behavior?** (You can also link to an open issue here)

Initiative macro does not work.

* **What is the new behavior (if this is a feature change)?**

Reliably adds tactics skill to macro roll.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
