### PR TITLE
fix: remove entity reference in createItemMacro

### DIFF
--- a/src/module/utils/createItemMacro.ts
+++ b/src/module/utils/createItemMacro.ts
@@ -7,18 +7,17 @@
  */
 export async function createItemMacro(item, slot):Promise<void> {
   const command = `game.twodsix.rollItemMacro("${item.id ? item.id : item.data._id}");`;
-  let macro = game.macros.entities.find((m) => (m.name === item.name) /*&& (m.data.command === command)*/);
+  let itemName = item.name ? item.name : item.data?.name;
+  let img = item.img ? item.img : item.data?.img;
+
+  //handle case for unattached item
+  if (!itemName) {
+    const origItem = game.items.get(item.id);
+    itemName = origItem.name;
+    img = origItem.img;
+  }
+  let macro = game.macros.getName(itemName);
   if (!macro) {
-    let itemName = item.name ? item.name : item.data?.name;
-    let img = item.img ? item.img : item.data?.img;
-
-    //handle case for unattached item
-    if (!itemName) {
-      const origItem = game.items.get(item.id);
-      itemName = origItem.name;
-      img = origItem.img;
-    }
-
     macro = await Macro.create({
       command: command,
       name: itemName,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)

createItemMacro include an "entity" reference.  No longer valid in FVTTv9

* **What is the new behavior (if this is a feature change)?**

Change to simple game.macros.getName() reference

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
