### PR TITLE
WIP fix: Allow non storage items to be seen in ship's locker

### DIFF
--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -260,12 +260,15 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
         case 'tool':
         case 'junk':
           equipment.push(item);
+          storage.push(item);
           break;
         case 'weapon':
           weapon.push(item);
+          storage.push(item);
           break;
         case 'armor':
           armor.push(item);
+          storage.push(item);
           break;
         case 'augment':
           augment.push(item);
@@ -278,6 +281,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
           break;
         case 'consumable':
           consumable.push(item);
+          storage.push(item);
           break;
         default:
           break;


### PR DESCRIPTION
Currently, any physical item that is dragged onto ship sheet is hidden (current only allows "storage" type items).  This fix adds weapons, armor, equipment, and consumables to the storage container so that they can be see in ship's locker.

* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: Currently, any physical item that is dragged onto ship sheet is hidden (current only allows "storage" type items).  This fix adds weapons, armor, equipment, and consumables to the storage container so that they can be see in ship's locker.


* **What is the current behavior?** (You can also link to an open issue here)
Can't see non-storage item types in ship's locker


* **What is the new behavior (if this is a feature change)?**
All "physical" items can be listed


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
A bit inelegant in that items are double listed.