### PR TITLE
Shorten encumbrance title and change its icon; restyle a bit

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -137,6 +137,7 @@
     },
     "Items": {
       "Encumbrance": "Encumbrance",
+      "Enc": "Enc",
       "Armor": {
         "Armor": "Armor",
         "SecondaryArmor": "Secondary Armor",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -416,7 +416,7 @@ span.bgi-age {
   margin-right: 0;
 }
 
-span.bgi-armor {
+span.bgi-armor, span.bgi-encumbrance {
   margin-right: 0.5em;
   height: 26px;
   font-size: 16px;
@@ -426,7 +426,13 @@ span.bgi-armor {
 
 .bgi-armor input {
   position: relative;
-  text-align: center;
+  margin-bottom: -0.5em;
+  width: 3ch;
+  border: none;
+}
+
+.bgi-encumbrance input {
+  position: relative;
   margin-bottom: -0.5em;
   width: 4ch;
   border: none;

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -379,7 +379,7 @@ img.character-info-mask {
 }
 
 .bgi-gender input {
-  width: 7em;
+  width: 10ch;
   border: none;
 }
 

--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -24,8 +24,10 @@
         class="fas fa-medal"></i>:<input type="number" name="data.heroPoints" value="{{data.heroPoints}}" min="0"
         step="1" placeholder="2" /></span>
 {{/if}} 
-<span class="bgi-armor" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:&nbsp<b>{{data.encumbrance.value}}</b>&nbsp/
-        <input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
+<span class="bgi-armor" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:
+        <input name="data.encumbrance.value" type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>/
+        <input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/>
+</span>
 <br>    
 <!-- Damage Stats Information-->
 <span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Stamina"}}'>

--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -23,11 +23,10 @@
 <span class="bgi-armor" title='{{localize "TWODSIX.Actor.HeroPoints"}}' style="color:gold !important"><i
         class="fas fa-medal"></i>:<input type="number" name="data.heroPoints" value="{{data.heroPoints}}" min="0"
         step="1" placeholder="2" /></span>
-{{/if}}      
-<span class="bgi-armor" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-hiking"></i>:<input
-      name="data.encumbrance.value" type="text" value="{{data.encumbrance.value}}" placeholder='0' onClick="this.select();"/>
-      /<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
-<br>
+{{/if}} 
+<span class="bgi-armor" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:&nbsp{{data.encumbrance.value}}&nbsp/
+        <input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
+<br>    
 <!-- Damage Stats Information-->
 <span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Stamina"}}'>
     {{#iff data.characteristics.stamina.value ">" data.characteristics.stamina.damage}} 

--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -24,7 +24,7 @@
         class="fas fa-medal"></i>:<input type="number" name="data.heroPoints" value="{{data.heroPoints}}" min="0"
         step="1" placeholder="2" /></span>
 {{/if}} 
-<span class="bgi-armor" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:&nbsp{{data.encumbrance.value}}&nbsp/
+<span class="bgi-armor" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:&nbsp<b>{{data.encumbrance.value}}</b>&nbsp/
         <input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
 <br>    
 <!-- Damage Stats Information-->

--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -24,7 +24,7 @@
         step="1" placeholder="2" /></span>
 {{/if}}      
 <span class="bgi-encumbrance" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:<input
-      name="data.encumbrance.value" style="text-align: right;" type="text" value="{{data.encumbrance.value}}" placeholder='0' onClick="this.select();"/>
+      name="data.encumbrance.value" style="text-align: right;" type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>
       /<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
 <br>
 <!-- Damage Stats Information-->

--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -3,26 +3,28 @@
         name="data.homeWorld" type="text" value="{{data.homeWorld}}"
         placeholder='{{localize "TWODSIX.Actor.HomeWorld"}}' onClick="this.select();" /> </span>
 <span class="bgi-age"><i class="fas fa-calendar-alt"></i>:<input type="text" name="data.age.value"
-        value="{{data.age.value}}" placeholder="0" title='{{localize "TWODSIX.Actor.Age"}}' /></span><br>
+        value="{{data.age.value}}" placeholder="0" title='{{localize "TWODSIX.Actor.Age"}}' /></span>
+<!-- Hero Points Information-->
+{{#if actor.data.settings.showHeroPoints}}
+<span class="bgi-armor" title='{{localize "TWODSIX.Actor.HeroPoints"}}' style="color:gold !important"><i
+        class="fas fa-medal"></i>:<input type="number" name="data.heroPoints" value="{{data.heroPoints}}" min="0"
+        step="1" placeholder="2" /></span>
+{{/if}}
+<br>
 <span class="bgi-species"><i class="fas fa-dna"></i>:<input name="data.species" type="text" value="{{data.species}}"
         placeholder='{{localize "TWODSIX.Actor.Species"}}' onClick="this.select();"
         title='{{localize "TWODSIX.Actor.Species"}}' /></span>
 <span class="bgi-gender"><i class="fas fa-venus-mars"></i>:<input name="data.gender" type="text" value="{{data.gender}}"
         placeholder='{{localize "TWODSIX.Actor.Gender"}}' onClick="this.select();"
-        title='{{localize "TWODSIX.Actor.Gender"}}' /></span><br>
+        title='{{localize "TWODSIX.Actor.Gender"}}' /></span>
+<br>
 <!-- Protection Information-->
 <span class="bgi-armor" title='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fas fa-user-shield"></i>:<input
         style="text-align: right;" name="data.primaryArmor.value" type="text" value="{{data.primaryArmor.value}}" placeholder='0'
         onClick="this.select();" />/<input name="data.secondaryArmor.value" type="text"
         value="{{data.secondaryArmor.value}}" placeholder='0' onClick="this.select();" /></span>
 <span class="bgi-armor" title='{{localize "TWODSIX.Items.Armor.RadProt"}}'><i class="fas fa-radiation-alt"></i>:<input 
-        name="data.radiationProtection.value" type="text" value="{{data.radiationProtection.value}}" placeholder='0' onClick="this.select();" /></span>
-<!-- Hero Points Information-->
-{{#if actor.data.settings.showHeroPoints}}
-<span class="bgi-armor" title='{{localize "TWODSIX.Actor.HeroPoints"}}' style="color:gold !important"><i
-        class="fas fa-medal"></i>:<input type="number" name="data.heroPoints" value="{{data.heroPoints}}" min="0"
-        step="1" placeholder="2" /></span>
-{{/if}}      
+        name="data.radiationProtection.value" type="text" value="{{data.radiationProtection.value}}" placeholder='0' onClick="this.select();" /></span>     
 <span class="bgi-encumbrance" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:<input
       name="data.encumbrance.value" style="text-align: right;" type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>
       /<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>

--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -12,37 +12,34 @@
         title='{{localize "TWODSIX.Actor.Gender"}}' /></span><br>
 <!-- Protection Information-->
 <span class="bgi-armor" title='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fas fa-user-shield"></i>:<input
-        name="data.primaryArmor.value" type="text" value="{{data.primaryArmor.value}}" placeholder='0'
+        style="text-align: right;" name="data.primaryArmor.value" type="text" value="{{data.primaryArmor.value}}" placeholder='0'
         onClick="this.select();" />/<input name="data.secondaryArmor.value" type="text"
         value="{{data.secondaryArmor.value}}" placeholder='0' onClick="this.select();" /></span>
-<span class="bgi-armor" title='{{localize "TWODSIX.Items.Armor.RadProt"}}'><i class="fas fa-radiation-alt"></i>:
-        <input name="data.radiationProtection.value" type="text" value="{{data.radiationProtection.value}}" placeholder='0'
-            onClick="this.select();" /></span>
+<span class="bgi-armor" title='{{localize "TWODSIX.Items.Armor.RadProt"}}'><i class="fas fa-radiation-alt"></i>:<input 
+        name="data.radiationProtection.value" type="text" value="{{data.radiationProtection.value}}" placeholder='0' onClick="this.select();" /></span>
 <!-- Hero Points Information-->
 {{#if actor.data.settings.showHeroPoints}}
 <span class="bgi-armor" title='{{localize "TWODSIX.Actor.HeroPoints"}}' style="color:gold !important"><i
         class="fas fa-medal"></i>:<input type="number" name="data.heroPoints" value="{{data.heroPoints}}" min="0"
         step="1" placeholder="2" /></span>
-{{/if}} 
-<span class="bgi-armor" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:
-        <input name="data.encumbrance.value" type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>/
-        <input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/>
-</span>
-<br>    
+{{/if}}      
+<span class="bgi-encumbrance" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:<input
+      name="data.encumbrance.value" style="text-align: right;" type="text" value="{{data.encumbrance.value}}" placeholder='0' onClick="this.select();"/>
+      /<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
+<br>
 <!-- Damage Stats Information-->
 <span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Stamina"}}'>
     {{#iff data.characteristics.stamina.value ">" data.characteristics.stamina.damage}} 
-        <i class="fas fa-battery-half"></i> 
+        <i class="fas fa-battery-half"></i>
     {{else}} 
-        <i class="fas fa-battery-empty" style="color:brown;"></i> 
-    {{/iff}}:
-    <input type="number" name="data.characteristics.stamina.value"
-        value="{{data.characteristics.stamina.value}}" />-</span>
+        <i class="fas fa-battery-empty" style="color:brown;"></i>
+    {{/iff}}:<input 
+    type="number" name="data.characteristics.stamina.value" value="{{data.characteristics.stamina.value}}" />-</span>
 <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.Stamina"}}'><input type="number"
-        name="data.characteristics.stamina.damage" value="{{data.characteristics.stamina.damage}}" /> </span>
-<span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Lifeblood"}}'><i class="fas fa-heartbeat"></i>:
-    <input type="number" name="data.characteristics.lifeblood.value" value="{{data.characteristics.lifeblood.value}}" />-</span>
+        name="data.characteristics.stamina.damage" value="{{data.characteristics.stamina.damage}}" /></span>
+<span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Lifeblood"}}'><i class="fas fa-heartbeat"></i>:<input 
+        type="number" name="data.characteristics.lifeblood.value" value="{{data.characteristics.lifeblood.value}}"/>-</span>
 <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.Lifeblood"}}'>
-    <input type="number" name="data.characteristics.lifeblood.damage" value="{{data.characteristics.lifeblood.damage}}" /> </span>
-<span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.RadiationExposure"}}'><i class="fas fa-radiation"></i>:
-    <input name="data.radiationDose.value" value={{data.radiationDose.value}} type="text" /></span><br>
+    <input type="number" name="data.characteristics.lifeblood.damage" value="{{data.characteristics.lifeblood.damage}}"/></span>
+<span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.RadiationExposure"}}'><i class="fas fa-radiation"></i>:<input 
+        name="data.radiationDose.value" value={{data.radiationDose.value}} type="text"/></span><br>

--- a/static/templates/actors/parts/actor/actor-bgi-std.html
+++ b/static/templates/actors/parts/actor/actor-bgi-std.html
@@ -17,6 +17,5 @@
               class="fas fa-medal"></i>:<input type="number" name="data.heroPoints" value="{{data.heroPoints}}" min="0"
               step="1" placeholder="2" /></span>
 {{/if}}
-<span class="bgi-armor">{{localize "TWODSIX.Items.Encumbrance"}}:<input name="data.encumbrance.value" type="text" value="{{data.encumbrance.value}}"
-      placeholder='0' onClick="this.select();"/>/<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}"
-      placeholder='0' onClick="this.select();"/></span>
+<span class="bgi-armor" title="{{localize 'TWODSIX.Items.Encumbrance'}}">{{localize "TWODSIX.Items.Enc"}}:&nbsp{{data.encumbrance.value}}&nbsp/
+    <input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>

--- a/static/templates/actors/parts/actor/actor-bgi-std.html
+++ b/static/templates/actors/parts/actor/actor-bgi-std.html
@@ -17,5 +17,5 @@
         name="data.heroPoints" value="{{data.heroPoints}}" min="0" step="1" placeholder="2" /></span>
 {{/if}}
 <span class="bgi-encumbrance" title="{{localize 'TWODSIX.Items.Encumbrance'}}">{{localize "TWODSIX.Items.Enc"}}:<input name="data.encumbrance.value" style="text-align: right;" 
-    type="text" value="{{data.encumbrance.value}}" placeholder='0' onClick="this.select();"/>/<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}"
+    type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>/<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}"
     placeholder='0' onClick="this.select();"/></span>

--- a/static/templates/actors/parts/actor/actor-bgi-std.html
+++ b/static/templates/actors/parts/actor/actor-bgi-std.html
@@ -7,17 +7,15 @@
 <span class="bgi-homeWorld">{{localize "TWODSIX.Actor.HomeWorld"}}:<input name="data.homeWorld" type="text"
     value="{{data.homeWorld}}" placeholder='{{localize "TWODSIX.Actor.HomeWorld"}}' onClick="this.select();" /></span>
 
-<span class="bgi-armor">{{localize "TWODSIX.Items.Armor.Armor"}}:<input name="data.primaryArmor.value" type="text" value="{{data.primaryArmor.value}}"
+<span class="bgi-armor">{{localize "TWODSIX.Items.Armor.Armor"}}:<input name="data.primaryArmor.value" style="text-align: right;" type="text" value="{{data.primaryArmor.value}}"
       placeholder='0' onClick="this.select();"/>/<input name="data.secondaryArmor.value" type="text" value="{{data.secondaryArmor.value}}" 
       placeholder='0' onClick="this.select();"/></span>
 <span class="bgi-armor">{{localize "TWODSIX.Items.Armor.RadProt"}}:<input name="data.radiationProtection.value" type="text" value="{{data.radiationProtection.value}}"
       placeholder='0' onClick="this.select();"/></span>
 {{#if actor.data.settings.showHeroPoints}}
-    <span class="bgi-armor" title='{{localize "TWODSIX.Actor.HeroPoints"}}' style="color:gold !important"><i
-              class="fas fa-medal"></i>:<input type="number" name="data.heroPoints" value="{{data.heroPoints}}" min="0"
-              step="1" placeholder="2" /></span>
+    <span class="bgi-armor" title='{{localize "TWODSIX.Actor.HeroPoints"}}' style="color:gold !important"><i class="fas fa-medal"></i>:<input type="number" 
+        name="data.heroPoints" value="{{data.heroPoints}}" min="0" step="1" placeholder="2" /></span>
 {{/if}}
-<span class="bgi-armor" title='{{localize "TWODSIX.Items.Encumbrance"}}'>{{localize "TWODSIX.Items.Enc"}}:
-    <input name="data.encumbrance.value" type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>/
-    <input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/>
-</span>
+<span class="bgi-encumbrance" title="{{localize 'TWODSIX.Items.Encumbrance'}}">{{localize "TWODSIX.Items.Enc"}}:<input name="data.encumbrance.value" style="text-align: right;" 
+    type="text" value="{{data.encumbrance.value}}" placeholder='0' onClick="this.select();"/>/<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}"
+    placeholder='0' onClick="this.select();"/></span>

--- a/static/templates/actors/parts/actor/actor-bgi-std.html
+++ b/static/templates/actors/parts/actor/actor-bgi-std.html
@@ -1,7 +1,11 @@
 <span class="bgi-age">{{localize "TWODSIX.Actor.Age"}}:<input type="text" name="data.age.value"
     value="{{data.age.value}}" placeholder="0" /></span>
 <span class="bgi-gender">{{localize "TWODSIX.Actor.Gender"}}:<input name="data.gender" type="text"
-    value="{{data.gender}}" placeholder='{{localize "TWODSIX.Actor.Gender"}}' onClick="this.select();" /></span>
+    value="{{data.gender}}" placeholder='{{localize "TWODSIX.Actor.Gender"}}' onClick="this.select();"/></span>
+{{#if actor.data.settings.showHeroPoints}}
+    <span class="bgi-armor" title='{{localize "TWODSIX.Actor.HeroPoints"}}' style="color:gold !important"><i class="fas fa-medal"></i>:<input type="number" 
+        name="data.heroPoints" value="{{data.heroPoints}}" min="0" step="1" placeholder="2" /></span>
+{{/if}}
 <span class="bgi-species">{{localize "TWODSIX.Actor.Species"}}:<input name="data.species" type="text"
     value="{{data.species}}" placeholder='{{localize "TWODSIX.Actor.Species"}}' onClick="this.select();" /></span>
 <span class="bgi-homeWorld">{{localize "TWODSIX.Actor.HomeWorld"}}:<input name="data.homeWorld" type="text"
@@ -12,10 +16,7 @@
       placeholder='0' onClick="this.select();"/></span>
 <span class="bgi-armor">{{localize "TWODSIX.Items.Armor.RadProt"}}:<input name="data.radiationProtection.value" type="text" value="{{data.radiationProtection.value}}"
       placeholder='0' onClick="this.select();"/></span>
-{{#if actor.data.settings.showHeroPoints}}
-    <span class="bgi-armor" title='{{localize "TWODSIX.Actor.HeroPoints"}}' style="color:gold !important"><i class="fas fa-medal"></i>:<input type="number" 
-        name="data.heroPoints" value="{{data.heroPoints}}" min="0" step="1" placeholder="2" /></span>
-{{/if}}
+
 <span class="bgi-encumbrance" title="{{localize 'TWODSIX.Items.Encumbrance'}}">{{localize "TWODSIX.Items.Enc"}}:<input name="data.encumbrance.value" style="text-align: right;" 
     type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>/<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}"
     placeholder='0' onClick="this.select();"/></span>

--- a/static/templates/actors/parts/actor/actor-bgi-std.html
+++ b/static/templates/actors/parts/actor/actor-bgi-std.html
@@ -17,5 +17,7 @@
               class="fas fa-medal"></i>:<input type="number" name="data.heroPoints" value="{{data.heroPoints}}" min="0"
               step="1" placeholder="2" /></span>
 {{/if}}
-<span class="bgi-armor" title="{{localize 'TWODSIX.Items.Encumbrance'}}">{{localize "TWODSIX.Items.Enc"}}:&nbsp{{data.encumbrance.value}}&nbsp/
-    <input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
+<span class="bgi-armor" title='{{localize "TWODSIX.Items.Encumbrance"}}'>{{localize "TWODSIX.Items.Enc"}}:
+    <input name="data.encumbrance.value" type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>/
+    <input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/>
+</span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Shortens title, makes calc value unedited, changes icon for encumbrance.  Fixes some minor styling issues for rest of big area.


* **What is the current behavior?** (You can also link to an open issue here)
Long title, reused icon, calculated field can selected and edited.


* **What is the new behavior (if this is a feature change)?**
Fixes these


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
