### PR TITLE
fix: show skill roll dialog for macros

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -236,7 +236,7 @@ export default function registerHandlebarsHelpers(): void {
           } else if (a.name === b.name) {
             return 0;
           } else {
-            return a.name?.toLocaleLowerCase().localeCompare(b.name?.toLocaleLowerCase());
+            return a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase());
           }
         }
       });

--- a/src/module/utils/rollItemMacro.ts
+++ b/src/module/utils/rollItemMacro.ts
@@ -26,7 +26,7 @@ export async function rollItemMacro(itemId: string): Promise<void> {
     }
   } else {
     if (item.data.type != "weapon") {
-      await item.skillRoll(false);
+      await item.skillRoll(!game.settings.get("twodsix", "invertSkillRollShiftClick"));
     } else {
       if (shouldShowCELAutoFireDialog(item)) {
         const attackType = await promptForROF();

--- a/user_macros/Planet Mapper/CepheusDeluxeGalaxyImporter.js
+++ b/user_macros/Planet Mapper/CepheusDeluxeGalaxyImporter.js
@@ -1,6 +1,3 @@
-/* eslint-disable quotes */
-/* eslint-disable no-undef */
-/* eslint-disable semi */
 // Simple subsector generator based on information from Cepheus Deluxe & Cepheus Deluxe Galaxy
 // using the generator https://www.drivethrurpg.com/product/377266/Cepheus-Deluxe-Galaxy
 // Fields used
@@ -41,7 +38,7 @@ async function translateCode () {
     const newNotes = [];
     let newDrawings = [];
     let newTiles = [];
-    const maxX = 800;
+    const maxX = 700;
     const maxY = 1000;
 
     // create new folder to hold planet journal entries
@@ -68,7 +65,7 @@ async function translateCode () {
       drawings: newDrawings,
       initial: {x: Math.round(maxX / 2), y: Math.round(maxY / 2), scale: 0.8},
       tiles: newTiles,
-      padding: 0,
+      padding: 0.05,
       width: maxX,
       height: maxY
     });
@@ -154,8 +151,8 @@ async function newPlanet (parse, folderID, topLabel) {
   const returnTiles = [];
   for (let i = 0; i < parse.markers.length; ++i) {
     returnTiles.push({
-      x: iconPos.x + iconSize / 2 + smFontSize / 2,
-      y: iconPos.y + lrgFontSize * (i - 0.5 * parse.markers.length),
+      x: Math.round(iconPos.x + iconSize / 2 + smFontSize / 2),
+      y: Math.round(iconPos.y + lrgFontSize * (i - 0.5 * parse.markers.length)),
       z: 20,
       t: CONST.DRAWING_TYPES.RECTANGLE,
       width: smFontSize,
@@ -164,11 +161,11 @@ async function newPlanet (parse, folderID, topLabel) {
       img: 'systems/twodsix/assets/icons/' + getMarkerIcon(parse.markers[i])
     });
   }
-  
+
   // add planet icon again incase notes are turned off
   returnTiles.push({
-    x: iconPos.x - iconSize / 2,
-    y: iconPos.y - iconSize / 2,
+    x: Math.round(iconPos.x - iconSize / 2),
+    y: Math.round(iconPos.y - iconSize / 2),
     z: 20,
     t: CONST.DRAWING_TYPES.RECTANGLE,
     width: iconSize,
@@ -198,9 +195,9 @@ function getMarkerIcon (textSymbol) {
 function getPixelFromHex (col, row) {
   const width = gridSize;
   const sqrt3 = Math.sqrt(3.0);
-
-  const xPixel = (0.75 * (col) + 0.5) * width;
-  const yPixel = ((row) + 0.5 * ((col) & 1) + 0.5) * sqrt3 / 2.0 * width;
+  //Add +1 offset due to needing non-zero Padding
+  const xPixel = Math.round((0.75 * (col + 1) + 0.5) * width);
+  const yPixel = Math.round(((row + 1) + 0.5 * ((col + 1) & 1) + 0.5) * sqrt3 / 2.0 * width);
 
   return ({
     x: xPixel,

--- a/user_macros/Planet Mapper/PlanetIcons v5b.js
+++ b/user_macros/Planet Mapper/PlanetIcons v5b.js
@@ -1,6 +1,3 @@
-/* eslint-disable quotes */
-/* eslint-disable no-undef */
-/* eslint-disable semi */
 // Simple planet creator based on information from Cepheus Light, Cepheus Engine
 // SRD and https://travellermap.com/doc/secondsurvey#uwp
 // GEnie / SEC Format for input
@@ -73,9 +70,9 @@ async function translateCode () {
       drawings: newDrawings,
       initial: {x: Math.round(maxX / 2), y: Math.round(maxY / 2), scale: 0.7},
       tiles: newTiles,
-      padding: 0,
-      width: Math.round(maxX + gridSize),
-      height: Math.round(maxY + gridSize)
+      padding: 0.05,
+      width: maxX,
+      height: maxY
     });
   }
 }
@@ -147,8 +144,8 @@ async function newPlanet (parse, folderID, topLabel) {
   const returnTiles = [];
   for (let i = 0; i < parse.markers.length; ++i) {
     returnTiles.push({
-      x: iconPos.x + iconSize / 2 + smFontSize / 4,
-      y: iconPos.y + smFontSize * (i - 0.5 * parse.markers.length),
+      x: Math.round(iconPos.x + iconSize / 2 + smFontSize / 4),
+      y: Math.round(iconPos.y + smFontSize * (i - 0.5 * parse.markers.length)),
       z: 20,
       t: CONST.DRAWING_TYPES.RECTANGLE,
       width: smFontSize,
@@ -157,11 +154,11 @@ async function newPlanet (parse, folderID, topLabel) {
       img: 'systems/twodsix/assets/icons/' + getMarkerIcon(parse.markers[i])
     });
   }
-  
+
   // add planet icon again incase notes are turned off
   returnTiles.push({
-    x: iconPos.x - iconSize / 2,
-    y: iconPos.y - iconSize / 2,
+    x: Math.round(iconPos.x - iconSize / 2),
+    y: Math.round(iconPos.y - iconSize / 2),
     z: 20,
     t: CONST.DRAWING_TYPES.RECTANGLE,
     width: iconSize,
@@ -169,7 +166,7 @@ async function newPlanet (parse, folderID, topLabel) {
     tint: parse.color,
     img: planetIcon
   });
-  
+
   // add color for Zone
   let zoneColor = '#969696';
   switch (parse.zone) {
@@ -183,7 +180,7 @@ async function newPlanet (parse, folderID, topLabel) {
   // Add allegiance
   returnDrawing.push({
     text: parse.aleg,
-    x: iconPos.x - iconSize / 2 - smFontSize,
+    x: Math.round(iconPos.x - iconSize / 2 - smFontSize),
     y: iconPos.y,
     z: 20,
     t: CONST.DRAWING_TYPES.TEXT,
@@ -213,8 +210,9 @@ function getPixelFromHex (col, row) {
   const width = gridSize;
   const sqrt3 = Math.sqrt(3.0);
 
-  const xPixel = (0.75 * (col) + 0.5) * width;
-  const yPixel = ((row) + 0.5 * ((col) & 1) + 0.5) * sqrt3 / 2.0 * width;
+  // Add +1 offset due to needing non-zero padding
+  const xPixel = Math.round((0.75 * (col + 1) + 0.5) * width);
+  const yPixel = Math.round(((row + 1) + 0.5 * ((col + 1) & 1) + 0.5) * sqrt3 / 2.0 * width);
 
   return ({
     x: xPixel,


### PR DESCRIPTION
show skill roll depending on "invertSkillRollShiftClick" setting.

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)

Skill roll macros do not show dialog to select difficulty, characteristic, etc.
FVTT does not like having zero padding

* **What is the new behavior (if this is a feature change)?**
Skill roll macros now show dialog if  "invertSkillRollShiftClick" is false.
Non-zero padding added to mapping macros

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
