### PR TITLE
fix: NPC image aspect ratio

### DIFF
--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -340,6 +340,8 @@ h2 {
 
 .npc-name-photo {
   grid-area: npc-name-photo;
+  height: 95%;
+  width: 100%;
 }
 
 .npc-bgi-stats {
@@ -439,10 +441,15 @@ img.character-info-mask {
   width: 18.5em;
 }
 
+.character-name .npc {
+  height: 22px !important;
+  width: 100% !important
+}
+
 .character-name input[type='text'] {
   background-color: transparent;
   position: relative;
-  width: 15.55em;
+  /*width: 15.55em;*/
   font-size: 1.2em;
   text-align: center;
   color: var(--s2d6-default-color) !important;
@@ -1223,7 +1230,7 @@ span.total-output {
   font-weight: bold;
   font-size: 15px;
   padding: 0.2em 0.2em 0.2em 0.5em;
-  border-radius: 1ch 0 4ch;
+  border-radius: 2ch 0 4ch;
 }
 
 .item-title-short {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -74,6 +74,8 @@
 
 .npc-name-photo {
   grid-area: npc-name-photo;
+  height: 95%;
+  width: 100%;
 }
 
 .npc-bgi-stats {
@@ -181,10 +183,16 @@ img.character-info-mask {
   border-color: inherit;
 }
 
+.character-name .npc {
+  height: 22px !important;
+  width: 100% !important
+}
+
+
 .character-name input[type='text'] {
   background-color: transparent !important;
   position: relative;
-  width: 30ch;
+  /*width: 30ch;*/
   font-size: 1.2em;
   text-align: center;
   border: none;

--- a/static/templates/actors/npc-sheet.html
+++ b/static/templates/actors/npc-sheet.html
@@ -4,8 +4,8 @@
       <div class="character-photo npc">
         <img class="profile-img" src="{{actor.img}}" {{#unless limited}}data-edit="img"{{/unless}} title="{{actor.name}}" alt='{{localize "TWODSIX.Actor.CharacterImage"}}'/>
       </div>
-      <div class="character-name npc" style="width: 100% !important;"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}'
-                                         onClick="this.select();" class="npc"/></div>
+      <div class="character-name npc" style="width: 100% !important; height: 24px !important;"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}'
+                                         onClick="this.select();"/></div>
     </div>
     {{#unless limited}}
     <div class="npc-bgi-stats">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)

NPC sheet image does not display tall and narrow images correctly

* **What is the new behavior (if this is a feature change)?**

Correct sizing of images

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
