### PR TITLE
WIP fix: add ability to quick add weapon consumable on actor-items tab

### DIFF
--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -81,6 +81,8 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
 
     html.find(".adjust-consumable").on("click", this._onAdjustConsumableCount.bind(this));
     html.find(".refill-button").on("click", this._onRefillConsumable.bind(this));
+
+    html.find(".item-fill-consumable").on("click", this._onAutoAddConsumable.bind(this));
   }
 
 
@@ -220,6 +222,33 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
       } else {
         throw err;
       }
+    }
+  }
+
+  /**
+   * Handle auto add of weapons consumables.
+   * @param {Event} event   The originating click event
+   * @private
+   */
+  private async _onAutoAddConsumable(event: Event): Promise<void> {
+    const li = $(event.currentTarget).parents(".item");
+    const weaponSelected = this.actor.items.get(li.data("itemId"));
+
+    const max = weaponSelected.data.data.ammo;
+    if (max > 0 && weaponSelected.data.data.consumables.length === 0) {
+      const data = {
+        name: "Magazine for " + weaponSelected.data.name,
+        type: "consumable",
+        data: {
+          subtype: "other",
+          quantity: 1,
+          currentCount: max,
+          max
+        }
+      };
+      const newConsumable = await weaponSelected.actor.createEmbeddedDocuments("Item", [data]);
+      await weaponSelected.addConsumable(newConsumable[0].id);
+      await weaponSelected.update({ "data.useConsumableForAttack": newConsumable[0].id });
     }
   }
 }

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -614,7 +614,7 @@ a.notes-tab.active {
 
 .items-weapons {
   display: grid;
-  grid-template-columns: 1em 14em 1.5em 1.5em 3.5em 3em 5em 3em;
+  grid-template-columns: 1em 14em 1.5em 1.5em 2.5em 3em 5em 4em;
   gap: 1px 1px;
   grid-template-areas: '. . . . .';
 }

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -32,6 +32,7 @@
             {{/if}}
             <span class="item-name centre roll-damage">{{twodsix_limitLength item.data.data.damage 8}}</span>
             <span class="item-controls centre">
+              <a class="item-control item-fill-consumable" title='{{localize "TWODSIX.Actor.Items.Refill"}}'><i class="fas fa-battery-full"></i></a>
               <a class="item-control item-edit" title='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fas fa-edit"></i></a>
               <a class="item-control item-delete" title='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fas fa-trash"></i></a>
             </span>


### PR DESCRIPTION
Creates an auto fill icon to create a linked consumable to a weapon.  Note that it only works when:
1) The weapon has no attached consumables
2) weapon's ammo property >0 (e.g. it isn't a melee weapon).

* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This adds an icon on the items-weapons tab (battery symbol) to auto fill a weapon consumable.  Suggested by @Orion on Discord


* **What is the current behavior?** (You can also link to an open issue here)
Must edit the weapon to add consumables


* **What is the new behavior (if this is a feature change)?**
New icon adds an attached weapons consumable only when:
1) there are no consumables attached
2) ammo property of the weapon is >0 (e.g. it is not a melee weapon)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
