### PR TITLE
fix: allow unattached skill rolls

### DIFF
--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -49,7 +49,7 @@ export class TwodsixDiceRoll {
     if (this.skill) {
       formula += "+ @skill";
       /*Check for "Untrained" value and use if better to account for JOAT*/
-      const joat = this.actor.getUntrainedSkill().data.data.value ?? game.system.template.Item.skills.value;
+      const joat = this.actor?.getUntrainedSkill().data.data.value ?? game.system.template.Item.skills.value;
       if (joat > this.skill.data.data.value) {
         data["skill"] = joat;
       } else {

--- a/src/module/utils/createItemMacro.ts
+++ b/src/module/utils/createItemMacro.ts
@@ -9,8 +9,16 @@ export async function createItemMacro(item, slot):Promise<void> {
   const command = `game.twodsix.rollItemMacro("${item.id ? item.id : item.data._id}");`;
   let macro = game.macros.entities.find((m) => (m.name === item.name) /*&& (m.data.command === command)*/);
   if (!macro) {
-    const itemName = item.name ? item.name : item.data.name;
-    const img = item.img ? item.img : item.data.img;
+    let itemName = item.name ? item.name : item.data?.name;
+    let img = item.img ? item.img : item.data?.img;
+
+    //handle case for unattached item
+    if (!itemName) {
+      const origItem = game.items.get(item.id);
+      itemName = origItem.name;
+      img = origItem.img;
+    }
+
     macro = await Macro.create({
       command: command,
       name: itemName,

--- a/src/module/utils/rollItemMacro.ts
+++ b/src/module/utils/rollItemMacro.ts
@@ -18,7 +18,7 @@ export async function rollItemMacro(itemId: string): Promise<void> {
   const item:TwodsixItem = actor ? actor.items.find((i) => i.id === itemId) : null;
   if (!item) {
     const unattachedItem:TwodsixItem = game.items.get(itemId);
-    if (unattachedItem.type != "weapon") {
+    if (unattachedItem?.type != "weapon" && !actor && unattachedItem) {
       await unattachedItem.skillRoll(true);
     } else {
       ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.ActorMissingItem").replace("_ITEM_ID_", itemId));

--- a/src/module/utils/rollItemMacro.ts
+++ b/src/module/utils/rollItemMacro.ts
@@ -17,7 +17,12 @@ export async function rollItemMacro(itemId: string): Promise<void> {
   }
   const item:TwodsixItem = actor ? actor.items.find((i) => i.id === itemId) : null;
   if (!item) {
-    ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.ActorMissingItem").replace("_ITEM_ID_", itemId));
+    const unattachedItem:TwodsixItem = game.items.get(itemId);
+    if (unattachedItem.type != "weapon") {
+      await unattachedItem.skillRoll(true);
+    } else {
+      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.ActorMissingItem").replace("_ITEM_ID_", itemId));
+    }
   } else {
     if (item.data.type != "weapon") {
       await item.skillRoll(false);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix - users want to be able to make skill rolls without having to create and control an actor (for the GM).


* **What is the current behavior?** (You can also link to an open issue here)
Unable to make skill rolls (using a macro) without an attached actor that is controlled


* **What is the new behavior (if this is a feature change)?**

Can create macro skill roll that works without an actor.  Create an skill (item), drag and drop item to macro bar - run macro results in dialog for a standard skill roll. _Does not work for a weapon._

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
