### PR TITLE
feat: show difficulty values along with text

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -13,6 +13,10 @@ export default function registerHandlebarsHelpers(): void {
     return advantageDisadvantageTerm(str);
   });
 
+  Handlebars.registerHelper('twodsix_difficultiesAsTargetNumber', () => {
+    return game.settings.get('twodsix', 'difficultiesAsTargetNumber');
+  });
+
   Handlebars.registerHelper('twodsix_isOdd', (num:number) => {
     return (num % 2) == 1;
   });

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -920,7 +920,7 @@ select.select-mod {
 }
 
 select.select-difficulty {
-  width: 10em;
+  width: 11em;
   margin-left: 1em;
 }
 

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -671,7 +671,7 @@ select.select-mod {
 }
 
 select.select-difficulty {
-  width: 10em;
+  width: 11em;
   margin-left: 1em;
 }
 

--- a/static/templates/chat/throw-dialog.html
+++ b/static/templates/chat/throw-dialog.html
@@ -5,7 +5,9 @@
       <select name="difficulty">
         {{#select difficulty}}
           {{#each difficulties as |label difficulty|}}
-            <option value="{{difficulty}}">{{localize difficulty}}</option>
+            <option value="{{difficulty}}">{{localize difficulty}} (
+              {{if twodsix_difficultiesAsTargetNumber}} {{this.target}} {{else}} {{this.mod}} {{/if}})
+            </option>
           {{/each}}
         {{/select}}
       </select>

--- a/static/templates/items/skills-sheet.html
+++ b/static/templates/items/skills-sheet.html
@@ -54,8 +54,10 @@
         <label class="resource-label">{{localize "TWODSIX.Chat.Roll.Difficulty"}}
           <select class="select-difficulty" name="data.difficulty" value={{difficulty}}>
             {{#select data.difficulty}}
-            {{#each data.settings.DIFFICULTIES as |label difficulty|}}
-            <option value="{{difficulty}}">{{localize difficulty}}</option>
+            {{#each data.settings.DIFFICULTIES}}
+            <option value="{{@key}}">{{localize @key}} (
+              {{#if (twodsix_difficultiesAsTargetNumber)}} {{this.target}} {{else}} {{this.mod}} {{/if}})
+            </option>
             {{/each}}
             {{/select}}
           </select>
@@ -73,7 +75,7 @@
         </select>
       </label>
     </div>
-    
+
     <div class="item-short">
       <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
         <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature - add difficulty numbers / values after text label on skill rolls


* **What is the current behavior?** (You can also link to an open issue here)
Only text appears


* **What is the new behavior (if this is a feature change)?**
text and value also appear.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
