### PR TITLE
fix: eliminate component icons from rows

### DIFF
--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1669,10 +1669,10 @@ a.ship-notes-tab.active {
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 10em 12em 3em 3em 3.5em 3em 3.5em 3.5em 4.5em 3.5em 3em;
+  grid-template-columns: 11em 14em 3em 3.5em 3em 3.5em 3.5em 4.5em 3.5em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
-  grid-template-areas: ". . . . . . . . . . .";
+  grid-template-areas: ". . . . . . . . . .";
 }
 
 .grid-columns-single-row:nth-of-type(even) {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1398,10 +1398,10 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 10em 12em 3em 3em 3.5em 3em 3.5em 3.5em 4.5em 3.5em 3em;
+  grid-template-columns: 11em 14em 3em 3.5em 3em 3.5em 3.5em 4.5em 3.5em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
-  grid-template-areas: ". . . . . . . . . . .";
+  grid-template-areas: ". . . . . . . . . .";
 }
 .grid-columns-single-row:nth-of-type(even) {
   background: var(--s2d6-skill-list-even);

--- a/static/templates/actors/parts/ship/ship-components-double.html
+++ b/static/templates/actors/parts/ship/ship-components-double.html
@@ -2,7 +2,7 @@
   <div class="grid-columns-double storage-header">
     <div class="components-stored-double ">
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
-      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.rating"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.status"}}</span>
@@ -11,7 +11,7 @@
     </div>
     <div class="components-stored-double ">
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
-      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.rating"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.status"}}</span>
@@ -19,13 +19,11 @@
         class="fas fa-plus"></i></a></span>
     </div>
   </div>
-  
+
     {{#each component}}
     <div class="grid-columns-single">
-      <div class="grid-columns-single-row">
-        <ol class="ol-no-indent header-row" >
-          --- {{twodsix_capitalize (localize (concat "TWODSIX.Items.Component." @key))}} ---
-        </ol>
+        <div class="grid-columns-single-row">
+          <ol class="ol-no-indent header-row"><i class= '{{twodsix_getComponentIcon @key}}' title='{{localize (concat "TWODSIX.Items.Component." @key)}}'></i> {{twodsix_capitalize (localize (concat "TWODSIX.Items.Component." @key))}}</ol>
       </div>
     </div>
     <div class="grid-columns-double">
@@ -34,9 +32,7 @@
       <ol class="ol-no-indent">
         <li class="item components-stored-double" data-item-id="{{item.id}}">
           <span class="item-name">{{item.name}}</span>
-          <span class="item-name centre">
-            <i class= '{{twodsix_getComponentIcon item.data.data.subtype}}' title='{{localize (concat "TWODSIX.Items.Component." item.data.data.subtype)}}'></i>
-          </span>
+          <span class="item-name centre">{{item.data.data.availableQuantity}}/{{item.data.data.quantity}}</span>
           <span class="item-name centre">{{item.data.data.techLevel}}</span>
           <span class="item-name centre">{{item.data.data.rating}}</span>
           <span class="item-name centre component-toggle">
@@ -64,5 +60,5 @@
     {{/if}}
     </div>
     {{/each}}
-  
+
 </div>

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -3,7 +3,6 @@
     <div class="components-stored-single ">
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.ShortDescr"}}</span>
-      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.rating"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
@@ -19,7 +18,7 @@
   <div class="grid-columns-single">
     {{#each component}}
     <div class="grid-columns-single-row">
-       <ol class="ol-no-indent header-row">--- {{twodsix_capitalize (localize (concat "TWODSIX.Items.Component." @key))}} ---</ol>
+       <ol class="ol-no-indent header-row"><i class= '{{twodsix_getComponentIcon @key}}' title='{{localize (concat "TWODSIX.Items.Component." @key)}}'></i> {{twodsix_capitalize (localize (concat "TWODSIX.Items.Component." @key))}}</ol>
     </div>
     {{#each this as |item id|}}
     <div class="grid-columns-single-row">
@@ -27,9 +26,6 @@
         <li class="item components-stored-single " data-item-id="{{item.id}}">
           <span class="item-name">{{item.name}}</span>
           <span class="item-name">{{item.data.data.shortdescr}}</span>
-          <span class="item-name centre">
-            <i class= '{{twodsix_getComponentIcon item.data.data.subtype}}' title='{{localize (concat "TWODSIX.Items.Component." item.data.data.subtype)}}'></i>
-          </span>
           <span class="item-name centre">{{item.data.data.techLevel}}</span>
           <span class="item-name centre">{{item.data.data.rating}}</span>
           <span class="item-name centre">{{item.data.data.weight}}</span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
format change


* **What is the current behavior?** (You can also link to an open issue here)
Ship component icons re shown for each item


* **What is the new behavior (if this is a feature change)?**
Only show icons for header rows


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
