### PR TITLE
fix: correct setting unskilled for non-traveller actors that store weapons

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -168,7 +168,7 @@ export default class TwodsixActor extends Actor {
 
   public static setUntrainedSkillForWeapons():void {
     TwodsixActor._applyToAllActorItems((actor:TwodsixActor, item:TwodsixItem) => {
-      if (item.type === "weapon" && !item.data.data.skill) {
+      if (item.type === "weapon" && !item.data.data.skill && actor.type === "traveller") {
         item.update({"data.skill": actor.getUntrainedSkill().id}, {});
       }
     });


### PR DESCRIPTION
Error happens when a ship actor has a weapon in cargo.  Only fix traveller actors.

* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
