### PR TITLE
Fix: incorrect reference to item root name.

### DIFF
--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -34,7 +34,7 @@ export class TwodsixRollSettings {
     if (showThrowDialog) {
       let title:string;
       if (item) {
-        title = `${skill.data.name} ${game.i18n.localize("TWODSIX.Actor.using")} ${item.data.data.name}`;
+        title = `${skill.data.name} ${game.i18n.localize("TWODSIX.Actor.using")} ${item.data.name}`;
       } else if (skill) {
         title = skill.data.name;
       } else {


### PR DESCRIPTION
This is a larger issue as we have both item.data.name and item.data.data.name.  The two aren't identical.

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: For item rolls (like an attack) the item named referenced is item.data.data.name rather than item.data.name.  The name entered on the Item sheet is actually item.data.name.


* **What is the current behavior?** (You can also link to an open issue here)

Depending on how item was created, name will be incorrect or missing in dialog.

* **What is the new behavior (if this is a feature change)?**
Fix dialog.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
