### PR TITLE
feat: allow for skill in roll formulas

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -50,6 +50,27 @@ export default class TwodsixActor extends Actor {
       characteristic.current = characteristic.value - characteristic.damage;
       characteristic.mod = calcModFor(characteristic.current);
     }
+    const actorSkills = actorData.items.filter(
+      (item:TwodsixItem) => item.type === "skills"
+    ).map(
+      (skill:TwodsixItem) => [TwodsixItem.simplifySkillName(skill.name ?? ""), (skill.data.data as Skills).value]
+    );
+
+    const handler = {
+      has: (target: Record<string,number>, property:string) => {
+        return property[property.length - 1] !== "_" ? true : property.slice(0, -1) in target;
+      },
+      get: (target: Record<string,number>, property:string) => {
+        if (property[property.length - 1] === "_") {
+          const newName = property[property.length - 1] === "_" ? property.slice(0, -1) : property;
+          return newName in target && target[newName] > 0 ? target[newName] : 0;
+        } else {
+          return property in target ? target[property] : (this.getUntrainedSkill().data.data as Skills).value;
+        }
+      }
+    };
+
+    data.skills = new Proxy(Object.fromEntries(actorSkills), handler);
   }
 
   protected async _onCreate() {

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -279,6 +279,10 @@ export default class TwodsixItem extends Item {
     }
   }
 
+  public static simplifySkillName(skillName:string): string {
+    return skillName.replace(/\W/g, "");
+  }
+
   //////// CONSUMABLE ////////
   public async consume(quantity: number): Promise<void> {
     const consumableLeft = (<Consumable>this.data.data).currentCount - quantity;

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -138,6 +138,14 @@ export default function registerHandlebarsHelpers(): void {
     return game.settings.get('twodsix', 'alternativeShort2');
   });
 
+  Handlebars.registerHelper('skillName', (skillName) => {
+    return TwodsixItem.simplifySkillName(skillName);
+  });
+
+  Handlebars.registerHelper('replace', (text, key, value) => {
+    return text.replaceAll(key, value);
+  });
+
   Handlebars.registerHelper('twodsix_getComponentIcon', (componentType: string) => {
     switch (componentType) {
       case 'accomodations':

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -223,6 +223,8 @@
         "SOC": "SOC",
         "STR": "STR",
         "SkillName": "Skill Name",
+        "SimplifiedSkillName": "Simplified Skill Name",
+        "SimplifiedSkillNameDescription": "Used in roll formulas as @skills._SKILL_NAME_.<br>@skills._SKILL_NAME__ defaults to zero if the skill is missing or below zero.",
         "LFB": "LFB",
         "STA": "STA",
         "ALT1": "ALT1",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1077,6 +1077,13 @@ span.total-output {
   padding: 0.2em 0.2em 0.2em 0.5em;
 }
 
+.simplified-skill-description {
+  font-weight: normal;
+  font-size: 10px;
+  text-align: left;
+  margin-bottom: 10px;
+}
+
 /*-------Info Tab-----------*/
 
 .info-container {

--- a/static/templates/items/skills-sheet.html
+++ b/static/templates/items/skills-sheet.html
@@ -16,6 +16,13 @@
           </th>
         </tr>
       </table>
+      <div class="item-name">
+        <label for="data.name">{{localize "TWODSIX.Items.Skills.SimplifiedSkillName"}}:</label>
+        <input type="text" value="{{skillName name}}" readonly/>
+        <div class="simplified-skill-description">
+          {{{replace (localize "TWODSIX.Items.Skills.SimplifiedSkillNameDescription") "_SKILL_NAME_" (skillName name)}}}
+        </div>
+      </div>
     </div>
     <div class="item-lvl">
       <label for="data.value" class="resource-label">{{localize "TWODSIX.Items.Skills.Level"}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Previously one could not use skills in roll formulas.


* **What is the new behavior (if this is a feature change)?**
This change allows for using skills in roll formulas.
Spaces are remove from skill names, thus Gun Combat becomes GunCombat.
Normally the setting for untrained skill value is returned when an actor
lacks the skill. Adding an undnerscore (_) at the end of the name will make the
skill default to 0 if it doesn't exist or for a negative value.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
