### PR TITLE
fix: component and storage headers so they don't scroll

### DIFF
--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1497,6 +1497,8 @@ a.ship-notes-tab.active {
   border: 2px solid #29aae1;
   background-color: #29aae1;
   color: #000;
+  position: sticky;
+  top:0%;
 }
 
 .components-stored-double {

--- a/static/templates/actors/parts/ship/ship-components-double.html
+++ b/static/templates/actors/parts/ship/ship-components-double.html
@@ -1,6 +1,6 @@
 <div class="storage-wrapper">
-  <div class="grid-columns-double">
-    <div class="components-stored-double storage-header">
+  <div class="grid-columns-double storage-header">
+    <div class="components-stored-double ">
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
@@ -9,7 +9,7 @@
       <span class="item-name centre"><a class="item-control item-create" title='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="component"><i
         class="fas fa-plus"></i></a></span>
     </div>
-    <div class="components-stored-double storage-header">
+    <div class="components-stored-double ">
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -1,6 +1,6 @@
 <div class="storage-wrapper">
-  <div class="grid-columns-single">
-    <div class="components-stored-single storage-header">
+  <div class="grid-columns-single storage-header">
+    <div class="components-stored-single ">
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.ShortDescr"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>

--- a/static/templates/actors/parts/ship/ship-storage.html
+++ b/static/templates/actors/parts/ship/ship-storage.html
@@ -1,6 +1,6 @@
 <div class="storage-wrapper">
-  <div class="grid-columns-double">
-    <div class="storage-stored storage-header">
+  <div class="grid-columns-double storage-header">
+    <div class="storage-stored">
       <span class="item-name">{{localize "TWODSIX.Actor.Items.Name"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
@@ -9,7 +9,7 @@
       <span class="item-name centre"><a class="item-control item-create" title='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="storage"><i
         class="fas fa-plus"></i></a></span>
     </div>
-    <div class="storage-stored storage-header">
+    <div class="storage-stored">
       <span class="item-name">{{localize "TWODSIX.Actor.Items.Name"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines *EXCEPT*, don't use 'feat:' if you're not me. Stepping major versions until 1.0 is a deliberate decision (after that, it'll be full semantic versioning.) 
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Style change for ship sheet.  Headers for stored items scroll off the screen.  Fix them to always be on top.


* **What is the current behavior?** (You can also link to an open issue here)
Headers scroll off the screen making tables difficult to read.


* **What is the new behavior (if this is a feature change)?**
Headers are fixed.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
