### PR TITLE
force cut and paste for contenteditables to be plain text

### DIFF
--- a/src/module/sheets/AbstractTwodsixItemSheet.ts
+++ b/src/module/sheets/AbstractTwodsixItemSheet.ts
@@ -5,6 +5,10 @@ export abstract class AbstractTwodsixItemSheet extends ItemSheet {
       'focusout',
       this._onSubmit.bind(this)
     );
+    html.find('div[contenteditable="true"][data-edit]').on(
+      'paste',
+      onPasteStripFormatting.bind(this)
+    );
   }
 
 
@@ -18,5 +22,17 @@ export abstract class AbstractTwodsixItemSheet extends ItemSheet {
     data.data.owner = this.actor;
 
     return data;
+  }
+}
+
+export function onPasteStripFormatting(event): void {
+  if (event.originalEvent && event.originalEvent.clipboardData && event.originalEvent.clipboardData.getData) {
+    event.preventDefault();
+    const text = event.originalEvent.clipboardData.getData('text/plain');
+    window.document.execCommand('insertText', false, text);
+  } else if (event.clipboardData && event.clipboardData.getData) {
+    event.preventDefault();
+    const text = event.clipboardData.getData('text/plain');
+    window.document.execCommand('insertText', false, text);
   }
 }

--- a/static/templates/items/armor-sheet.html
+++ b/static/templates/items/armor-sheet.html
@@ -41,7 +41,7 @@
 
     <div class="item-descr">
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
-      <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
+      <div contenteditable="true" data-edit="data.description" >{{{data.description}}}</div>
     </div>
     {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
     {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Cutting and pasting into contenteditable text fields results in formatted text inconsistent with Twodsix style 


* **What is the new behavior (if this is a feature change)?**
Cutting and pasting into a conteneditable is forced to plain text.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
