### PR TITLE
fix: adjust for short alternative names

### DIFF
--- a/static/templates/actors/parts/actor/actor-characteristics.html
+++ b/static/templates/actors/parts/actor/actor-characteristics.html
@@ -86,7 +86,7 @@
   {{#if (showAlternativeCharacteristics)}}
   <div class="special alternative1" data-characteristic="alternative1">
     <span class="special-name rollable-characteristic" title="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{data.characteristics.alternative1.mod}}" data-label="{{data.characteristics.alternative1.shortLabel}}"
-      >{{alternativeShort1}}</span>
+      >{{alternativeShort1}}</span><br>
     <span class="special-ability"><input type="number" min="0" name="data.characteristics.alternative1.value"
       data-label="data.characteristics.alternative1.value" value="{{data.characteristics.alternative1.value}}"
       placeholder="0" data-dtype="Number" onClick="this.select();"/></span>
@@ -98,7 +98,7 @@
     </div>
   <div class="special alternative2" data-characteristic="alternative2">
     <span class="special-name rollable-characteristic" title="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{data.characteristics.alternative2.mod}}" data-label="{{data.characteristics.alternative2.shortLabel}}"
-      >{{alternativeShort2}}</span>                               
+      >{{alternativeShort2}}</span><br>                         
     <span class="special-ability"><input type="number" min="0" name="data.characteristics.alternative2.value"
       data-label="data.characteristics.alternative2.value" value="{{data.characteristics.alternative2.value}}"
       placeholder="0" data-dtype="Number" onClick="this.select();"/></span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix: Short alternative names don't align the values 


* **What is the current behavior?** (You can also link to an open issue here)
Value, mod, and damage not aligned in boxes if shortName is too short


* **What is the new behavior (if this is a feature change)?**
Force a line break regardless of length


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
