### PR TITLE
fix: Advanced Macros Not working

### DIFF
--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -28,6 +28,8 @@ input.dice-tray__input {
 }
 
 /*Fix Advanced Macro Background Issue*/
-.macro-sheet .form-group.command .furnace-macro-command code {
-  background: var(--app-color);
+.macro-sheet .form-group.command .furnace-macro-command code,  .macro-sheet .form-group.command .furnace-macro-command textarea{
+  -webkit-text-fill-color: inherit !important;
+  background: var(--s2d6-background-opaque) !important;
+  color: var(--s2d6-default) !important;
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Advanced Macros not behaving well with Twodsix default style


* **What is the new behavior (if this is a feature change)?**
Force text and background to Twodsix default.  However, loose Advanced Macro context colors.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
