### PR TITLE
feat: add a deck plan hyperlink for ship

### DIFF
--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -176,6 +176,14 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       return false;
     }
 
+    // Handle dropped scene on ship sheet
+    if (data.type === "Scene") {
+      if (actor.data.type === 'ship') {
+        actor.update({"data.deckPlan": data.id});
+      }
+      return false;
+    }
+
     const itemData = await getItemDataFromDropData(data);
 
     switch (actor.data.type) {

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -99,6 +99,8 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     html.find('.create-ship-position').on('click', this._onShipPositionCreate.bind(this));
     // component State toggling
     html.find(".component-toggle").on("click", this._onToggleComponent.bind(this));
+    html.find(".ship-deck-link").on("click", this._onDeckplanClick.bind(this));
+    html.find(".ship-deck-unlink").on("click", this._onDeckplanUnlink.bind(this));
   }
 
   private _onShipPositionCreate():void {
@@ -145,6 +147,17 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
       const itemSelected = this.actor.items.get(li.data("itemId"));
       const stateTransitions = {"operational": "damaged", "damaged": "destroyed", "destroyed": "off", "off": "operational"};
       itemSelected?.update({"data.status": stateTransitions[(<Component>itemSelected.data.data)?.status]});
+    }
+  }
+  private _onDeckplanClick() {
+    if ((<Ship>this.actor.data.data)?.deckPlan) {
+      game.scenes?.get((<Ship>this.actor.data.data).deckPlan)?.view();
+    }
+  }
+
+  private _onDeckplanUnlink() {
+    if ((<Ship>this.actor.data.data)?.deckPlan) {
+      this.actor.update({"data.deckPlan": ""});;
     }
   }
 

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -116,6 +116,7 @@ export interface Actor {
 export type ShipPositionActorIds = Record<string, string>
 export interface Ship {
   name:string;
+  deckPlan:string;
   crew:Crew;
   notes:string;
   cargo:string;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -286,7 +286,7 @@
       "AddShipPosition": "Add Ship Position",
       "Order": "Order",
       "Name": "Name",
-      "Deckplan": "Deckplan",
+      "Deckplan": "Deck Plan",
       "Travellers": "Travellers",
       "RemoveTraveller": "Remove Traveller from ship",
       "Actions": "Actions",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -286,6 +286,7 @@
       "AddShipPosition": "Add Ship Position",
       "Order": "Order",
       "Name": "Name",
+      "Deckplan": "Deckplan",
       "Travellers": "Travellers",
       "RemoveTraveller": "Remove Traveller from ship",
       "Actions": "Actions",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1208,6 +1208,14 @@ img.ship-mask-bg {
   max-height: 100%;
 }
 
+.ship-deck {
+  width: 19em;
+  color: var(--color-text-hyperlink);
+  margin-left: 1.5em;
+  margin-top: 0.4em;
+  text-align: center;
+}
+
 .ship-name {
   grid-area: ship-name;
   border-bottom: 2px solid var(--s2d6-default-color);

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1210,10 +1210,17 @@ img.ship-mask-bg {
 
 .ship-deck {
   width: 19em;
-  color: var(--color-text-hyperlink);
   margin-left: 1.5em;
   margin-top: 0.4em;
   text-align: center;
+}
+
+.ship-deck-link {
+  color: var(--color-text-hyperlink);
+  border: solid;
+  border-radius: 1ch;
+  padding: 0.3ch;
+  border-style: outset;
 }
 
 .ship-name {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -960,6 +960,21 @@ img.ship-mask-bg {
   border: none !important;
 }
 
+.ship-deck {
+  width: 14em;
+  margin-left: 6.5em;
+  margin-top: 0.4em;
+  text-align: center;
+}
+
+.ship-deck-link {
+  color: var(--color-text-hyperlink);
+  border: solid;
+  border-radius: 1ch;
+  padding: 0.2ch;
+  border-style: groove;
+}
+
 .ship-name {
   grid-area: ship-name;
   z-index: 2;

--- a/static/template.json
+++ b/static/template.json
@@ -131,6 +131,7 @@
     },
     "ship": {
       "name": "",
+      "deckPlan": "",
       "crew": {
         "captain": "",
         "pilot": "",

--- a/static/templates/actors/ship-sheet.html
+++ b/static/templates/actors/ship-sheet.html
@@ -6,6 +6,12 @@
     <div class="ship-image">
       <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" alt='{{localize "TWODSIX.Actor.ShipImage"}}'/>
     </div>
+    {{#iff data.data.deckPlan "!==" ""}}
+    <div class="ship-deck">
+      <a class="ship-deck-link" rel="bookmark">{{localize "TWODSIX.Ship.Deckplan"}}</a>
+      <a class="item-control ship-deck-unlink" title='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fas fa-trash"></i></a>
+    </div>
+    {{/iff}}
     <div class="ship-name">
       <input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}' onClick="this.select();"/>
     </div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

No way to link a ship deck plan scene and ship actor

* **What is the new behavior (if this is a feature change)?**
Drag and drop a scene to hyperlink scene.  Clicking link opens the scene in view mode.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
