### PR TITLE
fix: background image not displaying correctly

### DIFF
--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -38,9 +38,9 @@
 
 body {
   background-image: url(../assets/workbg2.webp);
-  background-position: center;
+  /*background-position: center;
   background-repeat: no-repeat;
-  background-size: cover;
+  background-size: cover;*/
   font-family: "Asap-Regular";
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Background image does not fill active display area


* **What is the new behavior (if this is a feature change)?**

Background image now fills area, but is allowed to repeat.  Cover is not working to autofill.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
