### PR TITLE
fix: revise ship component listing

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -93,12 +93,12 @@ export default class TwodsixActor extends Actor {
 
     actorData.items.filter((item: TwodsixItem) => item.type === "component").forEach((item: TwodsixItem) => {
       const anComponent = <Component>item.data.data;
-      const powerForItem = getPowerNeeded(anComponent);
+      const powerForItem = getPower(anComponent);
       const weightForItem = getWeight(anComponent, actorData);
 
       /* Allocate Power */
-      if (powerForItem < 0) {
-        calcShipStats.power.max -= powerForItem;
+      if (anComponent.generatesPower) {
+        calcShipStats.power.max += powerForItem;
       } else {
         switch (anComponent.subtype) {
           case 'drive':
@@ -309,18 +309,14 @@ export default class TwodsixActor extends Actor {
   }
 }
 
-export function getPowerNeeded(item: Component): number{
+export function getPower(item: Component): number{
   if ((item.status === "operational") || (item.status === "damaged")) {
     let q = item.quantity || 1;
     if (item.subtype === "armament"  && item.availableQuantity) {
       q = parseInt(item.availableQuantity);
     }
     const p = item.powerDraw || 0;
-    if (item.subtype === "power"  && p > 0) {  //all power items generate power
-      return -(q * p);
-    } else {
-      return (q * p);
-    }
+    return (q * p);
   } else {
     return 0;
   }

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -97,28 +97,29 @@ export default class TwodsixActor extends Actor {
       const weightForItem = getWeight(anComponent, actorData);
 
       /* Allocate Power */
-      switch (anComponent.subtype) {
-        case 'power':
-          calcShipStats.power.max -= powerForItem;
-          break;
-        case 'drive':
-          if (item.data.name.toLowerCase().includes('j-drive') || item.data.name.toLowerCase().includes('j drive')) {
-            calcShipStats.power.jDrive += powerForItem;
-          } else if (item.data.name.toLowerCase().includes('m-drive') || item.data.name.toLowerCase().includes('m drive')) {
-            calcShipStats.power.mDrive += powerForItem;
-          } else {
+      if (powerForItem < 0) {
+        calcShipStats.power.max -= powerForItem;
+      } else {
+        switch (anComponent.subtype) {
+          case 'drive':
+            if (item.data.name.toLowerCase().includes('j-drive') || item.data.name.toLowerCase().includes('j drive')) {
+              calcShipStats.power.jDrive += powerForItem;
+            } else if (item.data.name.toLowerCase().includes('m-drive') || item.data.name.toLowerCase().includes('m drive')) {
+              calcShipStats.power.mDrive += powerForItem;
+            } else {
+              calcShipStats.power.systems += powerForItem;
+            }
+            break;
+          case 'sensor':
+            calcShipStats.power.sensors += powerForItem;
+            break;
+          case 'armament':
+            calcShipStats.power.weapons += powerForItem;
+            break;
+          default:
             calcShipStats.power.systems += powerForItem;
-          }
-          break;
-        case 'sensor':
-          calcShipStats.power.sensors += powerForItem;
-          break;
-        case 'armament':
-          calcShipStats.power.weapons += powerForItem;
-          break;
-        default:
-          calcShipStats.power.systems += powerForItem;
-          break;
+            break;
+        }
       }
 
       /* Allocate Weight*/
@@ -315,12 +316,14 @@ export function getPowerNeeded(item: Component): number{
       q = parseInt(item.availableQuantity);
     }
     const p = item.powerDraw || 0;
-    if (item.subtype === "power"){
+    if (item.subtype === "power"  && p > 0) {  //all power items generate power
       return -(q * p);
+    } else {
+      return (q * p);
     }
-    return (q * p);
+  } else {
+    return 0;
   }
-  return 0;
 }
 
 export function getWeight(item: Component, actorData): number{

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -93,8 +93,8 @@ export default class TwodsixActor extends Actor {
 
     actorData.items.filter((item: TwodsixItem) => item.type === "component").forEach((item: TwodsixItem) => {
       const anComponent = <Component>item.data.data;
-      const powerForItem = TwodsixActor._getPowerNeeded(anComponent);
-      const weightForItem = TwodsixActor._getWeight(anComponent, actorData);
+      const powerForItem = getPowerNeeded(anComponent);
+      const weightForItem = getWeight(anComponent, actorData);
 
       /* Allocate Power */
       switch (anComponent.subtype) {
@@ -159,35 +159,6 @@ export default class TwodsixActor extends Actor {
     actorData.data.weightStats.fuel = Math.round(calcShipStats.weight.fuel);
     actorData.data.weightStats.systems = Math.round(calcShipStats.weight.systems);
     actorData.data.weightStats.available = Math.round(calcShipStats.weight.available);
-  }
-
-  private static _getPowerNeeded(item: Component): number{
-    if ((item.status === "operational") || (item.status === "damaged")) {
-      let q = item.quantity || 1;
-      if (item.subtype === "armament"  && item.availableQuantity) {
-        q = parseInt(item.availableQuantity);
-      }
-      const p = item.powerDraw || 0;
-      if (item.subtype === "power"){
-        return -(q * p);
-      }
-      return (q * p);
-    }
-    return 0;
-  }
-
-  private static _getWeight(item: Component, actorData): number{
-    let q = item.quantity || 1;
-    if (["armament", "fuel"].includes(item.subtype) && item.availableQuantity) {
-      q = parseInt(item.availableQuantity);
-    }
-    let w = 0;
-    if (item.weightIsPct) {
-      w = (item.weight || 0) / 100 * actorData.data.shipStats.mass.max;
-    } else {
-      w = item.weight || 0;
-    }
-    return (w * q);
   }
 
   protected async _onCreate() {
@@ -335,4 +306,33 @@ export default class TwodsixActor extends Actor {
       }
     });
   }
+}
+
+export function getPowerNeeded(item: Component): number{
+  if ((item.status === "operational") || (item.status === "damaged")) {
+    let q = item.quantity || 1;
+    if (item.subtype === "armament"  && item.availableQuantity) {
+      q = parseInt(item.availableQuantity);
+    }
+    const p = item.powerDraw || 0;
+    if (item.subtype === "power"){
+      return -(q * p);
+    }
+    return (q * p);
+  }
+  return 0;
+}
+
+export function getWeight(item: Component, actorData): number{
+  let q = item.quantity || 1;
+  if (["armament", "fuel"].includes(item.subtype) && item.availableQuantity) {
+    q = parseInt(item.availableQuantity);
+  }
+  let w = 0;
+  if (item.weightIsPct) {
+    w = (item.weight || 0) / 100 * actorData.data.shipStats.mass.max;
+  } else {
+    w = item.weight || 0;
+  }
+  return (w * q);
 }

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -3,7 +3,8 @@ import { calcModFor, getKeyByValue } from "./utils/sheetUtils";
 import { TWODSIX } from "./config";
 import TwodsixItem from "./entities/TwodsixItem";
 import { getCharShortName } from "./utils/utils";
-import {Skills} from "../types/template";
+import {Skills, Component} from "../types/template";
+import { getPowerNeeded, getWeight } from "./entities/TwodsixActor";
 
 export default function registerHandlebarsHelpers(): void {
 
@@ -261,6 +262,16 @@ export default function registerHandlebarsHelpers(): void {
       });
     }
     return Handlebars.helpers.each(sortedArray, options);
+  });
+
+  Handlebars.registerHelper('getComponentWeight', (item: TwodsixItem) => {
+    const anComponent = <Component>item.data.data;
+    return getWeight(anComponent, item.actor?.data);
+  });
+
+  Handlebars.registerHelper('getComponentPower', (item: TwodsixItem) => {
+    const anComponent = <Component>item.data.data;
+    return getPowerNeeded(anComponent);
   });
 
   // Handy for debugging

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -265,13 +265,11 @@ export default function registerHandlebarsHelpers(): void {
   });
 
   Handlebars.registerHelper('getComponentWeight', (item: TwodsixItem) => {
-    const anComponent = <Component>item.data.data;
-    return getWeight(anComponent, item.actor?.data);
+    return getWeight(<Component>item.data.data, item.actor?.data);
   });
 
   Handlebars.registerHelper('getComponentPower', (item: TwodsixItem) => {
-    const anComponent = <Component>item.data.data;
-    return getPowerNeeded(anComponent);
+    return getPowerNeeded(<Component>item.data.data);
   });
 
   // Handy for debugging

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -4,7 +4,7 @@ import { TWODSIX } from "./config";
 import TwodsixItem from "./entities/TwodsixItem";
 import { getCharShortName } from "./utils/utils";
 import {Skills, Component} from "../types/template";
-import { getPowerNeeded, getWeight } from "./entities/TwodsixActor";
+import { getPower, getWeight } from "./entities/TwodsixActor";
 
 export default function registerHandlebarsHelpers(): void {
 
@@ -269,7 +269,13 @@ export default function registerHandlebarsHelpers(): void {
   });
 
   Handlebars.registerHelper('getComponentPower', (item: TwodsixItem) => {
-    return getPowerNeeded(<Component>item.data.data);
+    const anComponent = <Component>item.data.data;
+    const retValue:number = getPower(anComponent);
+    if (anComponent.generatesPower) {
+      return "+" + retValue;
+    } else {
+      return retValue;
+    }
   });
 
   // Handy for debugging

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -117,6 +117,9 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
         break;
       case "component":
         itemData.data.subtype = subtype || "otherInternal";
+        if (subtype === "power") {
+          itemData.data.generatesPower = true;
+        }
         itemData.data.status = "operational";
         itemData.img = "systems/twodsix/assets/icons/components/" + itemData.data.subtype + ".svg";
         break;

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -318,6 +318,8 @@ export interface Component extends GearTemplate {
   isIllegal:boolean;
   purchasePrice:string;
   cargoLocation:string;
+  generatesPower:boolean;
+  isRefined:boolean;
 }
 
 export interface Consumable extends GearTemplate {

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -117,6 +117,7 @@ export type ShipPositionActorIds = Record<string, string>
 export interface Ship {
   name:string;
   deckPlan:string;
+  techLevel:number;
   crew:Crew;
   notes:string;
   cargo:string;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -205,8 +205,9 @@
         "damaged": "damaged",
         "destroyed": "destroyed",
         "off": "off",
-        "powerDraw": "Power Draw",
+        "powerDraw": "Power Draw per Unit",
         "powerGenerated": "Power Generated per Unit",
+        "Power": "Power",
         "status": "Status",
         "rating": "Rating",
         "totalQuantity": "Total Quantity",
@@ -216,10 +217,13 @@
         "purchasePrice": "Purchase Price",
         "isIllegal": "Illegal?",
         "unitWeight": "Unit Weight",
+        "pctDisplacement": "% Displacement Weight",
         "CargoItem": "Cargo Item",
         "CargoLocation": "Cargo Location",
         "Price": "Price",
-        "Value": "Value"
+        "Value": "Value",
+        "GeneratesPower": "Generates Power?",
+        "IsRefined": "Refined?"
       },
       "Equipment": {
         "AssignSkill": "Assign Skill",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -205,7 +205,7 @@
         "damaged": "damaged",
         "destroyed": "destroyed",
         "off": "off",
-        "powerDraw": "Unit Power Draw",
+        "powerDraw": "Power Draw",
         "powerGenerated": "Power Generated per Unit",
         "status": "Status",
         "rating": "Rating",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1405,18 +1405,19 @@ img.ship-mask-bg {
   /*padding: 2px;
   margin-top: -0.2em;
   margin-left: 1.7em;*/
-  font-size: 22px;
-  /*width: 2.5em;*/
+  font-size: 18px;
+  width: 100%;
   border: none;
   background-color: transparent !important;
 }
 
 .ship-state-grid {
   display: grid;
-  grid-template-columns: 7em 7em 7em 7em;
-  grid-template-rows: 8em;
-  gap: 1px 1px;
-  grid-template-areas: "ship-hull ship-fuel ship-armor ship-mass";
+  grid-template-columns: 7em 7em 7em 6em 5em;
+  grid-template-rows: 10em;
+  gap: 1px 6px;
+  grid-template-areas: "ship-hull ship-fuel ship-armor ship-mass ship-tl";
+  font-size: smaller;
 }
 
 .ship-state-grid span {
@@ -1427,16 +1428,18 @@ img.ship-mask-bg {
 .ship-armor {
   grid-area: ship-armor;
   display: grid;
-  padding-right: 1ch;
+  grid-template-rows: max-content;
+  /*padding-right: 1ch;*/
 }
 
 .ship-armor-name textarea {
   border: solid;
-  border-radius: 1ch;
+  border-radius: 1ch !important;
   border-color: var(--s2d6-default-color);
   text-align: center;
-  display: grid;
+  /*display: grid;*/
   resize: none;
+  height: 100%;
 }
 
 .ship-hull {
@@ -1463,17 +1466,22 @@ img.ship-mask-bg {
   display: grid;
 }
 
-.ship-mass input {
+.ship-tl {
+  grid-area: ship-tl;
+  display: grid;
+}
+
+.ship-mass input, .ship-tl input {
   background-color: var(--s2d6-background-nearly-opaque) !important;
 }
 
-.ship-mass input[type="text"] {
-  width: 4.5em;
-  /*border: 1px solid var(--default-color);*/
+/*.ship-mass input[type="number"], .ship-tl input[type="number"] {
+  width: 100%;
+  border: 1px solid var(--default-color);
   left: -1em;
   position: relative;
   border: none;
-}
+}*/
 
 /*.ship-maintenance span {
   margin-left: -0.8em;

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1827,10 +1827,10 @@ a.ship-notes-tab.active {
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 11em 14em 3em 3.5em 3em 3.5em 3.5em 4.5em 3.5em 3em;
+  grid-template-columns: 20em 4em 4em 4em 4em 4em 4.5em 4em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
-  grid-template-areas: ". . . . . . . . . .";
+  grid-template-areas: ". . . . . . . . .";
 }
 
 .grid-columns-single-row:nth-of-type(even) {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1473,6 +1473,9 @@ img.ship-mask-bg {
 
 .ship-mass input, .ship-tl input {
   background-color: var(--s2d6-background-nearly-opaque) !important;
+  border: solid;
+  border-color: var(--s2d6-default-color);
+  border-radius: 0.5ch !important;
 }
 
 /*.ship-mass input[type="number"], .ship-tl input[type="number"] {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1074,8 +1074,20 @@ span.total-output {
   padding-top: 0.2em;
 }
 
-.short-label input[type='text']{
-  width: 15em;
+.short-label input[type='text'], .short-label input[type='number'] {
+  width: 18ch;
+}
+
+.short-label input[type='checkbox'] {
+  vertical-align: text-bottom;
+  height: 16px;
+}
+
+.multi-line {
+  justify-content: space-between;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
 }
 
 .select-mod:after {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -787,8 +787,20 @@ span.total-output {
   padding-top: 0.2em;
 }
 
-.short-label input[type='text']{
-  width: 15em;
+.short-label input[type='text'], .short-label input[type='number'] {
+  width: 18ch;
+}
+
+.short-label input[type='checkbox'] {
+  vertical-align: text-bottom;
+  height: 16px;
+}
+
+.multi-line {
+  justify-content: space-between;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
 }
 
 .select-mod:after {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1109,7 +1109,7 @@ img.ship-mask-bg {
   padding: 2px;
   margin-top: -0.2em;
   /*margin-left: 1.3em;*/
-  font-size: 22px;
+  font-size: 18px;
   /*width: 2.5em;*/
   border: none;
   background-color: transparent !important;
@@ -1117,9 +1117,11 @@ img.ship-mask-bg {
 
 .ship-state-grid {
   display: grid;
-  grid-template-columns: 5em 5em 5em 6em 6em;
-  gap: 1px 1px;
-  grid-template-areas: "ship-state-labels ship-hull ship-fuel ship-armor ship-mass";
+  grid-template-columns: 5em 5em 5em 6em 6em 4em;
+  grid-template-rows: 8em;
+  gap: 1px 4px;
+  grid-template-areas: "ship-state-labels ship-hull ship-fuel ship-armor ship-mass ship-tl";
+  font-size: smaller;
 }
 
 .ship-state-grid span {
@@ -1134,15 +1136,20 @@ img.ship-mask-bg {
 }
 .ship-armor {
   grid-area: ship-armor;
-  display: grid;
-  padding-right: 1ch;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.ship-armor-name {
+  flex-grow: 1;
 }
 
 .ship-armor-name textarea {
   border: solid;
   border-radius: 1ch;
   text-align: center;
-  display: grid;
+  height: 100%;
   resize: none;
 }
 
@@ -1191,7 +1198,7 @@ img.ship-mask-bg {
   justify-content: space-between;
 }
 
-.ship-mass input {
+.ship-mass input, .ship-tl input {
   background-color: var(--s2d6-background-nearly-transparent) !important;
   border: 1px solid;
 }
@@ -1202,6 +1209,14 @@ img.ship-mask-bg {
   left: -1em;
   position: relative;
 }
+
+.ship-tl {
+  grid-area: ship-tl;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
 
 .ship-power-management {
   grid-area: ship-requirements;
@@ -1214,7 +1229,7 @@ img.ship-mask-bg {
 
 .ship-power-management h3 {
   color: var(--s2d6-app-color);
-  background-color: var(--s2d6-background-opaque);
+  background-color: var(--s2d6-background-nearly-opaque);
   border-radius: 0 0 1ch 1ch;
   font-weight: bold;
   position: relative;
@@ -2075,8 +2090,8 @@ form .form-group > label {
 .header-row {
   text-align: center;
   color: var(--s2d6-item-hover);
-  background-color: var(--s2d6-background-nearly-opaque);
-  background-image: radial-gradient(circle farthest-side, var(--s2d6-background-nearly-opaque), var(--s2d6-input-background));
+  background-color: var(--s2d6-backgroun-semi-opaque);
+  background-image: radial-gradient(circle farthest-side, var(--s2d6-background-opaque), var(--s2d6-input-background));
 }
 /* ------ WEBCAM Settings ------ */
 /*

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1492,11 +1492,12 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 11em 14em 3em 3.5em 3em 3.5em 3.5em 4.5em 3.5em 3em;
+  grid-template-columns: 20em 4em 4em 4em 4em 4em 4.5em 4em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
-  grid-template-areas: ". . . . . . . . . .";
+  grid-template-areas: ". . . . . . . . .";
 }
+
 .grid-columns-single-row:nth-of-type(even) {
   background: var(--s2d6-skill-list-even);
 }

--- a/static/template.json
+++ b/static/template.json
@@ -141,6 +141,7 @@
     "ship": {
       "name": "",
       "deckPlan": "",
+      "techLevel": 0,
       "crew": {
         "captain": "",
         "pilot": "",

--- a/static/template.json
+++ b/static/template.json
@@ -324,7 +324,9 @@
       "weightIsPct": false,
       "isIllegal": false,
       "purchasePrice": "",
-      "cargoLocation": ""
+      "cargoLocation": "",
+      "generatesPower": false,
+      "isRefined": false
     },
     "ship_position": {
       "name": "",

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -2,7 +2,6 @@
   <div class="grid-columns-single storage-header">
     <div class="components-stored-single ">
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
-      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.ShortDescr"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.rating"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
@@ -28,11 +27,10 @@
       <ol class="ol-no-indent">
         <li class="item components-stored-single " data-item-id="{{item.id}}">
           <span class="item-name">{{item.name}}</span>
-          <span class="item-name">{{item.data.data.shortdescr}}</span>
           <span class="item-name centre">{{item.data.data.techLevel}}</span>
           <span class="item-name centre">{{item.data.data.rating}}</span>
-          <span class="item-name centre">{{item.data.data.weight}}</span>
-          <span class="item-name centre">{{item.data.data.powerDraw}}</span>
+          <span class="item-name centre">{{getComponentWeight this}}</span>
+          <span class="item-name centre">{{getComponentPower this}}</span>
           <span class="item-name centre">{{#if item.data.data.availableQuantity}}{{item.data.data.availableQuantity}}/{{/if}}{{item.data.data.quantity}}</span>
           <span class="item-name centre">{{twodsix_limitLength item.data.data.damage 7}}</span>
           <span class="item-name centre component-toggle">

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -5,7 +5,7 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.rating"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
-      <span class="item-name centre">{{localize "TWODSIX.Items.Component.powerDraw"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Items.Component.Power"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.damage"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.status"}}</span>

--- a/static/templates/actors/ship-sheet.html
+++ b/static/templates/actors/ship-sheet.html
@@ -44,6 +44,11 @@
           <span><input type="number" value="{{data.data.shipStats.mass.max}}" name="data.shipStats.mass.max" placeholder="0"/></span>
           <span>{{localize "TWODSIX.Ship.tons"}}</span>
         </div>
+        <div class ="ship-tl">
+          <span>{{localize "TWODSIX.Actor.Items.TL"}}</span>
+          <span><input type="number" value="{{data.data.techLevel}}" name="data.techLevel" placeholder="0"/></span>
+          <span>&nbsp</span>
+        </div>
       </div>
     </div>
     <div class="ship-power-management">

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -68,28 +68,47 @@
     </div>
     {{/iff}}
 
-    <div class="item-weight">
-      <label for="data.weight" class="resource-label short-label">{{localize "TWODSIX.Items.Component.unitWeight"}}
-        <input class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
+    <div class="item-weight multi-line">
       {{#iff data.subtype "!==" "cargo" }}
-      <label for="data.weightIsPct" class="resource-label short-label">{{localize "TWODSIX.Items.Component.weightIsPct"}}
-        <input type="checkbox" class="checkbox" name="data.weightIsPct" {{checked data.weightIsPct}} data-dtype="Boolean" />
-      </label>
+      <span class="short-label">
+      <label for="data.weightIsPct" class="resource-label short-label">{{localize "TWODSIX.Items.Component.weightIsPct"}} </label>
+      <input type="checkbox" class="checkbox" name="data.weightIsPct" {{checked data.weightIsPct}} data-dtype="Boolean" />
+      </span>
       {{/iff}}
+      <label for="data.weight" class="resource-label short-label">
+       {{#if data.weightIsPct}}
+         {{localize "TWODSIX.Items.Component.pctDisplacement"}}
+       {{else}}
+         {{localize "TWODSIX.Items.Component.unitWeight"}}
+       {{/if}}
+      <input class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>{{#if data.weightIsPct}}%{{/if}}
+    </label>
     </div>
 
-    {{#iff data.subtype "!==" "cargo" }}
-    <div class="item-power">
-      <label for="data.powerDraw" class="resource-label">
-      {{#iff data.subtype '==' "power"}}
+    {{#iff data.subtype "===" "fuel" }}
+    <div class="refined">
+      <label for="data.isRefined" class="resource-label short-label">{{localize "TWODSIX.Items.Component.IsRefined"}}
+        <input type="checkbox" class="checkbox" name="data.isRefined" {{checked data.isRefined}} data-dtype="Boolean" />
+      </label>
+    </div>
+    {{/iff}}
+
+    {{#iff data.subtype "!==" "cargo"}}
+    {{#iff data.subtype "!==" "fuel"}}
+    <div class="item-power multi-line">
+      <label for="data.generatesPower" class="resource-label short-label">{{localize "TWODSIX.Items.Component.GeneratesPower"}}
+        <input type="checkbox" class="checkbox" name="data.generatesPower" {{checked data.generatesPower}} data-dtype="Boolean" />
+      </label>
+      <label for="data.powerDraw" class="resource-label short-label">
+      {{#if data.generatesPower}}
         {{localize "TWODSIX.Items.Component.powerGenerated"}}
       {{else}}
         {{localize "TWODSIX.Items.Component.powerDraw"}}
-      {{/iff}}
-        <input id="data.powerDraw" type="text" name="data.powerDraw" value="{{data.powerDraw}}" data-dtype="Number"/>
-      </label>
+      {{/if}}
+      <input class="resource-label short-label" id="data.powerDraw" type="number" name="data.powerDraw" value="{{data.powerDraw}}" data-dtype="Number"/>
+    </label>
     </div>
+    {{/iff}}
 
     <div class="item-damage">
       <label for="data.damage" class="resource-label">{{localize "TWODSIX.Items.Component.damage"}}


### PR DESCRIPTION
weight is now total weight for all units
power is total power for all units - power gen is negative.

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Features and Fixes

* **What is the current behavior?** (You can also link to an open issue here)
Folks want ship component lists that are more useful


* **What is the new behavior (if this is a feature change)?**

> - Component power and weight list on ship actor is for all units - not per unit
> - Short description deleted from single-line list view
> - Checkbox to designate whether power is generated or consumed by component.
> - If a component generates power, its power value is prefixed by a '+' on the list
> -  Checkbox to designate whether fuel component is "refined"
> - Add TL for ship field


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
