### PR TITLE
fix: add setting to set new actor prototype icons to FVTT system default

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -53,15 +53,18 @@ export default class TwodsixActor extends Actor {
         await this.createUntrainedSkill();
         await this.update({
           'img': 'systems/twodsix/assets/icons/default_actor.png',
-          'token.img': 'systems/twodsix/assets/icons/default_actor.png'
         });
         break;
       case "ship":
         await this.update({
           'img': 'systems/twodsix/assets/icons/default_ship.png',
-          'token.img': 'systems/twodsix/assets/icons/default_ship.png'
         });
         break;
+    }
+    if(game.settings.get("twodsix", "useSystemDefaultTokenIcon")) {
+      await this.update({
+        'token.img': CONST.DEFAULT_TOKEN //'icons/svg/mystery-man.svg'
+      });
     }
   }
 

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -48,6 +48,7 @@ export const registerSettings = function ():void {
   _booleanSetting('invertSkillRollShiftClick', false);
   _booleanSetting('lifebloodInsteadOfCharacteristics', false);
   _booleanSetting('showContaminationBelowLifeblood', true);
+  _booleanSetting('useSystemDefaultTokenIcon', false);
 
   //As yet unused
   _numberSetting('maxSkillLevel', 9);

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -357,6 +357,10 @@
       "showContaminationBelowLifeblood": {
         "hint": "Show Contamination below Lifeblood. Only useful along with the 'show END and lifeblood' setting.",
         "name": "Show Contamination below Lifeblood. "
+      },
+      "useSystemDefaultTokenIcon": {
+        "hint": "Use system default token icon (mystery man) when creating new actor.  Check when using custom images so system automatically sets token image to the actor image.",
+        "name": "Use the system default token icon for new actors."
       }
     },
     "CloseAndCreateNew": "Close and create new",


### PR DESCRIPTION
This change allows syncing of actor image and token icon the first time the actor image is changed (as is the standard FVTT behavior).

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a Twodsix system setting so that users can choose to use FVTT default icon for prototype tokens rather than the Twodsix specific icons.  This allows the token icon to be automatically updated when selecting a new actor image.


* **What is the current behavior?** (You can also link to an open issue here)
Prototype tokens are set to Twodsix specific icons.  Changing the actor image also requires one to change the token image as a separate step - rather than the expected behavior of both changing on first update.


* **What is the new behavior (if this is a feature change)?**
New Twodsix option allows users to choose which behavior is desired.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No - but it does create two new translation entities.

* **Other information**:
