### PR TITLE
Allow damage actor code to work with lifeblood and stamina

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -44,11 +44,6 @@ export default class TwodsixActor extends Actor {
     for (const cha of Object.values(data.characteristics as Record<any, any>)) {
       cha.current = cha.value - cha.damage;
       cha.mod = calcModFor(cha.current);
-
-      //Check to see if inputCurrent is defined and synced
-      if (cha.inputCurrent === undefined || cha.inputCurrent === "") {
-        cha.inputCurrent = cha.current;
-      }
     }
   }
 

--- a/src/module/hooks/updateHits.ts
+++ b/src/module/hooks/updateHits.ts
@@ -7,6 +7,8 @@ function getCurrentHits(...args: Record<string, any>[]) {
 
   if (game.settings.get("twodsix", "showLifebloodStamina")) {
     hitsCharacteristics = ["stamina", "lifeblood"];
+  } else if (game.settings.get("twodsix", "lifebloodInsteadOfCharacteristics")) {
+    hitsCharacteristics = ["endurance", "strength"];
   } else {
     hitsCharacteristics = ["endurance", "strength", "dexterity"];
   }

--- a/src/module/hooks/updateHits.ts
+++ b/src/module/hooks/updateHits.ts
@@ -3,7 +3,13 @@ import { mergeDeep } from "../utils/utils";
 
 function getCurrentHits(...args: Record<string, any>[]) {
   const characteristics = mergeDeep({}, ...args);
-  const hitsCharacteristics = ["strength", "dexterity", "endurance"];
+  let hitsCharacteristics: string[] = [];
+
+  if (game.settings.get("twodsix", "showLifebloodStamina")) {
+    hitsCharacteristics = ["stamina", "lifeblood"];
+  } else {
+    hitsCharacteristics = ["endurance", "strength", "dexterity"];
+  }
 
   return Object.entries(characteristics).reduce((hits, [key, chr]) => {
     if (hitsCharacteristics.includes(key)) {

--- a/src/module/utils/actorDamage.ts
+++ b/src/module/utils/actorDamage.ts
@@ -43,6 +43,7 @@ export class Stats {
   actor: TwodsixActor;
   damageCharacteristics: string[] = [];
   useLifebloodStamina = false;
+  useLifebloodEndurance = false;
 
   constructor(actor: TwodsixActor, damage:number) {
     this.strength = new Attribute("strength", actor);
@@ -57,7 +58,11 @@ export class Stats {
     if (game.settings.get("twodsix", "showLifebloodStamina")) {
       this.damageCharacteristics = ["stamina", "lifeblood"];
       this.useLifebloodStamina = true;
-    } else {
+    } else if (game.settings.get("twodsix", "lifebloodInsteadOfCharacteristics")) {
+      this.damageCharacteristics = ["endurance", "strength"];
+      this.useLifebloodEndurance = true;
+    }
+    else {
       this.damageCharacteristics = ["endurance", "strength", "dexterity"];
     }
 

--- a/src/module/utils/actorDamage.ts
+++ b/src/module/utils/actorDamage.ts
@@ -205,7 +205,7 @@ class DamageDialogHandler {
       if (!this.stats.edited) {
         chrHtml.find(`.damage-input`).val(stat.damage);
       }
-      console.log(this.stats.damageCharacteristics[0]);
+      
       if (characteristic === this.stats.damageCharacteristics[0] && stat.current() !== 0 && this.stats.currentDamage() - stat.damage > 0) {
         if (!chrHtml.find(`.damage-input`).hasClass("orange-border")) {
           chrHtml.find(`.damage-input`).addClass("orange-border");

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -40,7 +40,9 @@
         "INT": "INT",
         "PSI": "PSI",
         "SOC": "SOC",
-        "STR": "STR"
+        "STR": "STR",
+        "LFB": "LFB",
+        "STA": "STA"
       },
       "DeleteOwnedItem": "Delete owned item",
       "Finances": {
@@ -185,7 +187,9 @@
         "PSI": "PSI",
         "SOC": "SOC",
         "STR": "STR",
-        "SkillName": "Skill Name"
+        "SkillName": "Skill Name",
+        "LFB": "LFB",
+        "STA": "STA"
       },
       "Traits": {
               "Prerequisite": "Prerequisite",
@@ -414,7 +418,7 @@
       "AutoDamageForMultipleTargetsNotImplemented": "Automatically damaging multiple targets (using Auto X) is currently not supported",
       "MaxStatVal": "The value exceededs the maximum stat value",
       "StatValBelowZero": "The value cannot be below zero",
-      "DecreaseEnduranceFirst": "Endurance should be decreased before other stats"
+      "DecreaseEnduranceFirst": "Endurance/Stamina should be decreased before other stats"
     }
   },
   "VeryDifficult": "Very Difficult"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -375,8 +375,8 @@
         "name": "Use the system default token icon for new actors."
       },
       "showLifebloodStamina": {
-        "hint": "Show Lifeblood and Stamina characteristics on actor sheet.  Useful for Cepheus Deluxe.",
-        "name": "Show Lifeblood and Stamina characteristics."
+        "hint": "Show Lifeblood and Stamina characteristics on actor sheet.  Damage will be applied to these characteristics.  Useful for Cepheus Deluxe.",
+        "name": "Show Lifeblood and Stamina characteristics and use for damage."
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -388,6 +388,7 @@ img.character-info-mask {
   width: 2.2em;
   border: none;
   text-align: left;
+  color:#b52c2c !important;
 }
 
 span.bgi-age {

--- a/static/template.json
+++ b/static/template.json
@@ -97,7 +97,6 @@
         "stamina": {
           "key": "stamina",
           "value": 7,
-          "inputCurrent": 7,
           "damage": 0,
           "label": "Stamina",
           "shortLabel": "STA"
@@ -105,7 +104,6 @@
         "lifeblood": {
           "key": "lifeblood",
           "value": 14,
-          "inputCurrent": 14,
           "damage": 0,
           "label": "Lifeblood",
           "shortLabel": "LFB"

--- a/static/templates/actors/actor-sheet.html
+++ b/static/templates/actors/actor-sheet.html
@@ -32,14 +32,17 @@
           <span class="bgi-gender"><i class="fas fa-venus-mars"></i>:<input name="data.gender" type="text" value="{{data.gender}}"
               placeholder='{{localize "TWODSIX.Actor.Gender"}}' onClick="this.select();"
               title='{{localize "TWODSIX.Actor.Gender"}}' /></span>
+          
           <span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Stamina"}}'><i class="fas fa-battery-half"></i>:<input
-              type="number" name="data.characteristics.stamina.inputCurrent" value="{{data.characteristics.stamina.inputCurrent}}"/> /</span>
-          <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.Stamina"}}'><input type="number"
-              name="data.characteristics.stamina.value" value="{{data.characteristics.stamina.value}}" /> </span>
+                type="number" name="data.characteristics.stamina.value" value="{{data.characteristics.stamina.value}}"/>-</span>
+          <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.Stamina"}}'><input type="number" 
+                name="data.characteristics.stamina.damage" value="{{data.characteristics.stamina.damage}}"/> </span>
+            
           <span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Lifeblood"}}'><i class="fas fa-heartbeat"></i>: <input
-              type="number" name="data.characteristics.lifeblood.inputCurrent" value="{{data.characteristics.lifeblood.inputCurrent}}"/> /</span>
+                type="number" name="data.characteristics.lifeblood.value" value="{{data.characteristics.lifeblood.value}}"/>-</span>
           <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.Lifeblood"}}'><input type="number"
-              name="data.characteristics.lifeblood.value" value="{{data.characteristics.lifeblood.value}}" /> </span>
+                name="data.characteristics.lifeblood.damage" value="{{data.characteristics.lifeblood.damage}}"/> </span>
+          
           <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.RadiationExposure"}}'><i class="fas fa-radiation"></i>:
             <input name="data.radiationDose.value" value={{data.radiationDose.value}} type="text" /></span>
           {{else}}

--- a/static/templates/actors/actor-sheet.html
+++ b/static/templates/actors/actor-sheet.html
@@ -34,7 +34,7 @@
               title='{{localize "TWODSIX.Actor.Gender"}}' /></span>
           
           <span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Stamina"}}'>
-            {{#if data.characteristics.stamina.current}} <i class="fas fa-battery-half"></i>{{else}}<i class="fas fa-battery-empty" style="color:brown;"></i> {{/if}}:
+            {{#iff data.characteristics.stamina.value ">" data.characteristics.stamina.damage}} <i class="fas fa-battery-half"></i> {{else}} <i class="fas fa-battery-empty" style="color:brown;"></i> {{/iff}}:
             <input type="number" name="data.characteristics.stamina.value" value="{{data.characteristics.stamina.value}}"/>-</span>
           <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.Stamina"}}'><input type="number" 
                 name="data.characteristics.stamina.damage" value="{{data.characteristics.stamina.damage}}"/> </span>

--- a/static/templates/actors/actor-sheet.html
+++ b/static/templates/actors/actor-sheet.html
@@ -33,8 +33,9 @@
               placeholder='{{localize "TWODSIX.Actor.Gender"}}' onClick="this.select();"
               title='{{localize "TWODSIX.Actor.Gender"}}' /></span>
           
-          <span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Stamina"}}'><i class="fas fa-battery-half"></i>:<input
-                type="number" name="data.characteristics.stamina.value" value="{{data.characteristics.stamina.value}}"/>-</span>
+          <span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Stamina"}}'>
+            {{#if data.characteristics.stamina.current}} <i class="fas fa-battery-half"></i>{{else}}<i class="fas fa-battery-empty" style="color:brown;"></i> {{/if}}:
+            <input type="number" name="data.characteristics.stamina.value" value="{{data.characteristics.stamina.value}}"/>-</span>
           <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.Stamina"}}'><input type="number" 
                 name="data.characteristics.stamina.damage" value="{{data.characteristics.stamina.damage}}"/> </span>
             

--- a/static/templates/actors/damage-dialog.html
+++ b/static/templates/actors/damage-dialog.html
@@ -46,12 +46,17 @@
         </tr>
       {{else}}
         <tr class="strength">
-          <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.STR"}}</td>
+          {{#if useLifebloodEndurance}}
+            <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.LFB"}}</td>
+          {{else}}
+            <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.STR"}}</td>
+          {{/if}}
           <td class="original-value">{{originalCharacteristics.strength.value}}</td>
           <td><span class="original-current">{{originalCharacteristics.strength.current}}</span> <span class="current-mod"></span></td>
           <td><input class="damage-input" data-stat="strength" type="number" value="{{strength.damage}}"></td>
           <td><span class="result-value"></span> <span class="mod"></span></td>
         </tr>
+        {{#unless useLifebloodEndurance}}
         <tr class="dexterity">
           <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.DEX"}}</td>
           <td class="original-value">{{originalCharacteristics.dexterity.value}}</td>
@@ -59,6 +64,7 @@
           <td><input class="damage-input" data-stat="dexterity" type="number" value="{{dexterity.damage}}"></td>
           <td><span class="result-value"></span> <span class="mod"></span></td>
         </tr>
+        {{/unless}}
         <tr class="endurance">
           <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.END"}}</td>
           <td class="original-value">{{originalCharacteristics.endurance.value}}</td>

--- a/static/templates/actors/damage-dialog.html
+++ b/static/templates/actors/damage-dialog.html
@@ -29,27 +29,44 @@
       </tr>
     </thead>
     <tbody>
-      <tr class="strength">
-        <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.STR"}}</td>
-        <td class="original-value">{{originalCharacteristics.strength.value}}</td>
-        <td><span class="original-current">{{originalCharacteristics.strength.current}}</span> <span class="current-mod"></span></td>
-        <td><input class="damage-input" data-stat="strength" type="number" value="{{strength}}"></td>
-        <td><span class="result-value"></span> <span class="mod"></span></td>
-      </tr>
-      <tr class="dexterity">
-        <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.DEX"}}</td>
-        <td class="original-value">{{originalCharacteristics.dexterity.value}}</td>
-        <td><span class="original-current">{{originalCharacteristics.dexterity.current}}</span> <span class="current-mod"></span></td>
-        <td><input class="damage-input" data-stat="dexterity" type="number" value="{{dexterity}}"></td>
-        <td><span class="result-value"></span> <span class="mod"></span></td>
-      </tr>
-      <tr class="endurance">
-        <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.END"}}</td>
-        <td class="original-value">{{originalCharacteristics.endurance.value}}</td>
-        <td><span class="original-current">{{originalCharacteristics.endurance.current}}</span> <span class="current-mod"></span></td>
-        <td><input class="damage-input" data-stat="endurance" type="number" value="{{endurance}}"></td>
-        <td><span class="result-value"></span> <span class="mod"></span></td>
-      </tr>
+      {{#if useLifebloodStamina}}
+        <tr class="stamina">
+          <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.STA"}}</td>
+          <td class="original-value">{{originalCharacteristics.stamina.value}}</td>
+          <td><span class="original-current">{{originalCharacteristics.stamina.current}}</span> <span class="current-mod"></span></td>
+          <td><input class="damage-input" data-stat="stamina" type="number" value="{{stamina.damage}}"></td>
+          <td><span class="result-value"></span> <span class="mod"></span></td>
+        </tr>
+        <tr class="lifeblood">
+          <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.LFB"}}</td>
+          <td class="original-value">{{originalCharacteristics.lifeblood.value}}</td>
+          <td><span class="original-current">{{originalCharacteristics.lifeblood.current}}</span> <span class="current-mod"></span></td>
+          <td><input class="damage-input" data-stat="lifeblood" type="number" value="{{lifeblood.damage}}"></td>
+          <td><span class="result-value"></span> <span class="mod"></span></td>
+        </tr>
+      {{else}}
+        <tr class="strength">
+          <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.STR"}}</td>
+          <td class="original-value">{{originalCharacteristics.strength.value}}</td>
+          <td><span class="original-current">{{originalCharacteristics.strength.current}}</span> <span class="current-mod"></span></td>
+          <td><input class="damage-input" data-stat="strength" type="number" value="{{strength.damage}}"></td>
+          <td><span class="result-value"></span> <span class="mod"></span></td>
+        </tr>
+        <tr class="dexterity">
+          <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.DEX"}}</td>
+          <td class="original-value">{{originalCharacteristics.dexterity.value}}</td>
+          <td><span class="original-current">{{originalCharacteristics.dexterity.current}}</span> <span class="current-mod"></span></td>
+          <td><input class="damage-input" data-stat="dexterity" type="number" value="{{dexterity.damage}}"></td>
+          <td><span class="result-value"></span> <span class="mod"></span></td>
+        </tr>
+        <tr class="endurance">
+          <td class="attribute-name-column">{{localize "TWODSIX.Items.Skills.END"}}</td>
+          <td class="original-value">{{originalCharacteristics.endurance.value}}</td>
+          <td><span class="original-current">{{originalCharacteristics.endurance.current}}</span> <span class="current-mod"></span></td>
+          <td><input class="damage-input" data-stat="endurance" type="number" value="{{endurance.damage}}"></td>
+          <td><span class="result-value"></span> <span class="mod"></span></td>
+        </tr>
+      {{/if}}
     </tbody>
   </table>
   


### PR DESCRIPTION
Adapt code and character sheet to allow damage to work with lifeblood and stamina stats rather than other characteristics

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)
add: ability to use damage code with lifeblood and stamina
fix: when using strength for lifeblood, damage and damage dialogs now display consistently.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature change
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
fields are manual
current damage dialog does not adapt to changes in characteristics.

* **What is the new behavior (if this is a feature change)?**
damage object works as with regular stats


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, other than a now unused data element for Lifeblood and Stamina is deleted from template (inputCurrent). Also, their display works like the other characteristics - the "value" and "damage" are shown on the sheet (but no mod as it is not applicable).  It will mean that damage using these attributes will be reset to zero for any existing characters using these characteristics for damage.  It doesn't seem worth a migration.


* **Other information**:
Actor sheet display for stamina and lifeblood changes a bit.  Now it is similar to other stats.  First field is the value (w/o damage).  The second field (red) is the applied damage.