### PR TITLE
fix: Inability to delete consumable

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -46,7 +46,7 @@ export default class TwodsixItem extends Item {
           await this.update({"data.consumables": this.data.data.consumables.concat(consumableId)}, {});
        }
     } else {
-      console.error(`Twodsix | Consumable can't be added to item ${this.id}`);
+      ui.notifications.error(`Twodsix | Consumable can't be added to item ${this.id}`);
     }
   }
 

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -39,11 +39,15 @@ export default class TwodsixItem extends Item {
   }
 
   public async addConsumable(consumableId:string):Promise<void> {
-    if (this.data.data.consumables.includes(consumableId)) {
-      console.error(`Twodsix | Consumable already exists for item ${this.id}`);
-      return;
+    if (this.data.data.consumables != undefined) {
+       if (this.data.data.consumables.includes(consumableId)) {
+         console.error(`Twodsix | Consumable already exists for item ${this.id}`);
+       } else {
+          await this.update({"data.consumables": this.data.data.consumables.concat(consumableId)}, {});
+       }
+    } else {
+      console.error(`Twodsix | Consumable can't be added to item ${this.id}`);
     }
-    await this.update({"data.consumables": this.data.data.consumables.concat(consumableId)}, {});
   }
 
   public async removeConsumable(consumableId: string):Promise<void> {

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -47,8 +47,10 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
           if (ownedItem.type === "consumable") {
             let tempItems = this.actor.items.filter(i => i.type !== "skills");
             tempItems.forEach( i => {
-              if (i.data.data.consumables.includes(ownedItem.id)  || i.data.data.useConsumableForAttack === ownedItem.id) {
-                 i.removeConsumable(ownedItem.id);
+              if (i.data.data.consumables != undefined) {
+                 if (i.data.data.consumables.includes(ownedItem.id)  || i.data.data.useConsumableForAttack === ownedItem.id) {
+                    i.removeConsumable(ownedItem.id);
+                 }
               }
             });
           }

--- a/static/template.json
+++ b/static/template.json
@@ -308,6 +308,11 @@
       "type": "equipment",
       "location": ["inventory", "storage"]
     },
+    "tool": {
+      "templates": ["gearTemplate"],
+      "type": "equipment",
+      "location": ["inventory", "storage"]
+    },
     "weapon": {
       "templates": ["gearTemplate"],
       "range": 0,


### PR DESCRIPTION
Error caused by item not having a consumables array - check for existence first.

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix...when trying to delete consumables, the check for attached consumables always assumed that the consumables array existed.  Now code checks that it exists. Bug found by Tremandur.


* **What is the current behavior?** (You can also link to an open issue here)
Can't delete a consumable from consumables tab.


* **What is the new behavior (if this is a feature change)?**
Consumables can be deleted.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
