### PR TITLE
feat: add option to show icons in bio

### DIFF
--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -29,6 +29,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.push(booleanSetting('useWoundedStatusIndicators', false));
     settings.push(booleanSetting('showWeightUsage', false));
     settings.push(booleanSetting('showItemReferences', true));
+    settings.push(booleanSetting('showIcons', false));
     return settings;
   }
 }

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -44,7 +44,8 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
       lifebloodInsteadOfCharacteristics: game.settings.get('twodsix', 'lifebloodInsteadOfCharacteristics'),
       showContaminationBelowLifeblood: game.settings.get('twodsix', 'showContaminationBelowLifeblood'),
       showLifebloodStamina: game.settings.get("twodsix", "showLifebloodStamina"),
-      showHeroPoints: game.settings.get("twodsix", "showHeroPoints")
+      showHeroPoints: game.settings.get("twodsix", "showHeroPoints"),
+      showIcons: game.settings.get("twodsix", "showIcons")
     };
     data.config = TWODSIX;
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -616,6 +616,10 @@
       "useTinyMCEditor": {
         "hint": "Use the embedded HTML editor for larger input blocks.",
         "name": "Use TinyMCE editor for larger input blocks."
+      },
+      "showIcons": {
+        "hint": "Use icons instead of text for biographical information.  Icons always shown when using lifeblood and stamina.",
+        "name": "Use icons for biographical information."
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -209,6 +209,7 @@ table tr:nth-child(even) {
   /* margin-bottom: 1em; */
   border: none !important;
   padding: 0;
+  margin-left: 3px;
 }
 
 .sheet footer.sheet-footer {

--- a/static/templates/actors/actor-sheet.html
+++ b/static/templates/actors/actor-sheet.html
@@ -13,7 +13,11 @@
       <div class="character-name"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}'
                                          onClick="this.select();"/></div>
       {{#unless limited}}
-        {{#if actor.data.settings.showLifebloodStamina}}
+        {{#if actor.data.settings.showLifebloodStamina }}
+          <div class="character-bgi">
+            {{> "systems/twodsix/templates/actors/parts/actor/actor-bgi-cd.html"}}
+          </div>
+        {{else if actor.data.settings.showIcons}}
           <div class="character-bgi">
             {{> "systems/twodsix/templates/actors/parts/actor/actor-bgi-cd.html"}}
           </div>


### PR DESCRIPTION
Option to show icons instead of text for biographical information

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
biographical information for actor sheet uses text or icons depending lifeblood/stamina settings.


* **What is the new behavior (if this is a feature change)?**
Add display option to force icons over text.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
