### PR TITLE
add: allow consumable quantities to be edited

### DIFF
--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -86,8 +86,8 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     html.find(".item-fill-consumable").on("click", this._onAutoAddConsumable.bind(this));
 
     //add hooks to allow skill levels to be updates on skill tab
-    html.find(".skill-level-edit").on("input", this._onSkillLevelEdit.bind(this));
-    html.find(".skill-level-edit").on("click", (event) => {
+    html.find(".item-value-edit").on("input", this._onItemValueEdit.bind(this));
+    html.find(".item-value-edit").on("click", (event) => {
       $(event.currentTarget).trigger("select");
     });
   }
@@ -260,14 +260,19 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
   }
 
   /**
-   * Update skill level when edited on skill tab.
-   * @param {Event} event   The originating input event
+   * Update an item value when edited on skill or inventory tab.
+   * @param {Event} event  The originating input event
    * @private
    */
-  private async _onSkillLevelEdit(event:Event): Promise<void> {
+  private async _onItemValueEdit(event:Event): Promise<void> {
     const newValue = parseInt(event.currentTarget["value"], 10);
     const li = $(event.currentTarget).parents(".item");
     const itemSelected = this.actor.items.get(li.data("itemId"));
-    itemSelected.update({'data.value': newValue});
+    
+    if (itemSelected.type === "skills") {
+      itemSelected.update({ "data.value": newValue });
+    } else if (itemSelected.type === "consumable") {
+      itemSelected.update({ "data.quantity": newValue });
+    }
   }
 }

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -85,7 +85,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
 
     html.find(".item-fill-consumable").on("click", this._onAutoAddConsumable.bind(this));
 
-    //add hooks to allow skill levels to be updates on skill tab
+    //add hooks to allow skill levels consumable counts to be updated on skill and equipment tabs, repectively
     html.find(".item-value-edit").on("input", this._onItemValueEdit.bind(this));
     html.find(".item-value-edit").on("click", (event) => {
       $(event.currentTarget).trigger("select");

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -755,7 +755,7 @@ a:hover, a.active {
   width: 2em;
 }
 
-input.skill-level-edit {
+input.item-value-edit {
   padding: initial;
   text-align: right;
   height: auto;

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -206,7 +206,7 @@
             </span>
             <span class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
             <span class="item-name centre">{{twodsix_localizeConsumable item.data.data.subtype}}</span>
-            <span class="item-name centre">{{item.data.data.quantity}}</span>
+            <input class= "item-value-edit" type="number" min="0" step="1" value="{{item.data.data.quantity}}"/>
             <span class="item-name centre">{{item.data.data.currentCount}}/{{item.data.data.max}}</span>
             <span class="item-controls centre">
               <a class="item-control item-edit" title='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fas fa-edit"></i></a>

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -32,7 +32,7 @@
                   <img class="rollable" data-label="{{item.name}}" title="{{twodsix_invertSkillRollShiftClick}}" src="./systems/twodsix/assets/d6-icon.svg" alt="d6"/>
                 </span>
                 <span class="item-name rollable" data-label="{{item.name}}" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
-                <input class= "skill-level-edit" type="number" value="{{item.data.data.value}}"/>
+                <input class= "item-value-edit" type="number" value="{{item.data.data.value}}"/>
                 <span class="item-name centre" for="skill-modifier">{{twodsix_skillCharacteristic ../actor item.data.data.characteristic}}</span>
                 <span class="total-output flex1 skill-mod">{{twodsix_skillTotal ../actor item.data.data.characteristic item.data.data.value}}</span>
                 <span class="item-controls centre">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the ability to edit consumable quantities directly on actor sheet.


* **What is the current behavior?** (You can also link to an open issue here)
Must click the edit button to edit value


* **What is the new behavior (if this is a feature change)?**
Edit right on the actor sheet.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
