### PR TITLE
fix: vertical alignment of consumables row

### DIFF
--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1813,12 +1813,13 @@ a:hover {
 .consumable-row {
   padding-right: 3px;
   width: 100%;
-  height: 30px;
+  /*height: 30px;*/
+  text-align: right;
 }
 
-.consumable-row .wrapper {
+/*.consumable-row .wrapper {
   float: right;
-}
+}*/
 
 .consumable-row .refill-button {
   width: 100px;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1547,12 +1547,12 @@ button.flexrow.flex-group-center.toggle-skills {
 .consumable-row {
   padding-right: 3px;
   width: 100%;
-  height: 30px;
+  text-align: right;
 }
 
-.consumable-row .wrapper {
+/*.consumable-row .wrapper {
   float: right;
-}
+}*/
 
 .consumable-row .refill-button {
   width: 100px;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix: Long consumable names overlap item box (does not expand correctly)


* **What is the current behavior?** (You can also link to an open issue here)
Overlap of box boundaries


* **What is the new behavior (if this is a feature change)?**
Make it auto sizable


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
