### PR TITLE
fix: drag and drop macro onto macro bar

### DIFF
--- a/src/module/utils/createItemMacro.ts
+++ b/src/module/utils/createItemMacro.ts
@@ -18,9 +18,9 @@ export async function createItemMacro(item, slot): Promise<void> {
     if (!itemName) {
       const origItem = <Item>game.items?.get(item.id);
       itemName = origItem?.name || "???";
-      img = origItem?.img || "icons/svg/mystery-man.svg";
+      img = origItem?.img || CONST.DEFAULT_MACRO_ICON;
     }
-    let macro: Macro | undefined = game.macros?.get(itemName);
+    let macro: Macro | undefined = game.macros?.getName(itemName);
     if (!macro) {
       macro = await Macro.create({
         command: command,

--- a/src/module/utils/createItemMacro.ts
+++ b/src/module/utils/createItemMacro.ts
@@ -6,27 +6,30 @@
  * @param {number} slot     The hotbar slot to use
  * @returns {Promise}
  */
-export async function createItemMacro(item, slot):Promise<void> {
-  const command = `game.twodsix.rollItemMacro("${item.id ? item.id : item.data._id}");`;
-  let itemName = item.name ? item.name : item.data?.name;
-  let img = item.img ? item.img : item.data?.img;
+export async function createItemMacro(item, slot): Promise<void> {
+  if (item.type === "Macro") {
+    await game.user?.assignHotbarMacro(game.macros.get(item.id), slot);
+  } else {
+    const command = `game.twodsix.rollItemMacro("${item.id ? item.id : item.data._id}");`;
+    let itemName = item.name ? item.name : item.data?.name;
+    let img = item.img ? item.img : item.data?.img;
 
-  //handle case for unattached item
-  if (!itemName) {
-    const origItem = <Item>game.items?.get(item.id);
-    itemName = origItem?.name || "???";
-    img = origItem?.img || "icons/svg/mystery-man.svg";
-  }
-  let macro: Macro|undefined = game.macros?.get(itemName);
-  if (!macro) {
-    macro = await Macro.create({
-      command: command,
-      name: itemName,
-      type: 'script',
-      img: img,
-      flags: {'twodsix.itemMacro': true},
-    }, {renderSheet: false}) as Macro;
-
+    //handle case for unattached item
+    if (!itemName) {
+      const origItem = <Item>game.items?.get(item.id);
+      itemName = origItem?.name || "???";
+      img = origItem?.img || "icons/svg/mystery-man.svg";
+    }
+    let macro: Macro | undefined = game.macros?.get(itemName);
+    if (!macro) {
+      macro = await Macro.create({
+        command: command,
+        name: itemName,
+        type: 'script',
+        img: img,
+        flags: { 'twodsix.itemMacro': true },
+      }, { renderSheet: false }) as Macro;
+    }
     await game.user?.assignHotbarMacro(macro, slot);
   }
 }


### PR DESCRIPTION
Current code forces it to be a rollItemMacro

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When macros are dropped onto macro bar, they are recast to rollItemMacros (scripts)


* **What is the new behavior (if this is a feature change)?**
If item is already a macro, leave it as a macro


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
