### PR TITLE
fix: weapon input field can't be forced to a single number

### DIFF
--- a/static/templates/items/weapon-sheet.html
+++ b/static/templates/items/weapon-sheet.html
@@ -70,7 +70,7 @@
     {{#if data.settings.ShowRateOfFire}}
     <div class="item-rateOfFire">
       <span class="resource-label">{{localize "TWODSIX.Items.Weapon.rateOfFire"}}</span>
-      <input type="text" name="data.rateOfFire" value="{{data.rateOfFire}}" data-dtype="Number">
+      <input type="text" name="data.rateOfFire" value="{{data.rateOfFire}}">
     </div>
     {{/if}}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for weapons fire rate


* **What is the current behavior?** (You can also link to an open issue here)

Can only enter single value

* **What is the new behavior (if this is a feature change)?**

Can enter any "text format

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
