### PR TITLE
feat: add armor piercing feature on weapons and consumables

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -172,10 +172,11 @@ export default class TwodsixActor extends Actor {
     }
   }
 
-  public async damageActor(damage: number, showDamageDialog = true): Promise<void> {
+  public async damageActor(damage: number, armorPiercingValue: number, showDamageDialog = true): Promise<void> {
     if (showDamageDialog) {
-      const damageData: { damage: number; damageId: string, tokenId?: string|null, actorId?: string|null } = {
+      const damageData: { damage: number, armorPiercingValue: number, damageId: string, tokenId?: string|null, actorId?: string|null } = {
         damage: damage,
+        armorPiercingValue: armorPiercingValue,
         damageId: "damage-" + Math.random().toString(36).substring(2, 15)
       };
 
@@ -187,7 +188,7 @@ export default class TwodsixActor extends Actor {
       game.socket?.emit("system.twodsix", ["createDamageDialog", damageData]);
       Hooks.call('createDamageDialog', damageData);
     } else {
-      const stats = new Stats(this, damage);
+      const stats = new Stats(this, damage, armorPiercingValue);
       stats.applyDamage(); //TODO Should have await?
     }
   }

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -246,7 +246,7 @@ export default class TwodsixItem extends Item {
       const actor = game.actors?.get(actorID);
       const magazine = actor?.items.get(weapon.useConsumableForAttack);
       if (magazine?.type === "consumable") {
-        returnValue += (<Consumable>magazine?.data.data).armorPiercing || 0;
+        returnValue += (<Consumable>magazine.data.data)?.armorPiercing || 0;
       }
     }
     return returnValue;

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -140,7 +140,7 @@ export default class TwodsixItem extends Item {
       if (game.settings.get("twodsix", "automateDamageRollOnHit") && roll && roll.isSuccess()) {
         const damage = await this.rollDamage(settings.rollMode, `${roll.effect} + ${bonusDamage}`, showInChat) || null;
         if (game.user?.targets.size === 1) {
-          game.user?.targets.values().next().value.actor.damageActor(damage.total);
+          game.user?.targets.values().next().value.actor.damageActor(damage.total, TwodsixItem.getApValue(weapon, this.actor?.id || ""));
         } else if (game.user?.targets && game.user?.targets.size > 1) {
           ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.AutoDamageForMultipleTargetsNotImplemented"));
         }
@@ -212,14 +212,15 @@ export default class TwodsixItem extends Item {
     const damageFormula = weapon.damage + (bonusDamage ? "+" + bonusDamage : "");
     const damageRoll = new Roll(damageFormula, this.actor?.data.data);
     const damage: Roll = await damageRoll.evaluate({async: true}); // async: true will be default in foundry 0.10
+    const apValue = TwodsixItem.getApValue(weapon, this.actor?.id || "");
     if (showInChat) {
       const results = damage.terms[0]["results"];
       const contentData = {
-        flavor: `${game.i18n.localize("TWODSIX.Rolls.DamageUsing")} ${this.name}`,
+        flavor: `${game.i18n.localize("TWODSIX.Rolls.DamageUsing")} ${this.name}, ${game.i18n.localize("TWODSIX.Damage.AP")}(${apValue})`,
         roll: damage,
         damage: damage.total,
         dice: results,
-        armorPiercingValue: TwodsixItem.getApValue(weapon, this.actor?.id || "")
+        armorPiercingValue: apValue
       };
 
       const html = await renderTemplate('systems/twodsix/templates/chat/damage-message.html', contentData);

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -218,7 +218,8 @@ export default class TwodsixItem extends Item {
         flavor: `${game.i18n.localize("TWODSIX.Rolls.DamageUsing")} ${this.name}`,
         roll: damage,
         damage: damage.total,
-        dice: results
+        dice: results,
+        armorPiercingValue: TwodsixItem.getApValue(weapon, this.actor?.id || "")
       };
 
       const html = await renderTemplate('systems/twodsix/templates/chat/damage-message.html', contentData);
@@ -238,6 +239,17 @@ export default class TwodsixItem extends Item {
       }, {rollMode: rollMode});
     }
     return damage;
+  }
+  public static getApValue(weapon: Weapon, actorID = ""): number {
+    let returnValue = weapon.armorPiercing;
+    if (weapon.useConsumableForAttack && actorID) {
+      const actor = game.actors?.get(actorID);
+      const magazine = actor?.items.get(weapon.useConsumableForAttack);
+      if (magazine?.type === "consumable") {
+        returnValue += (<Consumable>magazine?.data.data).armorPiercing || 0;
+      }
+    }
+    return returnValue;
   }
 
   public static burstAttackDM(number: number | null): number {

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -169,7 +169,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       if (actor.data.type === 'traveller') {
         const useInvertedShiftClick:boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
         const showDamageDialog = useInvertedShiftClick ? event["shiftKey"] : !event["shiftKey"];
-        await (<TwodsixActor>this.actor).damageActor(data.payload.damage, showDamageDialog);
+        await (<TwodsixActor>this.actor).damageActor(data.payload.damage, data.payload.armorPiercingValue, showDamageDialog);
       } else {
         ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.CantAutoDamageShip"));
       }

--- a/src/module/utils/actorDamage.ts
+++ b/src/module/utils/actorDamage.ts
@@ -41,6 +41,7 @@ export class Stats {
   stamina: Attribute;
   lifeblood: Attribute;
   damage: number;
+  armorPiercingValue: number;
   armor: number;
   edited = false;
   actor: TwodsixActor;
@@ -48,7 +49,7 @@ export class Stats {
   useLifebloodStamina = false;
   useLifebloodEndurance = false;
 
-  constructor(actor: TwodsixActor, damage: number) {
+  constructor(actor: TwodsixActor, damage: number, armorPiercingValue: number) {
     this.strength = new Attribute("strength", actor);
     this.dexterity = new Attribute("dexterity", actor);
     this.endurance = new Attribute("endurance", actor);
@@ -56,8 +57,9 @@ export class Stats {
     this.lifeblood = new Attribute("lifeblood", actor);
     this.actor = actor;
     this.damage = damage;
+    this.armorPiercingValue = armorPiercingValue;
     if (actor.type !== "ship") {
-      this.armor = (<Traveller>actor.data.data).primaryArmor.value;
+      this.armor = Math.max((<Traveller>actor.data.data).primaryArmor.value - this.armorPiercingValue, 0);
     }
     this.damageCharacteristics = getDamageCharacteristics();
 
@@ -293,7 +295,7 @@ class DamageDialogHandler {
 }
 
 export async function renderDamageDialog(damageData: Record<string, any>): Promise<void> {
-  const {damageId, damage} = damageData;
+  const {damageId, damage, armorPiercingValue} = damageData;
   let actor;
   if (damageData.actorId) {
     actor = game.actors?.get(damageData.actorId);
@@ -307,7 +309,7 @@ export async function renderDamageDialog(damageData: Record<string, any>): Promi
 
   const template = 'systems/twodsix/templates/actors/damage-dialog.html';
 
-  const stats = new Stats(actor, damage);
+  const stats = new Stats(actor, damage, armorPiercingValue);
   const damageDialogHandler = new DamageDialogHandler(stats);
   const renderedHtml = await renderTemplate(template, {stats: damageDialogHandler.stats});
   const title = game.i18n.localize("TWODSIX.Damage.DealDamageTo").replace("_ACTOR_NAME_", actor.name);

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -312,6 +312,7 @@ export interface Consumable extends GearTemplate {
   type:string;
   subtype:string;
   location:string[];
+  armorPiercing:number;
 }
 
 export interface Equipment extends GearTemplate {
@@ -385,4 +386,5 @@ export interface Weapon extends GearTemplate {
   damageType:string;
   rateOfFire:string;
   recoil:boolean;
+  armorPiercing:number;
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -77,6 +77,7 @@
         "AUGMENTS": "AUGMENTS",
         "Ammo": "Ammo",
         "Armor": "Armor",
+        "EffectiveArmor": "Effective Armor",
         "CONSUMABLES": "CONSUMABLES",
         "Count": "Count",
         "CreateItem": "Create Item",
@@ -259,6 +260,7 @@
         "Size": "Size",
         "Subtype": "Type",
         "Count": "Count",
+        "ArmorPiercing": "Armor Piercing Value",
         "DropConsumablesHere": "You can drop consumables here.",
         "RemoveConsumable": "Remove consumable",
         "RemoveConsumableFrom": "Remove consumable _CONSUMABLE_NAME_ from _ITEM_NAME_?"
@@ -274,7 +276,8 @@
         "rateOfFire": "Rate of Fire/Auto X",
         "recoil": "Recoil",
         "UseAsAmmunitionForAttack": "Use as consumable for rolls",
-        "MagazineCost": "Magazine/Power Cell Cost"
+        "MagazineCost": "Magazine/Power Cell Cost",
+        "ArmorPiercing": "Armor Piercing Value"
       }
     },
     "Ship": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -14,6 +14,7 @@
     "Damage": {
       "DealDamage": "Deal damage",
       "Damage": "Damage",
+      "AP": "AP",
       "TotalDamage": "Total damage",
       "Characteristics": "Characteristics",
       "Max": "Max",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2005,7 +2005,7 @@ background: var(--s2d6-sidebar-background);
   margin: 0;
   line-height: 24px;
   text-align: center;
-  background: var(--s2d6-background-opaque);
+  background: var(--s2d6-background-nearly-transparent);
   border: 1px solid var(--s2d6-default-color);
   border-radius: 1px;
   box-shadow: 0 0 2px var(--s2d6-background-opaque) inset;

--- a/static/template.json
+++ b/static/template.json
@@ -239,7 +239,8 @@
       "weaponType": "",
       "damageType": "",
       "rateOfFire": "",
-      "recoil": false
+      "recoil": false,
+      "armorPiercing": 0
     },
     "armor": {
       "templates": ["gearTemplate"],
@@ -291,7 +292,8 @@
       "max": 0,
       "type": "consumable",
       "subtype": "other",
-      "location": ["inventory", "storage"]
+      "location": ["inventory", "storage"],
+      "armorPiercing": 0
     },
     "component": {
       "templates": ["gearTemplate"],

--- a/static/templates/actors/damage-dialog.html
+++ b/static/templates/actors/damage-dialog.html
@@ -4,7 +4,7 @@
     <thead>
       <tr>
         <td>{{localize "TWODSIX.Damage.Damage"}}</td>
-        <td>{{localize "TWODSIX.Actor.Items.Armor"}}</td>
+        <td>{{localize "TWODSIX.Actor.Items.EffectiveArmor"}}</td>
         <td>{{localize "TWODSIX.Damage.TotalDamage"}}</td>
       </tr>
     </thead>
@@ -75,10 +75,10 @@
       {{/if}}
     </tbody>
   </table>
-  
+
   <span class="unalocated-damage-text">{{localize "TWODSIX.Damage.UnallocatedDamage"}}: <span class="unalocated-damage"></span></span><br><br>
   <span class="character-dead red">{{localize "TWODSIX.Damage.CharacterIsDead"}}</span>
-  
+
   <br><br>
   {{/with}}
 </div>

--- a/static/templates/items/consumable-sheet.html
+++ b/static/templates/items/consumable-sheet.html
@@ -9,6 +9,12 @@
     </div>
 
     <div class="form-section">
+      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.ArmorPiercing"}}
+        <input type="number" name="data.armorPiercing" value="{{data.armorPiercing}}" data-dtype="Number"/>
+      </label>
+    </div>
+
+    <div class="form-section">
       <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Count"}}
         <div>
           <input class="form-consumable-count" name="data.currentCount" type="number" value="{{data.currentCount}}" data-dtype="Number">

--- a/static/templates/items/consumable-sheet.html
+++ b/static/templates/items/consumable-sheet.html
@@ -10,7 +10,7 @@
 
     <div class="form-section">
       <label class="resource-label">{{localize "TWODSIX.Items.Consumable.ArmorPiercing"}}
-        <input type="number" name="data.armorPiercing" value="{{data.armorPiercing}}" data-dtype="Number"/>
+        <input type="number" name="data.armorPiercing" value="{{data.armorPiercing}}" data-dtype="Number" step ="1" oninput="this.value = Math.round(this.value);"/>
       </label>
     </div>
 

--- a/static/templates/items/weapon-sheet.html
+++ b/static/templates/items/weapon-sheet.html
@@ -16,6 +16,12 @@
       </label>
     </div>
 
+    <div class="item-damage">
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.ArmorPiercing"}}
+        <input type="number" name="data.armorPiercing" value="{{data.armorPiercing}}">
+      </label>
+    </div>
+
     <div class="item-range">
       {{#if data.settings.ShowRangeBandAndHideRange}}
       <label class="resource-label">{{localize "TWODSIX.Items.Weapon.rangeBand"}}

--- a/static/templates/items/weapon-sheet.html
+++ b/static/templates/items/weapon-sheet.html
@@ -18,7 +18,7 @@
 
     <div class="item-damage">
       <label class="resource-label">{{localize "TWODSIX.Items.Weapon.ArmorPiercing"}}
-        <input type="number" name="data.armorPiercing" value="{{data.armorPiercing}}">
+        <input type="number" name="data.armorPiercing" value="{{data.armorPiercing}}" step="1" oninput="this.value = Math.round(this.value);">
       </label>
     </div>
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)

No allowance for armor piercing ability for weapons 

* **What is the new behavior (if this is a feature change)?**

Armor piercing value now added for weapons and consumables.  It is a value to subtract from armor protection.  The total AP value is the sum of both the weapon and consumable AP values (not to exceed the primary armor value).  The. AP inputs are forced to be integers on their respective item sheets.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
