### PR TITLE
fix: Tidy UI Module tab issue

### DIFF
--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -33,3 +33,8 @@ input.dice-tray__input {
   background: var(--s2d6-background-opaque) !important;
   color: var(--s2d6-default) !important;
 }
+
+/*Fix for Tidy UI */
+#client-settings nav.tabs {
+  flex-grow: 0 !important;
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)
The Tidy UI module causes the tabs on the system settings to grow too large


* **What is the new behavior (if this is a feature change)?**

Tabs don't grow when using the debug-correct some css issues setting

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
