### PR TITLE
fix: traveller image format

### DIFF
--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -344,13 +344,14 @@ img.character-info-mask {
   margin-left: 2.1em;
   position: absolute;
   width: 19.3em;
-  height: 100%;
+  height: 20em;
+  text-align: center;
   z-index: 0;
 }
 
 .character-photo img {
-  width: 100%;
   vertical-align: middle;
+  max-height: 100%;
   z-index: -1;
 }
 

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -91,10 +91,12 @@ img.character-info-mask {
   border: solid;
   border-color: inherit;
   border-radius: 1ch 1ch 0 0;
+  text-align: center;
 }
 
 .character-photo img {
-  width: 100%;
+  max-height: 100%;
+  max-width: 100%;
   vertical-align: middle;
   z-index: -1;
 }


### PR DESCRIPTION
Traveller image overlaps other areas.  Make it fit into image box.

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix:  fix traveller actor image alignment to fit within box


* **What is the current behavior?** (You can also link to an open issue here)

Traveller image does not correctly fill the image box or extends past/

* **What is the new behavior (if this is a feature change)?**

Constrain image to box and make it centered while preserving aspect ratio.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
