### PR TITLE
feat: use two separate initiative formulas for ships and travellers

### DIFF
--- a/src/module/entities/TwodsixCombatant.ts
+++ b/src/module/entities/TwodsixCombatant.ts
@@ -1,0 +1,9 @@
+export default class TwodsixCombatant extends Combatant {
+  protected _getInitiativeFormula():string {
+    if ((<TwodsixActor>this.actor).type === "ship") {
+      return <string>game.settings.get("twodsix", "shipInitiativeFormula");
+    } else {
+      return <string>game.settings.get("twodsix", "initiativeFormula");
+    }
+  }
+}

--- a/src/module/hooks/ready.ts
+++ b/src/module/hooks/ready.ts
@@ -11,12 +11,6 @@ Hooks.once("ready", async function () {
     }
   }
 
-  //Things that need to be done once settings have been set (and should probably be moved elsewhere...)
-  CONFIG.Combat.initiative = {
-    formula: (<string>game.settings.get("twodsix", "initiativeFormula")),
-    decimals: 0
-  };
-
   // Determine whether a system migration is required and feasible
 
   let worldVersion = <string>game.settings.get("twodsix", "systemMigrationVersion");

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -29,12 +29,12 @@ export default class RulesetSettings extends AdvancedSettings {
 
   static registerSettings(): string[] {
     const DEFAULT_INITIATIVE_FORMULA = "2d6 + @characteristics.dexterity.mod";
-    const onChangeInitformula = (formula: string) => CONFIG.Combat.initiative = {
-      formula: formula,
-      decimals: 0
-    };
+    // TODO: With the new ship positions this should be changed to take the pilot's piloting skill into consideration.
+    const DEFAULT_SHIP_INITIATIVE_FORMULA = "2d6";
+
     const settings: string[] = [];
-    settings.push(stringSetting('initiativeFormula', DEFAULT_INITIATIVE_FORMULA, false, 'world', onChangeInitformula));
+    settings.push(stringSetting('initiativeFormula', DEFAULT_INITIATIVE_FORMULA, false, 'world'));
+    settings.push(stringSetting('shipInitiativeFormula', DEFAULT_SHIP_INITIATIVE_FORMULA, false, 'world'));
     settings.push(stringChoiceSetting('difficultyListUsed', TWODSIX.RULESETS.CE.key, TWODSIX.VARIANTS));
     settings.push(booleanSetting('difficultiesAsTargetNumber', false));
     settings.push(stringChoiceSetting('autofireRulesUsed', TWODSIX.RULESETS.CE.key, TWODSIX.VARIANTS));

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -9,6 +9,7 @@
 
 import TwodsixActor from "./module/entities/TwodsixActor";
 import TwodsixItem from "./module/entities/TwodsixItem";
+import TwodsixCombatant from "./module/entities/TwodsixCombatant";
 import {TwodsixActorSheet} from "./module/sheets/TwodsixActorSheet";
 import {TwodsixShipSheet} from "./module/sheets/TwodsixShipSheet";
 import {TwodsixItemSheet} from "./module/sheets/TwodsixItemSheet";
@@ -57,17 +58,10 @@ Hooks.once('init', async function () {
   // Items
   CONFIG.Item.documentClass = TwodsixItem;
   Items.unregisterSheet("core", ItemSheet);
+  // @ts-ignore
   Items.registerSheet("twodsix", TwodsixItemSheet, {makeDefault: true});
 
-  /**
-   * Set an initiative formula for the system
-   * @type {String}
-   */
-  CONFIG.Combat.initiative = {
-    formula: "1d6",
-    decimals: 1
-  };
-
+  CONFIG.Combatant.documentClass = TwodsixCombatant;
   registerHandlebarsHelpers();
 
   registerSettings();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Previously there was only an initiative formula for travellers.



* **What is the new behavior (if this is a feature change)?**
This update allows for defining two independent initiative for
those actors.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
Fix #380