### PR TITLE
fix: getKeyByValue

### DIFF
--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -184,7 +184,7 @@ export function calcModFor(characteristic:number):number {
 
 export function getKeyByValue(object:{ [x:string]:unknown; }, value:unknown):string {
   //TODO This assumes I always find the value. Bad form really.
-  return <string>Object.keys(object).find(key => object[key] === value);
+  return <string>Object.keys(object).find(key => JSON.stringify(object[key]) === JSON.stringify(value));
 }
 
 export function getDataFromDropEvent(event:DragEvent):Record<string, any> {


### PR DESCRIPTION
Javascript comparison not working with mixed strings and numbers

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix: getKeyByValue function was not working if using a mixed string number comparison.  Fix courtesy of @jonepatr 


* **What is the current behavior?** (You can also link to an open issue here)
Can not call a characteristic roll and have the difficulty displayed correctly in chat


* **What is the new behavior (if this is a feature change)?**

Difficulty selected displays correctly.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
