### PR TITLE
fix: calculate armor correctly

### DIFF
--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -293,7 +293,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       if (sheetData.actor.type === "traveller") {
         encumbrance += AbstractTwodsixActorSheet._getWeight(item);
         const anArmor = <Armor>item.data.data;
-        if (item.type === "armor" && anArmor.equipped) {
+        if (item.type === "armor" && anArmor.equipped === "equipped") {
           primaryArmor += anArmor.armor;
           secondaryArmor += anArmor.secondaryArmor.value;
           radiationProtection += anArmor.radiationProtection.value;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
all armor in inventory counts towards equipped value


* **What is the new behavior (if this is a feature change)?**
only armor being worn


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
IMPORTANT - the linter / type check shows an error.  It thinks the variable item.data.data.equipped is binary where it is actually a string.