### PR TITLE
add: add option to show ship component on single line

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -21,7 +21,11 @@ export default function registerHandlebarsHelpers():void {
   });
 
   Handlebars.registerHelper('twodsix_limitLength', function (a, b) {
-    return a.length > b ? '(...)' : a;
+    if (!a) {
+      return '';
+    } else {
+      return a.length > b ? '(...)' : a;
+    }
   });
 
   Handlebars.registerHelper('twodsix_skillCharacteristic', (actor, characteristic) => {

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -119,6 +119,51 @@ export default function registerHandlebarsHelpers():void {
     return skill != null && !skill.getFlag("twodsix", "untrainedSkill") && skill.type === "skills";
   });
 
+  Handlebars.registerHelper('twodsix_getComponentIcon', (componentType: string) => {
+    switch (componentType) {
+      case 'accomodations':
+        return "fas fa-bed";
+        break;
+      case 'armament':
+        return "fas fa-crosshairs";
+        break;
+      case 'armor':
+        return "fas fa-grip-vertical";
+        break;
+      case 'cargo':
+        return "fas fa-boxes";
+        break;
+      case 'computer':
+        return "fas fa-microchip";
+        break;
+      case 'drive':
+        return "fas fa-arrows-alt";
+        break;
+      case 'electronics':
+        return "fas fa-satellite-dish";
+        break;
+      case 'hull':
+        return "fas fa-rocket";
+        break;
+      case 'power':
+        return "fas fa-atom";
+        break;
+      case 'shield':
+        return "fas fa-shield-alt";
+        break;
+      case 'software':
+        return "fas fa-code";
+        break;
+      case 'vehicle':
+        return "fas fa-space-shuttle";
+        break;
+      default:
+        return "fas fa-question-circle";
+    }
+  });
+  
+  Handlebars.registerHelper("concat", (...args) => args.slice(0, args.length - 1).join(''));
+
   Handlebars.registerHelper('each_sort_by_name', (array, options) => {
     const sortedArray = array?.slice(0).sort((a:TwodsixItem, b:TwodsixItem) => {
       const aName = a.name.toLowerCase(), bName = b.name.toLowerCase();

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -60,6 +60,7 @@ export const registerSettings = function ():void {
   _booleanSetting('showContaminationBelowLifeblood', true);
   _booleanSetting('showLifebloodStamina', false);
   _booleanSetting('showHeroPoints', false);
+  _booleanSetting('showSingleComponentColumn', false);
 
   //As yet unused
   _numberSetting('maxSkillLevel', 9);

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -20,7 +20,11 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
       data.data.storage = data.actor.items;
       AbstractTwodsixActorSheet._prepareItemContainers(this.actor.items, data);
     }
-
+    
+    // Add relevant data from system settings
+    data.data.settings = {
+      showSingleComponentColumn: game.settings.get('twodsix', 'showSingleComponentColumn')
+    };
     return data;
   }
 

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -97,7 +97,8 @@ Hooks.once('init', async function () {
     "systems/twodsix/templates/actors/parts/ship/ship-crew.html",
     "systems/twodsix/templates/actors/parts/ship/ship-notes.html",
     "systems/twodsix/templates/actors/parts/ship/ship-storage.html",
-    "systems/twodsix/templates/actors/parts/ship/ship-components.html",
+    "systems/twodsix/templates/actors/parts/ship/ship-components-single.html",
+    "systems/twodsix/templates/actors/parts/ship/ship-components-double.html",
     //
     "systems/twodsix/templates/chat/damage-message.html",
     "systems/twodsix/templates/chat/throw-dialog.html",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -446,6 +446,10 @@
       "showHeroPoints": {
         "hint": "Show Hero Points counter on actor sheet.",
         "name": "Show Hero Points"
+      },
+      "showSingleComponentColumn": {
+        "hint": "Show the ship components list as a single row.",
+        "name": "Ship components listed as single row"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1339,7 +1339,7 @@ input.power-total {
 /*----------- Ship Tabs ----------*/
 
 .ship-tabs {
-  width: 398px;
+  width: 485px;
   display: block;
   margin-left: 20.5em;
   margin-top: -2.3em;

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1465,12 +1465,22 @@ a.ship-notes-tab.active {
   height: 21em;
 }
 
-.grid-columns {
+.grid-columns-double {
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr;
   gap: 1px 1px;
   grid-template-areas: ". .";
+  margin-left: 1em;
+  width: 54.4em;
+}
+
+.grid-columns-single {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+  gap: 1px;
+  grid-template-areas: ".";
   margin-left: 1em;
   width: 54.4em;
 }
@@ -1489,12 +1499,20 @@ a.ship-notes-tab.active {
   color: #000;
 }
 
-.components-stored {
+.components-stored-double {
   display: grid;
   grid-template-columns: 10.5em 4em 2em 3.5em 3.5em 3em;
   grid-template-rows: 1fr;
   gap: 1px 1px;
   grid-template-areas: ". . . . . .";
+}
+
+.components-stored-single {
+  display: grid;
+  grid-template-columns: 12em 12em 4em 3.5em 3.5em 3.5em 3.5em 3.5em 3.5em 3em;
+  grid-template-rows: 1fr;
+  gap: 1px;
+  grid-template-areas: ". . . . . . . . . .";
 }
 
 .cargo-wrapper {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1509,10 +1509,10 @@ a.ship-notes-tab.active {
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 12em 12em 4em 3.5em 3.5em 3.5em 3.5em 3.5em 3.5em 3em;
+  grid-template-columns: 10em 12em 3em 3em 3.5em 3em 3.5em 3.5em 4.5em 3.5em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
-  grid-template-areas: ". . . . . . . . . .";
+  grid-template-areas: ". . . . . . . . . . .";
 }
 
 .cargo-wrapper {

--- a/static/templates/actors/parts/ship/ship-components-double.html
+++ b/static/templates/actors/parts/ship/ship-components-double.html
@@ -1,6 +1,6 @@
 <div class="storage-wrapper">
-  <div class="grid-columns">
-    <div class="components-stored storage-header">
+  <div class="grid-columns-double">
+    <div class="components-stored-double storage-header">
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
@@ -9,7 +9,7 @@
       <span class="item-name centre"><a class="item-control item-create" title='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="component"><i
         class="fas fa-plus"></i></a></span>
     </div>
-    <div class="components-stored storage-header">
+    <div class="components-stored-double storage-header">
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
@@ -20,11 +20,11 @@
     </div>
   </div>
 
-  <div class="grid-columns">
+  <div class="grid-columns-double">
     {{#each_sort_by_name data.component as |item id|}}
     <div>
       <ol class="ol-no-indent">
-        <li class="item components-stored" data-item-id="{{item.id}}">
+        <li class="item components-stored-double" data-item-id="{{item.id}}">
           <span class="item-name">{{item.name}}</span>
           <span class="item-name centre">
             {{#iff item.data.data.subtype "==" 'accomodations'}}<i class="fas fa-bed" title='{{localize "TWODSIX.Items.Component.accomodations"}}'></i>

--- a/static/templates/actors/parts/ship/ship-components-double.html
+++ b/static/templates/actors/parts/ship/ship-components-double.html
@@ -27,32 +27,7 @@
         <li class="item components-stored-double" data-item-id="{{item.id}}">
           <span class="item-name">{{item.name}}</span>
           <span class="item-name centre">
-            {{#iff item.data.data.subtype "==" 'accomodations'}}<i class="fas fa-bed" title='{{localize "TWODSIX.Items.Component.accomodations"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'armament'}}<i class="fas fa-crosshairs" title='{{localize "TWODSIX.Items.Component.armament"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'armor'}}<i class="fas fa-grip-vertical" title='{{localize "TWODSIX.Items.Component.armor"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'cargo'}}<i class="fas fa-boxes" title='{{localize "TWODSIX.Items.Component.cargo"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'computer'}}<i class="fas fa-microchip" title='{{localize "TWODSIX.Items.Component.computer"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'drive'}}<i class="fas fa-arrows-alt" title='{{localize "TWODSIX.Items.Component.drive"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'electronics'}}<i class="fas fa-satellite-dish" title='{{localize "TWODSIX.Items.Component.electronics"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'hull'}}<i class="fas fa-rocket" title='{{localize "TWODSIX.Items.Component.hull"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'power'}}<i class="fas fa-atom" title='{{localize "TWODSIX.Items.Component.power"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'shield'}}<i class="fas fa-shield-alt" title='{{localize "TWODSIX.Items.Component.shield"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'software'}}<i class="fas fa-code" title='{{localize "TWODSIX.Items.Component.software"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'vehicle'}}<i class="fas fa-space-shuttle" title='{{localize "TWODSIX.Items.Component.vehicle"}}'></i>
-            {{else}}
-              <i class="fas fa-question-circle" title='{{localize "TWODSIX.Items.Component.other"}}'></i>
-            {{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}
+            <i class= '{{twodsix_getComponentIcon item.data.data.subtype}}' title='{{localize (concat "TWODSIX.Items.Component." item.data.data.subtype)}}'></i>
           </span>
           <span class="item-name centre">{{item.data.data.techLevel}}</span>
           <span class="item-name centre">{{item.data.data.rating}}</span>

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -56,7 +56,7 @@
           <span class="item-name centre">{{item.data.data.weight}}</span>
           <span class="item-name centre">{{item.data.data.powerDraw}}</span>
           <span class="item-name centre">{{item.data.data.availableQuantity}}/{{item.data.data.quantity}}</span>
-          <span class="item-name centre">{{item.data.data.damage}}</span>
+          <span class="item-name centre">{{twodsix_limitLength item.data.data.damage 7}}</span>
           <span class="item-name centre">
             {{#iff item.data.data.status "===" 'operational'}} <i class="fas fa-check-circle" style="color: green;" title='{{localize "TWODSIX.Items.Component.operational"}}'></i>
             {{else}}

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -9,6 +9,7 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.powerDraw"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Items.Component.damage"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.status"}}</span>
       <span class="item-name centre"><a class="item-control item-create" title='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="component"><i
         class="fas fa-plus"></i></a></span>
@@ -55,6 +56,7 @@
           <span class="item-name centre">{{item.data.data.weight}}</span>
           <span class="item-name centre">{{item.data.data.powerDraw}}</span>
           <span class="item-name centre">{{item.data.data.availableQuantity}}/{{item.data.data.quantity}}</span>
+          <span class="item-name centre">{{item.data.data.damage}}</span>
           <span class="item-name centre">
             {{#iff item.data.data.status "===" 'operational'}} <i class="fas fa-check-circle" style="color: green;" title='{{localize "TWODSIX.Items.Component.operational"}}'></i>
             {{else}}

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -1,0 +1,79 @@
+<div class="storage-wrapper">
+  <div class="grid-columns-single">
+    <div class="components-stored-single storage-header">
+      <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.ShortDescr"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Items.Component.rating"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Items.Component.powerDraw"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Items.Component.status"}}</span>
+      <span class="item-name centre"><a class="item-control item-create" title='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="component"><i
+        class="fas fa-plus"></i></a></span>
+    </div>
+  </div>
+
+  <div class="grid-columns-single">
+    {{#each_sort_by_name data.component as |item id|}}
+    <div>
+      <ol class="ol-no-indent">
+        <li class="item components-stored-single" data-item-id="{{item.id}}">
+          <span class="item-name">{{item.name}}</span>
+          <span class="item-name">{{item.data.data.shortdescr}}</span>
+          <span class="item-name centre">
+            {{#iff item.data.data.subtype "==" 'accomodations'}}<i class="fas fa-bed" title='{{localize "TWODSIX.Items.Component.accomodations"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'armament'}}<i class="fas fa-crosshairs" title='{{localize "TWODSIX.Items.Component.armament"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'armor'}}<i class="fas fa-grip-vertical" title='{{localize "TWODSIX.Items.Component.armor"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'cargo'}}<i class="fas fa-boxes" title='{{localize "TWODSIX.Items.Component.cargo"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'computer'}}<i class="fas fa-microchip" title='{{localize "TWODSIX.Items.Component.computer"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'drive'}}<i class="fas fa-arrows-alt" title='{{localize "TWODSIX.Items.Component.drive"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'electronics'}}<i class="fas fa-satellite-dish" title='{{localize "TWODSIX.Items.Component.electronics"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'hull'}}<i class="fas fa-rocket" title='{{localize "TWODSIX.Items.Component.hull"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'power'}}<i class="fas fa-atom" title='{{localize "TWODSIX.Items.Component.power"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'shield'}}<i class="fas fa-shield-alt" title='{{localize "TWODSIX.Items.Component.shield"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'software'}}<i class="fas fa-code" title='{{localize "TWODSIX.Items.Component.software"}}'></i>
+            {{else}}
+              {{#iff item.data.data.subtype "===" 'vehicle'}}<i class="fas fa-space-shuttle" title='{{localize "TWODSIX.Items.Component.vehicle"}}'></i>
+            {{else}}
+              <i class="fas fa-question-circle" title='{{localize "TWODSIX.Items.Component.other"}}'></i>
+            {{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}
+          </span>
+          <span class="item-name centre">{{item.data.data.techLevel}}</span>
+          <span class="item-name centre">{{item.data.data.rating}}</span>
+          <span class="item-name centre">{{item.data.data.weight}}</span>
+          <span class="item-name centre">{{item.data.data.powerDraw}}</span>
+          <span class="item-name centre">{{item.data.data.availableQuantity}}/{{item.data.data.quantity}}</span>
+          <span class="item-name centre">
+            {{#iff item.data.data.status "===" 'operational'}} <i class="fas fa-check-circle" style="color: green;" title='{{localize "TWODSIX.Items.Component.operational"}}'></i>
+            {{else}}
+              {{#iff item.data.data.status "===" 'damaged'}} <i class="fas fa-exclamation-circle" style="color: yellow;" title='{{localize "TWODSIX.Items.Component.damaged"}}'></i>
+            {{else}}
+              {{#iff item.data.data.status "===" 'destroyed'}} <i class="fas fa-times-circle" style="color: red;" title='{{localize "TWODSIX.Items.Component.destroyed"}}'></i>
+            {{else}}
+              {{#iff item.data.data.status "===" 'off'}} <i class="fas fa-power-off" style="color: grey;" title='{{localize "TWODSIX.Items.Component.off"}}'></i>
+            {{/iff}} {{/iff}} {{/iff}} {{/iff}}
+          </span>
+          <span class="item-controls centre">
+            <a class="item-control item-edit" title='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i
+              class="fas fa-edit"></i></a>
+            <a class="item-control item-delete" title='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i
+              class="fas fa-trash"></i></a>
+          </span>
+        </li>
+      </ol>
+    </div>
+    {{/each_sort_by_name}}
+  </div>
+</div>

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -24,32 +24,7 @@
           <span class="item-name">{{item.name}}</span>
           <span class="item-name">{{item.data.data.shortdescr}}</span>
           <span class="item-name centre">
-            {{#iff item.data.data.subtype "==" 'accomodations'}}<i class="fas fa-bed" title='{{localize "TWODSIX.Items.Component.accomodations"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'armament'}}<i class="fas fa-crosshairs" title='{{localize "TWODSIX.Items.Component.armament"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'armor'}}<i class="fas fa-grip-vertical" title='{{localize "TWODSIX.Items.Component.armor"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'cargo'}}<i class="fas fa-boxes" title='{{localize "TWODSIX.Items.Component.cargo"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'computer'}}<i class="fas fa-microchip" title='{{localize "TWODSIX.Items.Component.computer"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'drive'}}<i class="fas fa-arrows-alt" title='{{localize "TWODSIX.Items.Component.drive"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'electronics'}}<i class="fas fa-satellite-dish" title='{{localize "TWODSIX.Items.Component.electronics"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'hull'}}<i class="fas fa-rocket" title='{{localize "TWODSIX.Items.Component.hull"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'power'}}<i class="fas fa-atom" title='{{localize "TWODSIX.Items.Component.power"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'shield'}}<i class="fas fa-shield-alt" title='{{localize "TWODSIX.Items.Component.shield"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'software'}}<i class="fas fa-code" title='{{localize "TWODSIX.Items.Component.software"}}'></i>
-            {{else}}
-              {{#iff item.data.data.subtype "===" 'vehicle'}}<i class="fas fa-space-shuttle" title='{{localize "TWODSIX.Items.Component.vehicle"}}'></i>
-            {{else}}
-              <i class="fas fa-question-circle" title='{{localize "TWODSIX.Items.Component.other"}}'></i>
-            {{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}{{/iff}}
+            <i class= '{{twodsix_getComponentIcon item.data.data.subtype}}' title='{{localize (concat "TWODSIX.Items.Component." item.data.data.subtype)}}'></i>
           </span>
           <span class="item-name centre">{{item.data.data.techLevel}}</span>
           <span class="item-name centre">{{item.data.data.rating}}</span>

--- a/static/templates/actors/parts/ship/ship-storage.html
+++ b/static/templates/actors/parts/ship/ship-storage.html
@@ -1,5 +1,5 @@
 <div class="storage-wrapper">
-  <div class="grid-columns">
+  <div class="grid-columns-double">
     <div class="storage-stored storage-header">
       <span class="item-name">{{localize "TWODSIX.Actor.Items.Name"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
@@ -20,7 +20,7 @@
     </div>
   </div>
 
-  <div class="grid-columns">
+  <div class="grid-columns-double">
     {{#each_sort_by_name data.storage as |item id|}}
     <div>
       <ol class="ol-no-indent">

--- a/static/templates/actors/parts/ship/ship-storage.html
+++ b/static/templates/actors/parts/ship/ship-storage.html
@@ -26,7 +26,7 @@
       <ol class="ol-no-indent">
         <li class="item storage-stored" data-item-id="{{item.id}}">
           <span class="item-name">{{item.name}}</span>
-          <span class="item-name centre">{{twodsix_capitalize item.type}}</span>
+          <span class="item-name centre">{{twodsix_capitalize (localize (concat "TWODSIX.itemTypes." item.type))}}</span>
           <span class="item-name centre">{{item.data.data.techLevel}}</span>
           <span class="item-name centre">{{item.data.data.weight}}</span>
           <span class="item-name centre">{{item.data.data.quantity}}</span>

--- a/static/templates/actors/ship-sheet.html
+++ b/static/templates/actors/ship-sheet.html
@@ -43,7 +43,7 @@
     <div class="ship-tabs">
       <nav class="sheet-tabs tabs" data-group="primary">
         <a class="item ship-crew-tab" data-tab="ship-crew">{{localize "TWODSIX.Ship.Tabs.Crew"}}</a>
-        <a class="item ship-storage-tab" data-tab="ship-component" style="padding-left: 1ch;padding-right: 1ch;">{{localize "TWODSIX.Ship.Tabs.Components"}}</a>
+        <a class="item ship-storage-tab" data-tab="ship-component">{{localize "TWODSIX.Ship.Tabs.Components"}}</a>
         <a class="item ship-storage-tab" data-tab="ship-storage">{{localize "TWODSIX.Ship.Tabs.Locker"}}</a>
         <a class="item ship-cargo-tab" data-tab="ship-cargo">{{localize "TWODSIX.Ship.Tabs.Cargo"}}</a>
         <a class="item ship-notes-tab" data-tab="ship-notes">{{localize "TWODSIX.Ship.Tabs.Notes"}}</a>

--- a/static/templates/actors/ship-sheet.html
+++ b/static/templates/actors/ship-sheet.html
@@ -57,12 +57,16 @@
 
     {{!-- Component Tab --}}
     <div class="tab ship-storage" data-group="primary" data-tab="ship-component">
-      {{> "systems/twodsix/templates/actors/parts/ship/ship-components.html"}}
+      {{#if data.settings.showSingleComponentColumn}}
+        {{> "systems/twodsix/templates/actors/parts/ship/ship-components-single.html"}}
+      {{else}}
+        {{> "systems/twodsix/templates/actors/parts/ship/ship-components-double.html"}}
+      {{/if}}
     </div>
 
     {{!-- Storage Tab --}}
     <div class="tab ship-storage" data-group="primary" data-tab="ship-storage">
-      {{> "systems/twodsix/templates/actors/parts/ship/ship-storage.html"}}
+        {{> "systems/twodsix/templates/actors/parts/ship/ship-storage.html"}}
     </div>
 
     {{!-- Cargo Tab --}}

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -87,7 +87,7 @@
 
     <div class="item-damage">
       <label for="data.damage" class="resource-label">{{localize "TWODSIX.Items.Component.damage"}}
-        <input id="data.damage" type="text" name="data.damage" value="{{data.damage}}" data-dtype="Number"/>
+        <input id="data.damage" type="text" name="data.damage" value="{{data.damage}}"/>
       </label>
     </div>
     


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a feature to show ship component list on single line.  It required some refactor of the tab sheet html to make the code understandable and not too repetitive.  Also, expands real estate on ship tabs.  Adds overlooked localization to storage tab item type.


* **What is the current behavior?** (You can also link to an open issue here)
Must use double column format. Tabs too narrow.  Item types not localized.  Oh my.


* **What is the new behavior (if this is a feature change)?**
Option to choose between single or double column format.  Tabs wider. Better localization.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
