### PR TITLE
fix: encumbrance, armor and rads should be numbers and not text

### DIFF
--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -24,14 +24,13 @@
 <br>
 <!-- Protection Information-->
 <span class="bgi-armor" title='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fas fa-user-shield"></i>:<input
-        style="text-align: right;" name="data.primaryArmor.value" type="text" value="{{data.primaryArmor.value}}" placeholder='0'
-        onClick="this.select();" />/<input name="data.secondaryArmor.value" type="text"
-        value="{{data.secondaryArmor.value}}" placeholder='0' onClick="this.select();" /></span>
+        style="text-align: right;" name="data.primaryArmor.value" type="number" value="{{data.primaryArmor.value}}" placeholder='0'
+       readonly />/<input name="data.secondaryArmor.value" type="number" value="{{data.secondaryArmor.value}}" placeholder='0' readonly /></span>
 <span class="bgi-armor" title='{{localize "TWODSIX.Items.Armor.RadProt"}}'><i class="fas fa-radiation-alt"></i>:<input 
-        name="data.radiationProtection.value" type="text" value="{{data.radiationProtection.value}}" placeholder='0' onClick="this.select();" /></span>     
+        name="data.radiationProtection.value" type="number" value="{{data.radiationProtection.value}}" placeholder='0' readonly /></span>     
 <span class="bgi-encumbrance" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:<input
-      name="data.encumbrance.value" style="text-align: right;" type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>
-      /<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
+      name="data.encumbrance.value" style="text-align: right;" type="number" value="{{data.encumbrance.value}}" placeholder='0' readonly/>
+      /<input name="data.encumbrance.max" type="number" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
 <br>
 <!-- Damage Stats Information-->
 <span class="bgi-char-narrow" title='{{localize "TWODSIX.Actor.Stamina"}}'>
@@ -48,4 +47,4 @@
 <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.Lifeblood"}}'>
     <input type="number" name="data.characteristics.lifeblood.damage" value="{{data.characteristics.lifeblood.damage}}"/></span>
 <span class="bgi-char-wide" title='{{localize "TWODSIX.Actor.RadiationExposure"}}'><i class="fas fa-radiation"></i>:<input 
-        name="data.radiationDose.value" value={{data.radiationDose.value}} type="text"/></span><br>
+        name="data.radiationDose.value" value={{data.radiationDose.value}} type="number"/></span><br>

--- a/static/templates/actors/parts/actor/actor-bgi-std.html
+++ b/static/templates/actors/parts/actor/actor-bgi-std.html
@@ -16,15 +16,15 @@
 <span class="bgi-homeWorld">{{localize "TWODSIX.Actor.HomeWorld"}}:<input name="data.homeWorld" type="text"
     value="{{data.homeWorld}}" placeholder='{{localize "TWODSIX.Actor.HomeWorld"}}' onClick="this.select();" /></span>
 
-<span class="bgi-armor">{{localize "TWODSIX.Items.Armor.Armor"}}:<input name="data.primaryArmor.value" style="text-align: right;" type="text" value="{{data.primaryArmor.value}}"
-      placeholder='0' onClick="this.select();"/>/<input name="data.secondaryArmor.value" type="text" value="{{data.secondaryArmor.value}}" 
-      placeholder='0' onClick="this.select();"/></span>
-<span class="bgi-armor">{{localize "TWODSIX.Items.Armor.RadProt"}}:<input name="data.radiationProtection.value" type="text" value="{{data.radiationProtection.value}}"
-      placeholder='0' onClick="this.select();"/></span>
+<span class="bgi-armor">{{localize "TWODSIX.Items.Armor.Armor"}}:<input name="data.primaryArmor.value" style="text-align: right;" type="number" value="{{data.primaryArmor.value}}"
+      placeholder='0' readonly/>/<input name="data.secondaryArmor.value" type="number" value="{{data.secondaryArmor.value}}" 
+      placeholder='0' readonly/></span>
+<span class="bgi-armor">{{localize "TWODSIX.Items.Armor.RadProt"}}:<input name="data.radiationProtection.value" type="number" value="{{data.radiationProtection.value}}"
+      placeholder='0' readonly/></span>
 
 <span class="bgi-encumbrance" title="{{localize 'TWODSIX.Items.Encumbrance'}}">{{localize "TWODSIX.Items.Enc"}}:<input name="data.encumbrance.value" style="text-align: right;" 
-    type="text" value="{{data.encumbrance.value}}" placeholder='0' disabled/>/<input name="data.encumbrance.max" type="text" value="{{data.encumbrance.max}}"
+    type="number" value="{{data.encumbrance.value}}" placeholder='0' readonly/>/<input name="data.encumbrance.max" type="number" value="{{data.encumbrance.max}}"
     placeholder='0' onClick="this.select();"/></span>
 
 <span class="bgi-radExposure" title="{{localize 'TWODSIX.Actor.RadiationExposure'}}">Rads:<input name="data.radiationDose.value" style="text-align: right;" 
-      type="text" value="{{data.radiationDose.value}}" placeholder='0' onClick="this.select();"/></span>
+      type="number" value="{{data.radiationDose.value}}" placeholder='0' onClick="this.select();"/></span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: armor, encumbrance and rads should be numbers and not text 


* **What is the current behavior?** (You can also link to an open issue here)
Values typed to strings rather than numbers - cause issues when using values as resource


* **What is the new behavior (if this is a feature change)?**
Values a kept as numbers - per template


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
