### PR TITLE
Change to always use the tag rather than latest

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -20,4 +20,4 @@ plugins:
         - dist/system.json
         - dist/twodsix.zip
 preset: angular
-branches: ['+([0-9])?(.{+([0-9]),x}).x', 'master', {name: 'foundry-0.81', prerelease: true}]
+branches: ['+([0-9])?(.{+([0-9]),x}).x', 'master', {name: 'development', prerelease: true}]

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -1,9 +1,7 @@
 SEARCH_PATTERN='(\s\"(manifest|download)\"\: \"https:\/\/github.com\/xdy\/twodsix-foundryvtt\/releases\/).*(\/(system.json|twodsix.zip)\",)'
 DEVELOPMENT_REPLACE="\1download/v$1\3"
-MASTER_REPLACE="\1latest/download\3"
 
-sed -i -e 's|\(.*"version"\): "\(.*\)",.*|\1: '"\"$1\",|" static/system.json &&
-  if echo "$1" | grep -q "foundry-0.81"; then sed -i -r  s"~$SEARCH_PATTERN~$DEVELOPMENT_REPLACE~" static/system.json; else sed -i -r s"~$SEARCH_PATTERN~$MASTER_REPLACE~" static/system.json; fi &&
+  sed -i -r  s"~$SEARCH_PATTERN~$DEVELOPMENT_REPLACE~" static/system.json &&
   cp static/system.json dist &&
   sed -i -e 's|\(.*"version"\): "\(.*\)",.*|\1: '"\"$1\",|" package.json &&
   npm install &&


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)
No

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Changes the manifest to always point to the tagged release rather than the latest one.


* **What is the current behavior?** (You can also link to an open issue here)
All releases actually point to latest.


* **What is the new behavior (if this is a feature change)?**
It should be possible to install old versions.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Hopefully not...


* **Other information**:
n/a