### PR TITLE
WIP fix: allow JOAT to work with rolls

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -55,15 +55,22 @@ export default function registerHandlebarsHelpers():void {
   Handlebars.registerHelper('twodsix_skillTotal', (actor, characteristic, value) => {
     const actorData = actor.data;
     const characteristicElement = actorData.characteristics[getKeyByValue(TWODSIX.CHARACTERISTICS, characteristic)];
+    let adjValue = value;
+
+    /* only modify if hideUntrained is false and skill value is untrained (-3) */
+    if (value === game.system.template.Item.skills.value && !game.settings.get("twodsix", "hideUntrainedSkills")) {
+      adjValue = actor.items.find((i) =>  i._id === actorData.untrainedSkill).data.value;
+    }
+
     if (characteristicElement) {
       if (!characteristicElement.current) {
         characteristicElement.current = characteristicElement.value - characteristicElement.damage;
       }
 
       const mod = calcModFor(characteristicElement.current);
-      return Number(value) + mod;
+      return Number(adjValue) + mod;
     } else {
-      return value;
+      return adjValue;
     }
   });
 

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -47,7 +47,13 @@ export class TwodsixDiceRoll {
     // Add skill modifier
     if (this.skill) {
       formula += "+ @skill";
-      data["skill"] = this.skill.data.data.value;
+      /*Check for "Untrained" value and use if better to account for JOAT*/
+      const joat = this.actor.getUntrainedSkill().data.data.value;
+      if (joat > this.skill.data.data.value) {
+        data["skill"] = joat;
+      } else {
+        data["skill"] = this.skill.data.data.value;
+      }
     }
 
     // Add dice modifier


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This allows for rolls (skill and attack) to reflect the the JOT value on top of actor sheet.


* **What is the current behavior?** (You can also link to an open issue here)
Rolls for untrained skills don't reflect JOAT value


* **What is the new behavior (if this is a feature change)?**
Account for JOAT in rolls.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Does not address the value of the actual skill item corresponding to Jack of all Trades.  It works from the actor sheet field.