### PR TITLE
feature: add optional stylesheet

### DIFF
--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -42,18 +42,13 @@ export const registerSettings = function ():void {
   }
 };
 
-export function switchCss() {
+export function switchCss(fileName:string) {
   const head = document.getElementsByTagName("head")[0];
   const mainCss = document.createElement("link");
-  let sheetName = "systems/twodsix/styles/";
-  if (game.settings.get('twodsix', 'useFoundryStandardStyle')) {
-    sheetName += "twodsix_basic.css";
-  } else {
-    sheetName += "twodsix.css";
-  }
+
   mainCss.setAttribute("rel", "stylesheet");
   mainCss.setAttribute("type", "text/css");
-  mainCss.setAttribute("href", sheetName);
+  mainCss.setAttribute("href", fileName);
   mainCss.setAttribute("media", "all");
   head.insertBefore(mainCss, head.lastChild);
 }

--- a/src/module/settings/DebugSettings.ts
+++ b/src/module/settings/DebugSettings.ts
@@ -1,5 +1,6 @@
 import AdvancedSettings from "./AdvancedSettings";
 import {booleanSetting, stringSetting} from "./settingsUtils";
+import {refreshWindow} from "./DisplaySettings";
 
 export default class DebugSettings extends AdvancedSettings {
   static create() {
@@ -22,6 +23,7 @@ export default class DebugSettings extends AdvancedSettings {
     const settings: string[] = [];
     settings.push(booleanSetting('ExperimentalFeatures', false));
     settings.push(stringSetting('systemMigrationVersion', game.system.data.version));
+    settings.push(booleanSetting('useModuleFixStyle', false, false, 'world', refreshWindow));
     return settings;
   }
 }

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -19,10 +19,7 @@ export default class DisplaySettings extends AdvancedSettings {
   }
 
   static registerSettings(): string[] {
-    const refreshWindow = function () {
-      /*switchCss();*/
-      window.location.reload();
-    };
+
     const settings: string[] = [];
     settings.push(booleanSetting('defaultTokenSettings', true));
     settings.push(booleanSetting('useSystemDefaultTokenIcon', false));
@@ -34,3 +31,7 @@ export default class DisplaySettings extends AdvancedSettings {
     return settings;
   }
 }
+export const refreshWindow = function () {
+  /*switchCss();*/
+  window.location.reload();
+};

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -68,7 +68,19 @@ Hooks.once('init', async function () {
 
   registerSettings();
 
-  switchCss();
+  /*Register CSS Styles*/
+  let sheetName = "systems/twodsix/styles/";
+  if (game.settings.get('twodsix', 'useFoundryStandardStyle')) {
+    sheetName += "twodsix_basic.css";
+  } else {
+    sheetName += "twodsix.css";
+  }
+  switchCss(sheetName);
+
+  if (game.settings.get('twodsix', 'useModuleFixStyle') && !game.settings.get('twodsix', 'useFoundryStandardStyle')) {
+    switchCss("systems/twodsix/styles/twodsix_moduleFix.css");
+  }
+
 
   //@ts-ignore
   await loadTemplates(handlebarsTemplateFiles);

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -518,6 +518,10 @@
         "hint": "Uses status indicators to indicate wounded status and automatically roll unconcious saves on serious wounds.",
         "name": "Display wounded status indicators"
       },
+      "useModuleFixStyle": {
+        "hint": "Modifies CSS style to correct idetified style issues for certain modules when using the Twodsix style.  It doesn't work when using Foundry default style.",
+        "name": "Correct some css style issues due to modules and default Twodsix style."
+      },
       "settingsInterface": {
         "rulesetSettings": {
           "intro": "Current Rules",

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -1,0 +1,33 @@
+/* Custom CSS */
+
+/*fix in default fvtt for item images not preserving aspect ratio*/
+.item-img {
+	object-fit: contain;
+}
+
+/* fix for dice-tray input box shift for default mode*/
+input.dice-tray__input {
+    margin-top: 8px;
+}
+
+/* Fix GM Screen background for dark formats*/
+.gm-screen-app, .gm-screen-actions button  {
+  background: #0d0d0d !important;
+}
+
+/*Correct popOut auto resizing*/
+.ship-container {
+  min-height: 21.8em;
+  max-height: 21.8em;
+}
+
+/* Allow sidebar pop-outs to be resized*/
+.app.sidebar-popout {
+	resize: both;
+    overflow: auto;
+}
+
+/*Fix Advanced Macro Background Issue*/
+.macro-sheet .form-group.command .furnace-macro-command code {
+  background: var(--app-color);
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)

Certain modules don't work well with the default Twodsix style

* **What is the new behavior (if this is a feature change)?**
Add an optional style sheet to correct identified issues:

- Item icons not respecting aspect ratio for item sheets
- Dice Tray input box shifted out of line
- GM Screen tabs don't have dar background
- PopOut! resizing Ship actor sheet
- Allow side bar poppets to be resized
- Macro code can't be seen due to Advanced Macro light background for editor


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
