### PR TITLE
fix: clarify default token icon setting and move after other token se…

### DIFF
--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -5,6 +5,7 @@ export const registerSettings = function ():void {
 
   //Foundry default behaviour related settings
   _booleanSetting('defaultTokenSettings', true);
+  _booleanSetting('useSystemDefaultTokenIcon', false);
 
   const rulesetOptions = Object.entries(TWODSIX.RULESETS).map(([id, ruleset]) => {
     return [id, ruleset["name"]];
@@ -57,7 +58,6 @@ export const registerSettings = function ():void {
   _booleanSetting('invertSkillRollShiftClick', false);
   _booleanSetting('lifebloodInsteadOfCharacteristics', false);
   _booleanSetting('showContaminationBelowLifeblood', true);
-  _booleanSetting('useSystemDefaultTokenIcon', false);
   _booleanSetting('showLifebloodStamina', false);
 
   //As yet unused

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -371,8 +371,8 @@
         "name": "Show Contamination below Lifeblood. "
       },
       "useSystemDefaultTokenIcon": {
-        "hint": "Use system default token icon (mystery man) when creating new actor.  Check when using custom images so system automatically sets token image to the actor image.",
-        "name": "Use the system default token icon for new actors."
+        "hint": "Use Foundry VTT system default token icon (mystery man) instead of Twodsix default icon when creating new actor.  Check this setting when using custom images so that the system automatically sets token image to be the same as the actor image.",
+        "name": "Use Foundry VTT rather than Twodsix default token icon for new actors."
       },
       "showLifebloodStamina": {
         "hint": "Show Lifeblood and Stamina characteristics on actor sheet.  Damage will be applied to these characteristics.  Useful for Cepheus Deluxe.",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix: clarify default token option setting and move to after other token setting in configuration list.


* **What is the current behavior?** (You can also link to an open issue here)
Confusing wording and token settings appear in different locations.


* **What is the new behavior (if this is a feature change)?**
Reworded slightly and move the settings to be adjacent.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
