### PR TITLE
fix: use correct cepheus deluxe initiative formula

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -150,7 +150,7 @@ const RULESETS = Object.freeze({
     key: "CD",
     name: "Cepheus Deluxe",
     settings: {
-      initiativeFormula: "2d6",
+      initiativeFormula: "2d6 + @skills.Tactics_ + @characteristics.intelligence.mod",
       difficultyListUsed: "CE",
       difficultiesAsTargetNumber: true,
       autofireRulesUsed: "CEL",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
previously the cepheus deluxe initiative was 2d6.


* **What is the new behavior (if this is a feature change)?**
This change sets it to 2d6 + @skills.Tactics_ + @characteristics.intelligence.mod


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
