### PR TITLE
feat: add optional document references

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -150,6 +150,10 @@ export default function registerHandlebarsHelpers(): void {
     return game.settings.get('twodsix', 'useShipAutoCalcs');
   });
 
+  Handlebars.registerHelper('twodsix_showReferences', () => {
+    return game.settings.get('twodsix', 'showItemReferences');
+  });
+
   Handlebars.registerHelper('skillName', (skillName) => {
     return TwodsixItem.simplifySkillName(skillName);
   });

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -28,6 +28,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.push(booleanSetting('useFoundryStandardStyle', false, false, 'world', refreshWindow));
     settings.push(booleanSetting('useWoundedStatusIndicators', false));
     settings.push(booleanSetting('showWeightUsage', false));
+    settings.push(booleanSetting('showItemReferences', true));
     return settings;
   }
 }

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -2,6 +2,7 @@ import { AbstractTwodsixItemSheet } from "./AbstractTwodsixItemSheet";
 import { TWODSIX } from "../config";
 import TwodsixItem from "../entities/TwodsixItem";
 import { getDataFromDropEvent, getItemDataFromDropData } from "../utils/sheetUtils";
+import { GearTemplate } from "src/types/template";
 
 /**
  * Extend the basic ItemSheet with some very simple modifications
@@ -76,6 +77,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
     html.find('.consumable-delete').on('click', this._onDeleteConsumable.bind(this));
     html.find('.consumable-use-consumable-for-attack').on('change', this._onChangeUseConsumableForAttack.bind(this));
     this.handleContentEditable(html);
+    html.find('.open-link').on('click', this._openPDFReference.bind(this));
   }
 
   private getConsumable(event) {
@@ -188,6 +190,22 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
     } catch (err) {
       console.error(`Twodsix | ${err}`);
       ui.notifications.error(err);
+    }
+  }
+
+  private _openPDFReference(event): void {
+    event.preventDefault();
+    const sourceString = (<GearTemplate>this.item.data.data).docReference;
+    if (sourceString) {
+      const [code, page] = sourceString.split(' ');
+      const selectedPage = parseInt(page);
+      if (ui["PDFoundry"]) {
+        ui["PDFoundry"].openPDFByCode(code, {page: selectedPage});
+      } else {
+        ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.PDFFoundryNotInstalled"));
+      }
+    } else {
+      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
     }
   }
 }

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -369,6 +369,7 @@ export interface GearTemplate {
   skill:string;
   associatedSkillName:string;
   equipped:string;
+  docReference:string;
 }
 
 export interface Trait {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -162,6 +162,7 @@
     "Items": {
       "Encumbrance": "Encumbrance",
       "Enc": "Enc",
+      "DocumentReference": "Document Reference",
       "Armor": {
         "Armor": "Armor",
         "SecondaryArmor": "Secondary Armor",
@@ -576,6 +577,10 @@
         "hint": "When enabled, the ship summary power and weight statistics are calculated based on component vaules. Otherwise, values are input by user.",
         "name": "Automatically calculate summary ship power and weight values"
       },
+      "showItemReferences": {
+        "hint": "Shows a text field on item sheets to use with PDFoundry or as a freeform reference.  For PDFoundry, format must be '[abbreviated name] [page number]'.",
+        "name": "Show reference field on item sheets."
+      },
       "settingsInterface": {
         "rulesetSettings": {
           "intro": "Current Rules",
@@ -642,7 +647,9 @@
       "StatValBelowZero": "The value cannot be below zero",
       "DecreaseEnduranceFirst": "Endurance/Stamina should be decreased before other stats",
       "CantAutoDamageShip": "Automatic damage of ship is not supported",
-      "CantDragOntoActor": "This item can't be dragged onto this actor"
+      "CantDragOntoActor": "This item can't be dragged onto this actor",
+      "PDFFoundryNotInstalled": "PDFoundry must be installed to use source links.",
+      "NoSpecfiedLink": "No document and page specified for document link."
     }
   },
   "VeryDifficult": "Very Difficult"

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2028,8 +2028,12 @@ a:hover {
   margin-top: 0.5em;
 }
 
-.item-short, .item-armor, .item-secondaryArmor, .item-radiationProtection, .item-lvl, .item-prereq, .mini-grid {
+.item-short, .item-armor, .item-secondaryArmor, .item-radiationProtection, .item-lvl, .item-prereq, .mini-grid, .item-reference {
   margin-top: 0.5em;
+}
+
+.open-link {
+  color: var(--color-text-hyperlink);
 }
 
 .item-descr div[contenteditable] {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1627,8 +1627,12 @@ button.flexrow.flex-group-center.toggle-skills {
 }
 
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-lvl, .item-armor, .item-range, .item-short,
-.item-secondaryArmor, .item-radiationProtection, .item-prereq, .mini-grid, .form-section  {
+.item-secondaryArmor, .item-radiationProtection, .item-prereq, .mini-grid, .form-section, .item-reference {
   margin-top: 0.5em;
+}
+
+.open-link {
+  color: var(--color-text-hyperlink);
 }
 
 .item-descr {

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -38,3 +38,8 @@ input.dice-tray__input {
 #client-settings nav.tabs {
   flex-grow: 0 !important;
 }
+
+/*Fix for PDFoundry*/
+div.pdf-app section.window-content {
+  background: var(--s2d6-background-transparent) !important;
+}

--- a/static/template.json
+++ b/static/template.json
@@ -224,7 +224,8 @@
         "skillModifier": 0,
         "skill": "",
         "associatedSkillName": "",
-        "equipped": ["equipped", "ship", "backpack"]
+        "equipped": ["equipped", "ship", "backpack"],
+        "docReference": ""
       }
     },
     "equipment": {

--- a/static/templates/items/armor-sheet.html
+++ b/static/templates/items/armor-sheet.html
@@ -43,6 +43,7 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
     {{> "systems/twodsix/templates/items/parts/useConsumableForRoll.html"}}
   </div>

--- a/static/templates/items/augment-sheet.html
+++ b/static/templates/items/augment-sheet.html
@@ -39,6 +39,7 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -135,5 +135,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
   </div>
 </form>

--- a/static/templates/items/consumable-sheet.html
+++ b/static/templates/items/consumable-sheet.html
@@ -51,6 +51,7 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/equipment-sheet.html
+++ b/static/templates/items/equipment-sheet.html
@@ -24,6 +24,7 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
     {{> "systems/twodsix/templates/items/parts/useConsumableForRoll.html"}}
   </div>

--- a/static/templates/items/item-sheet.html
+++ b/static/templates/items/item-sheet.html
@@ -34,6 +34,7 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
     {{> "systems/twodsix/templates/items/parts/useConsumableForRoll.html"}}
   </div>

--- a/static/templates/items/junk-sheet.html
+++ b/static/templates/items/junk-sheet.html
@@ -24,6 +24,7 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/parts/reference-footer.html
+++ b/static/templates/items/parts/reference-footer.html
@@ -1,0 +1,6 @@
+{{#if (twodsix_showReferences)}}
+<div class="item-reference">
+  <a class="open-link">{{localize "TWODSIX.Items.DocumentReference"}}</a>
+  <input id="source" type="text" name="data.docReference" value="{{data.docReference}}"/>
+</div>
+{{/if}}

--- a/static/templates/items/skills-sheet.html
+++ b/static/templates/items/skills-sheet.html
@@ -86,5 +86,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
   </div>
 </form>

--- a/static/templates/items/storage-sheet.html
+++ b/static/templates/items/storage-sheet.html
@@ -24,6 +24,7 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/tool-sheet.html
+++ b/static/templates/items/tool-sheet.html
@@ -30,6 +30,7 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
     {{> "systems/twodsix/templates/items/parts/useConsumableForRoll.html"}}
   </div>

--- a/static/templates/items/trait-sheet.html
+++ b/static/templates/items/trait-sheet.html
@@ -36,5 +36,6 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
   </div>
 </form>

--- a/static/templates/items/weapon-sheet.html
+++ b/static/templates/items/weapon-sheet.html
@@ -97,6 +97,7 @@
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
+    {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
     {{> "systems/twodsix/templates/items/parts/useConsumableForRoll.html"}}
   </div>


### PR DESCRIPTION
Add an optional field for items that contains a document (rules) reference.  Can be optionally used with PDFoundry module for links.

* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)

No way to reference rules source on item sheets

* **What is the new behavior (if this is a feature change)?**
Adds an optional footer to item sheets that also works with PDFoundry module.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
