### PR TITLE
fix: Move JOAT line to inside skills list

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -132,6 +132,7 @@ export default class TwodsixActor extends Actor {
     const data = {
       "name": game.i18n.localize("TWODSIX.Actor.Skills.Untrained"),
       "type": "skills",
+      "data": {"characteristic": "NONE"},
       "flags": {'twodsix.untrainedSkill': true}
     };
 

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -18,7 +18,7 @@
 <div class="skill">
   <span class="item skill-container">
     <ol class="ol-no-indent">
-      <li class="item flexrow" data-item-id="{{joat-skill-input}}" style="margin-bottom: 0px;">
+      <li class="item flexrow" data-item-id="{{joat-skill-input}}" style="margin-bottom: 0.01px;">
         <span class="skill-container">
           <span></span>
           <span class="item-name" >{{localize "TWODSIX.Actor.Skills.JOAT"}}</span>

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -1,7 +1,4 @@
 <div id="skill-top-row">
-  <div id="joat-skill">
-    {{localize "TWODSIX.Actor.Skills.JOAT"}}:<input type="number" value="{{jackOfAllTrades}}" id="joat-skill-input" maxlength="1">
-  </div>
   <a class="add-skill item-control item-create" title="Create item" data-type="skills">
     <span class="add-skill-txt">{{localize "TWODSIX.Actor.Skills.AddSkill"}}</span>
   </a>
@@ -15,6 +12,20 @@
     <span class="skill-mod centre">{{localize "TWODSIX.Actor.Skills.Modifier"}}</span>
     <span class="skill-total centre">{{localize "TWODSIX.Actor.Skills.Total"}}</span>
     <span class="skill-edit-remove centre">{{localize "TWODSIX.Actor.Skills.EditOrRemove"}}</span>
+  </span>
+</div>
+
+<div class="skill">
+  <span class="item skill-container">
+    <ol class="ol-no-indent">
+      <li class="item flexrow" data-item-id="{{joat-skill-input}}" style="margin-bottom: 0px;">
+        <span class="skill-container">
+          <span></span>
+          <span class="item-name" >{{localize "TWODSIX.Actor.Skills.JOAT"}}</span>
+          <input type="number" value="{{jackOfAllTrades}}" id="joat-skill-input" style="text-align: right; width: 4ch;"/>
+        </span>
+      </li>
+    </ol>
   </span>
 </div>
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Moves the JOAT skill value inside the skills list/


* **What is the current behavior?** (You can also link to an open issue here)
JOAT value is outside, on top of the list.  This location can be confusing.


* **What is the new behavior (if this is a feature change)?**

JOAT skill is first item in list.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
fixes another issue where "Untrained skill" defaults to "STR" modifier.