### PR TITLE
feature: Sub menus for settings

### DIFF
--- a/src/module/AdvancedSettings.ts
+++ b/src/module/AdvancedSettings.ts
@@ -1,0 +1,44 @@
+export default class AdvancedSettings extends FormApplication {
+    settings = [];
+    intro = "";
+
+    /** @override */
+    // @ts-ignore
+    static get defaultOptions(): FormApplicationOptions {
+        // @ts-ignore
+        return mergeObject(super.defaultOptions, {
+            classes: ["twodsix"],
+            template: "systems/twodsix/templates/misc/advanced-settings.html",
+            width: 600
+        });
+    }
+
+    /** @override */
+    getData(): any {
+        const data: any = super.getData();
+
+        const settings = this.settings.map((settingName) => {
+            const setting = game.settings.settings.get("twodsix." + settingName);
+            setting["value"] = game.settings.get(setting.namespace, settingName);
+            if (setting.choices) {
+                setting["htmlType"] = "Select";
+            } else {
+                setting["htmlType"] = setting.type.name;
+            }
+            return [settingName, setting];
+        });
+        data.intro = this.intro;
+        data.settings = Object.fromEntries(settings);
+        return data;
+    }
+
+    async _updateObject(event, formData): Promise<void> {
+        if (event.submitter.name === "submit") {
+            console.log(formData)
+            Object.entries(formData).forEach(([key, value]) => {
+                game.settings.set("twodsix", key, value);
+            });
+        }
+        return Promise.resolve();
+    }
+}

--- a/src/module/hooks/renderSettingsConfig.ts
+++ b/src/module/hooks/renderSettingsConfig.ts
@@ -14,20 +14,19 @@ function createWarningDialog(event:Event, message:string) {
 }
 
 Hooks.on('renderSettingsConfig', async (app, html) => {
-  html.find('[name="twodsix.ruleset"]').on('change', ev => {
-    const ruleset = ev.target.value;
-    const rulesetSettings = TWODSIX.RULESETS[ruleset].settings;
-
-    // Step through each option and update the corresponding field
-    Object.entries(rulesetSettings).forEach(([settingName, value]) => {
-      console.log(`${ruleset} ${settingName} = ${value}`);
-      const setting = html.find(`[name="twodsix.${settingName}"]`);
-      if (!setting.is(':checkbox')) {
-        setting.val(value);
-      } else {
-        setting.prop('checked', Boolean(value));
+  html.find('[name="twodsix.ruleset"]').on('change', async ev => {
+    if (await Dialog.confirm({title: "Change ruleset", content: "Do you want to change ruleset? If you have custom options they will be erased. This step cannot be undone."})) {
+      const ruleset = ev.target.value;
+      const rulesetSettings = TWODSIX.RULESETS[ruleset].settings;
+      game.settings.set("twodsix", "ruleset", ruleset);
+      if (ruleset !== "OTHER") {
+        // Step through each option and update the corresponding field
+        Object.entries(rulesetSettings).forEach(([settingName, value]) => {
+          game.settings.set("twodsix", settingName, value);
+          console.log(`${ruleset} ${settingName} = ${value}`);
+        });
       }
-    });
+    }
   });
 
   html.find('[name="twodsix.hideUntrainedSkills"]').on('click', async (event:Event) => {

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -1,11 +1,83 @@
+import AdvancedSettings from "./AdvancedSettings";
 import {TWODSIX} from "./config";
 import TwodsixActor from "./entities/TwodsixActor";
 
+class RulesetSettings extends AdvancedSettings {
+  static settings = ["initiativeFormula", "difficultyListUsed", "difficultiesAsTargetNumber", "autofireRulesUsed", "modifierForZeroCharacteristic", "termForAdvantage",
+    "termForDisadvantage", "absoluteBonusValueForEachTimeIncrement", 'maxSkillLevel', "criticalNaturalAffectsEffect", "absoluteCriticalEffectValue", "showLifebloodStamina",
+    "lifebloodInsteadOfCharacteristics", "showContaminationBelowLifeblood", 'showHeroPoints', 'showAlternativeCharacteristics', "alternativeShort1", "alternativeShort2"];
+  constructor() {
+    super();
+    const ruleset = TWODSIX.RULESETS[game.settings.get("twodsix", "ruleset")].name;
+    this.intro = `<h2>Current rules: ${ruleset}</h2><br>`;
+    this.settings = RulesetSettings.settings;
+  }
+}
+
+class ItemSettings extends AdvancedSettings {
+  static settings = ["ShowLawLevel", "ShowRangeBandAndHideRange", "ShowWeaponType", "ShowDamageType", "ShowRateOfFire", "ShowRecoil"];
+  constructor() {
+    super();
+    this.intro = `<h2>Item Display Settings</h2><br>`;
+    this.settings = ItemSettings.settings;
+  }
+}
+
+class DisplaySettings extends AdvancedSettings {
+  static settings = ['defaultTokenSettings', 'useSystemDefaultTokenIcon', 'showMissingCompendiumWarnings', 'showSingleComponentColumn', 'useFoundryStandardStyle','useWoundedStatusIndicators' ];
+  constructor() {
+    super();
+    this.intro = `<h2>General Display Settings</h2><br>`;
+    this.settings = DisplaySettings.settings;
+  }
+}
+class DebugSettings extends AdvancedSettings {
+  static settings = ['ExperimentalFeatures', 'systemMigrationVersion'];
+  constructor() {
+    super();
+    this.intro = `<h2>Debug Settings</h2><br>`;
+    this.settings = DebugSettings.settings;
+  }
+}
 export const registerSettings = function ():void {
 
-  //Foundry default behaviour related settings
-  _booleanSetting('defaultTokenSettings', true);
-  _booleanSetting('useSystemDefaultTokenIcon', false);
+  const advancedSettings = RulesetSettings.settings.concat(ItemSettings.settings).concat(DisplaySettings.settings).concat(DebugSettings.settings);
+
+  game.settings.registerMenu("twodsix", "rulesetSettings", {
+    name: "Advanced Ruleset Settings",
+    label: "Advanced Ruleset Settings",
+    hint: "Here you can configure the ruleset settings.",
+    icon: "fas fa-gavel",
+    type: RulesetSettings,
+    restricted: true
+  });
+
+  game.settings.registerMenu("twodsix", "itemSettings", {
+    name: "Item Settings",
+    label: "Item Settings",
+    hint: "Here you can configure the item settings.",
+    icon: "fas fa-bars",
+    type: ItemSettings,
+    restricted: true
+  });
+
+  game.settings.registerMenu("twodsix", "displaySettings", {
+    name: "Display Settings",
+    label: "Display Settings",
+    hint: "Here you can configure the display settings.",
+    icon: "fas fa-tv",
+    type: DisplaySettings,
+    restricted: true
+  });
+
+  game.settings.registerMenu("twodsix", "debugSettings", {
+    name: "Debug Settings",
+    label: "Debug Settings",
+    hint: "Here you can configure the debug settings / information.",
+    icon: "fas fa-bug",
+    type: DebugSettings,
+    restricted: true
+  });
 
   const rulesetOptions = Object.entries(TWODSIX.RULESETS).map(([id, ruleset]) => {
     return [id, ruleset["name"]];
@@ -18,8 +90,11 @@ export const registerSettings = function ():void {
     }
     return 0;
   });
-
   _stringChoiceSetting('ruleset', TWODSIX.RULESETS["CE"].name, Object.fromEntries(rulesetOptions));
+
+  //Foundry default behaviour related settings
+  _booleanSetting('defaultTokenSettings', true);
+  _booleanSetting('useSystemDefaultTokenIcon', false);
 
   //House rules/variant related settings
   const DEFAULT_INITIATIVE_FORMULA = "2d6 + @characteristics.dexterity.mod";
@@ -85,7 +160,7 @@ export const registerSettings = function ():void {
       name: game.i18n.localize(`TWODSIX.Settings.${key}.name`),
       hint: game.i18n.localize(`TWODSIX.Settings.${key}.hint`),
       scope: scope,
-      config: true,
+      config: !advancedSettings.includes(key),
       default: defaultValue,
       type: Boolean,
       onChange: onChange
@@ -97,7 +172,7 @@ export const registerSettings = function ():void {
       name: game.i18n.localize(`TWODSIX.Settings.${key}.name`),
       hint: game.i18n.localize(`TWODSIX.Settings.${key}.hint`),
       scope: scope,
-      config: true,
+      config: !advancedSettings.includes(key),
       default: defaultValue,
       type: Number,
       onChange: onChange
@@ -109,7 +184,7 @@ export const registerSettings = function ():void {
       name: game.i18n.localize(`TWODSIX.Settings.${key}.name`),
       hint: game.i18n.localize(`TWODSIX.Settings.${key}.hint`),
       scope: scope,
-      config: true,
+      config: !advancedSettings.includes(key),
       default: defaultValue,
       type: String,
       onChange: onChange,
@@ -122,7 +197,7 @@ export const registerSettings = function ():void {
       name: game.i18n.localize(`TWODSIX.Settings.${key}.name`),
       hint: game.i18n.localize(`TWODSIX.Settings.${key}.hint`),
       scope: scope,
-      config: true,
+      config: !advancedSettings.includes(key),
       default: defaultValue,
       type: String,
       onChange: onChange

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -9,7 +9,7 @@ class RulesetSettings extends AdvancedSettings {
   constructor() {
     super();
     const ruleset = TWODSIX.RULESETS[game.settings.get("twodsix", "ruleset")].name;
-    this.intro = `<h2>Current rules: ${ruleset}</h2><br>`;
+    this.intro = `<h2>${game.i18n.localize(`TWODSIX.Settings.settingsInterface.rulesetSettings.intro`)}: ${ruleset}</h2><br>`;
     this.settings = RulesetSettings.settings;
   }
 }
@@ -18,7 +18,7 @@ class ItemSettings extends AdvancedSettings {
   static settings = ["ShowLawLevel", "ShowRangeBandAndHideRange", "ShowWeaponType", "ShowDamageType", "ShowRateOfFire", "ShowRecoil"];
   constructor() {
     super();
-    this.intro = `<h2>Item Display Settings</h2><br>`;
+    this.intro = `<h2>${game.i18n.localize(`TWODSIX.Settings.settingsInterface.itemSettings.intro`)}</h2><br>`;
     this.settings = ItemSettings.settings;
   }
 }
@@ -27,7 +27,7 @@ class DisplaySettings extends AdvancedSettings {
   static settings = ['defaultTokenSettings', 'useSystemDefaultTokenIcon', 'showMissingCompendiumWarnings', 'showSingleComponentColumn', 'useFoundryStandardStyle','useWoundedStatusIndicators' ];
   constructor() {
     super();
-    this.intro = `<h2>General Display Settings</h2><br>`;
+    this.intro = `<h2>${game.i18n.localize(`TWODSIX.Settings.settingsInterface.displaySettings.intro`)}</h2><br>`;
     this.settings = DisplaySettings.settings;
   }
 }
@@ -35,7 +35,7 @@ class DebugSettings extends AdvancedSettings {
   static settings = ['ExperimentalFeatures', 'systemMigrationVersion'];
   constructor() {
     super();
-    this.intro = `<h2>Debug Settings</h2><br>`;
+    this.intro = `<h2>${game.i18n.localize(`TWODSIX.Settings.settingsInterface.debugSettings.intro`)}</h2><br>`;
     this.settings = DebugSettings.settings;
   }
 }
@@ -44,36 +44,36 @@ export const registerSettings = function ():void {
   const advancedSettings = RulesetSettings.settings.concat(ItemSettings.settings).concat(DisplaySettings.settings).concat(DebugSettings.settings);
 
   game.settings.registerMenu("twodsix", "rulesetSettings", {
-    name: "Advanced Ruleset Settings",
-    label: "Advanced Ruleset Settings",
-    hint: "Here you can configure the ruleset settings.",
+    name: game.i18n.localize(`TWODSIX.Settings.settingsInterface.rulesetSettings.name`),
+    label: game.i18n.localize(`TWODSIX.Settings.settingsInterface.rulesetSettings.name`),
+    hint: game.i18n.localize(`TWODSIX.Settings.settingsInterface.rulesetSettings.hint`),
     icon: "fas fa-gavel",
     type: RulesetSettings,
     restricted: true
   });
 
   game.settings.registerMenu("twodsix", "itemSettings", {
-    name: "Item Settings",
-    label: "Item Settings",
-    hint: "Here you can configure the item settings.",
+    name: game.i18n.localize(`TWODSIX.Settings.settingsInterface.itemSettings.name`),
+    label: game.i18n.localize(`TWODSIX.Settings.settingsInterface.itemSettings.name`),
+    hint: game.i18n.localize(`TWODSIX.Settings.settingsInterface.itemSettings.hint`),
     icon: "fas fa-bars",
     type: ItemSettings,
     restricted: true
   });
 
   game.settings.registerMenu("twodsix", "displaySettings", {
-    name: "Display Settings",
-    label: "Display Settings",
-    hint: "Here you can configure the display settings.",
+    name: game.i18n.localize(`TWODSIX.Settings.settingsInterface.displaySettings.name`),
+    label: game.i18n.localize(`TWODSIX.Settings.settingsInterface.displaySettings.name`),
+    hint: game.i18n.localize(`TWODSIX.Settings.settingsInterface.displaySettings.hint`),
     icon: "fas fa-tv",
     type: DisplaySettings,
     restricted: true
   });
 
   game.settings.registerMenu("twodsix", "debugSettings", {
-    name: "Debug Settings",
-    label: "Debug Settings",
-    hint: "Here you can configure the debug settings / information.",
+    name: game.i18n.localize(`TWODSIX.Settings.settingsInterface.debugSettings.name`),
+    label: game.i18n.localize(`TWODSIX.Settings.settingsInterface.debugSettings.name`),
+    hint: game.i18n.localize(`TWODSIX.Settings.settingsInterface.debugSettings.hint`),
     icon: "fas fa-bug",
     type: DebugSettings,
     restricted: true

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -79,6 +79,7 @@ Hooks.once('init', async function () {
 
   const templatePaths = [
     //TODO Set up so the templates are instead loaded during build (or possibly during startup?), using all html files in the templates folder
+    "systems/twodsix/templates/misc/advanced-settings.html",
     "systems/twodsix/templates/actors/actor-sheet.html",
     "systems/twodsix/templates/actors/damage-dialog.html",
     "systems/twodsix/templates/actors/ship-sheet.html",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -487,6 +487,28 @@
       "useWoundedStatusIndicators": {
         "hint": "Uses status indicators to indicate wounded status and automatically roll unconcious saves on serious wounds.",
         "name": "Display wounded status indicators"
+      },
+      "settingsInterface": {
+        "rulesetSettings": {
+          "intro": "Current Rules",
+          "name": "Advanced Ruleset Settings",
+          "hint": "Configure the ruleset settings."
+        },
+        "itemSettings": {
+          "intro": "Item Settings",
+          "name": "Item Settings",
+          "hint": "Configure the item fields that are shown."
+        },
+        "displaySettings": {
+          "intro": "Display Settings",
+          "name": "Display Settings",
+          "hint": "Configure the display settings."
+        },
+        "debugSettings": {
+          "intro": "Debug Settings",
+          "name": "Debug Settings",
+          "hint": "Configure/View the debug settings."
+        }
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -256,6 +256,10 @@ form .form-group, form .form-group-stacked {
   color: var(--light-color) !important;
 }
 
+form .form-group > label {
+  flex: 4;
+}
+
 form .form-group span.units {
   flex: 0;
   line-height: 28px;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -328,7 +328,7 @@ span.stat-ability {
 
 span.stat-ability-table {
   text-align: center !important;
-  position: relative; 
+  position: relative;
 }
 
 span.stat-modifier {
@@ -1235,14 +1235,14 @@ a.ship-crew-tab, a.ship-storage-tab, a.ship-cargo-tab, a.ship-finance-tab, a.shi
 }
 
 a.ship-crew-tab:hover, a.ship-storage-tab:hover, a.ship-cargo-tab:hover, a.ship-finance-tab:hover, a.ship-notes-tab:hover {
-  
+
   color: var(--item-hover);
   background-color: var(--background-semi-opaque);
   border-radius: 1ch;
 }
 
 a.ship-crew-tab.active, a.ship-storage-tab.active, a.ship-cargo-tab.active, a.ship-finance-tab.active, a.ship-notes-tab.active {
-  
+
   color: var(--item-hover);
   text-shadow: none !important;
   background-color: var(--background-nearly-opaque);
@@ -1871,6 +1871,10 @@ div.app.window-app.twodsix.ship.actor header a.close {
   margin-top: 1.5em;
 }
 */
+form .form-group > label {
+  flex: 4;
+}
+
 /* EDITOR */
 
 .editor {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1230,8 +1230,9 @@ input.power-total {
 a.ship-crew-tab, a.ship-storage-tab, a.ship-cargo-tab, a.ship-finance-tab, a.ship-notes-tab {
   /*display: block;*/
   border: solid;
-  border-radius: 1ch;
+  border-radius: 2ch;
   vertical-align: middle;
+  padding: 0.2em 1em;
 }
 
 a.ship-crew-tab:hover, a.ship-storage-tab:hover, a.ship-cargo-tab:hover, a.ship-finance-tab:hover, a.ship-notes-tab:hover {
@@ -1539,9 +1540,9 @@ button.flexrow.flex-group-center.toggle-skills {
   height: 2em;
 }
 
-.tabs .item.active {
+/*.tabs .item.active {
   text-shadow: 0 0 10px !important;
-}
+}*/
 
 /* ------ Item page - Consumables ------ */
 .consumable-row {

--- a/static/templates/misc/advanced-settings.html
+++ b/static/templates/misc/advanced-settings.html
@@ -1,0 +1,39 @@
+<form>
+    {{{intro}}}
+    {{#each settings as |setting key|}}
+        <div class="form-group">
+            <label>{{{localize setting.name}}}</label>
+            <div class="form-fields">
+                {{#iff setting.htmlType "===" "Number"}}
+                <input type="number" name="{{key}}" value="{{setting.value}}" data-dtype="Number">
+                {{/iff}}
+                {{#iff setting.htmlType "===" "String"}}
+                <input type="text" name="{{key}}" value="{{setting.value}}" data-dtype="String">
+                {{/iff}}
+
+                {{#iff setting.htmlType "===" "Select"}}
+                <select name="{{key}}" data-dtype="String" value="{{setting.value}}">
+                    {{#each setting.choices as |choice choiceKey|}}
+                        {{#select setting.value}}
+                        <option value="{{choiceKey}}">{{choice}}</option>
+                        {{/select}}
+                    {{/each}}
+                </select>
+                {{/iff}}
+
+                {{#iff setting.htmlType "===" "Boolean"}}
+                <input type="checkbox" name="{{key}}" data-dtype="Boolean" {{#if setting.value}}checked{{/if}}>
+                {{/iff}}
+            </div>
+            <p class="notes">{{{localize setting.hint}}}</p>
+        </div>
+    {{/each}}
+    <footer class="sheet-footer flexrow">
+      <button type="submit" name="submit">
+          <i class="far fa-save"></i> Save Changes
+      </button>
+      <button type="button" name="reset">
+          <i class="fas fa-undo"></i> Reset Defaults
+      </button>
+    </footer>
+</form>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Previously all settings were placed on one settings page.


* **What is the new behavior (if this is a feature change)?**
This change allows for creating sub pages for settings.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Fix #183