### PR TITLE
feat: add damage rolls on ship actor sheet

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -273,7 +273,7 @@ export default class TwodsixItem extends Item {
           `<label>Formula</label><input type="text" name="outputFormula" id="outputFormula" value= ${initFormula}></input>`,
         buttons: {
           Roll: {
-            label: `Roll`,
+            label: `<i class="fas fa-dice" alt="d6" ></i> Roll`,
             callback:
               (html: JQuery) => {
                 resolve( html.find('[name="outputFormula"]')[0]["value"]);

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -348,3 +348,24 @@ export default class TwodsixItem extends Item {
     }
   }
 }
+
+/**
+   * Handle clickable damage rolls.
+   * @param {Event} event   The originating click event
+   * @private
+   */
+export async function onRollDamage(event): Promise < void> {
+  event.preventDefault();
+  event.stopPropagation();
+  const itemId = $(event.currentTarget).parents('.item').data('item-id');
+  const item = this.actor.items.get(itemId) as TwodsixItem;
+
+  const element = $(event.currentTarget);
+  const bonusDamageFormula = String(element.data('bonus-damage') || 0);
+
+  const useInvertedShiftClick: boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
+  const showFormulaDialog = useInvertedShiftClick ? event["shiftKey"] : !event["shiftKey"];
+
+  await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, showFormulaDialog);
+
+}

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -268,12 +268,12 @@ export default class TwodsixItem extends Item {
   public static async confirmRollFormula(initFormula):Promise<string> {
     const returnText:string = await new Promise((resolve) => {
       new Dialog({
-        title: `Damage Roll Formula`,
+        title: game.i18n.localize("TWODSIX.Damage.DamageFormula"),
         content:
           `<label>Formula</label><input type="text" name="outputFormula" id="outputFormula" value= ${initFormula}></input>`,
         buttons: {
           Roll: {
-            label: `<i class="fas fa-dice" alt="d6" ></i> Roll`,
+            label: `<i class="fas fa-dice" alt="d6" ></i> ` + game.i18n.localize("TWODSIX.Rolls.Roll"),
             callback:
               (html: JQuery) => {
                 resolve( html.find('[name="outputFormula"]')[0]["value"]);

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -270,13 +270,13 @@ export default class TwodsixItem extends Item {
       new Dialog({
         title: `Damage Roll Formula`,
         content:
-          `<label>Formula</label><input type="text" name="outputFormula" value= ${initFormula}></input>`,
+          `<label>Formula</label><input type="text" name="outputFormula" id="outputFormula" value= ${initFormula}></input>`,
         buttons: {
           Roll: {
             label: `Roll`,
             callback:
-              (html) => {
-                resolve( html.find('[name="outputFormula"]')[0].value );
+              (html: JQuery) => {
+                resolve( html.find('[name="outputFormula"]')[0]["value"]);
               }
           }
         },

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -198,7 +198,10 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     const element = $(event.currentTarget);
     const bonusDamageFormula = String(element.data('bonus-damage') || 0);
 
-    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, true);
+    const useInvertedShiftClick:boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
+    const showFormulaDialog = useInvertedShiftClick ? event["shiftKey"] : !event["shiftKey"];
+
+    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, showFormulaDialog);
 
   }
 

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -2,7 +2,6 @@ import { AbstractTwodsixActorSheet } from "./AbstractTwodsixActorSheet";
 import { TWODSIX } from "../config";
 import TwodsixItem, { onRollDamage } from "../entities/TwodsixItem";
 import TwodsixActor from "../entities/TwodsixActor";
-import { DICE_ROLL_MODES } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs";
 import {Consumable, Skills} from "../../types/template";
 import { resolveUnknownAutoMode } from "../utils/rollItemMacro";
 

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -1,6 +1,6 @@
 import { AbstractTwodsixActorSheet } from "./AbstractTwodsixActorSheet";
 import { TWODSIX } from "../config";
-import TwodsixItem from "../entities/TwodsixItem";
+import TwodsixItem, { onRollDamage } from "../entities/TwodsixItem";
 import TwodsixActor from "../entities/TwodsixActor";
 import { DICE_ROLL_MODES } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs";
 import {Consumable, Skills} from "../../types/template";
@@ -76,7 +76,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     html.find('.rollable').on('click', this._onRollWrapper(this._onSkillRoll));
     html.find('.rollable-characteristic').on('click', this._onRollWrapper(this._onRollChar));
 
-    html.find('.roll-damage').on('click', this._onRollDamage.bind(this));
+    html.find('.roll-damage').on('click', onRollDamage.bind(this));
 
     html.find('#joat-skill-input').on('input', this._updateJoatSkill.bind(this));
     html.find('#joat-skill-input').on('blur', this._onJoatSkillBlur.bind(this));
@@ -182,27 +182,6 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
    */
   private async _onRollChar(event, showTrowDiag: boolean): Promise<void> {
     await (<TwodsixActor>this.actor).characteristicRoll({"characteristic": $(event.currentTarget).data("label")}, showTrowDiag);
-  }
-
-  /**
-   * Handle clickable damage rolls.
-   * @param {Event} event   The originating click event
-   * @private
-   */
-  private async _onRollDamage(event): Promise<void> {
-    event.preventDefault();
-    event.stopPropagation();
-    const itemId = $(event.currentTarget).parents('.item').data('item-id');
-    const item = this.actor.items.get(itemId) as TwodsixItem;
-
-    const element = $(event.currentTarget);
-    const bonusDamageFormula = String(element.data('bonus-damage') || 0);
-
-    const useInvertedShiftClick:boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
-    const showFormulaDialog = useInvertedShiftClick ? event["shiftKey"] : !event["shiftKey"];
-
-    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, showFormulaDialog);
-
   }
 
   private static untrainedToJoat(skillValue: number): number {

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -198,7 +198,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     const element = $(event.currentTarget);
     const bonusDamageFormula = String(element.data('bonus-damage') || 0);
 
-    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula);
+    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, true);
 
   }
 

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -236,7 +236,7 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     const element = $(event.currentTarget);
     const bonusDamageFormula = String(element.data('bonus-damage') || 0);
 
-    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula);
+    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, true);
 
   }
 }

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -4,8 +4,7 @@ import { getDataFromDropEvent } from "../utils/sheetUtils";
 import { TwodsixShipActions } from "../utils/TwodsixShipActions";
 import { AbstractTwodsixActorSheet } from "./AbstractTwodsixActorSheet";
 import { TwodsixShipPositionSheet } from "./TwodsixShipPositionSheet";
-import TwodsixItem from "../entities/TwodsixItem";
-import { DICE_ROLL_MODES } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs";
+import TwodsixItem, { onRollDamage } from "../entities/TwodsixItem";
 
 export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
 
@@ -103,7 +102,7 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     html.find(".component-toggle").on("click", this._onToggleComponent.bind(this));
     html.find(".ship-deck-link").on("click", this._onDeckplanClick.bind(this));
     html.find(".ship-deck-unlink").on("click", this._onDeckplanUnlink.bind(this));
-    html.find('.roll-damage').on('click', this._onRollDamage.bind(this));
+    html.find('.roll-damage').on('click', onRollDamage.bind(this));
   }
 
   private _onShipPositionCreate():void {
@@ -221,25 +220,5 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
       // console.warn(err); // uncomment when debugging
       return false;
     }
-  }
-  /**
-   * Handle clickable damage rolls.
-   * @param {Event} event   The originating click event
-   * @private
-   */
-  private async _onRollDamage(event): Promise<void> {
-    event.preventDefault();
-    event.stopPropagation();
-    const itemId = $(event.currentTarget).parents('.item').data('item-id');
-    const item = this.actor.items.get(itemId) as TwodsixItem;
-
-    const element = $(event.currentTarget);
-    const bonusDamageFormula = String(element.data('bonus-damage') || 0);
-
-    const useInvertedShiftClick:boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
-    const showFormulaDialog = useInvertedShiftClick ? event["shiftKey"] : !event["shiftKey"];
-
-    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, showFormulaDialog);
-
   }
 }

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -236,7 +236,10 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     const element = $(event.currentTarget);
     const bonusDamageFormula = String(element.data('bonus-damage') || 0);
 
-    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, true);
+    const useInvertedShiftClick:boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
+    const showFormulaDialog = useInvertedShiftClick ? event["shiftKey"] : !event["shiftKey"];
+
+    await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, showFormulaDialog);
 
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -655,7 +655,8 @@
       "OnlyDropConsumables": "Only consumables can be dropped on an item.",
       "DropFailedWith": "Drop failed with _ERROR_MSG_",
       "CouldNotFindItem": "Could not find an item with id: _ITEM_ID_",
-      "DraggedCompendiumIsNotItem": "The dragged compendium object is not an item."
+      "DraggedCompendiumIsNotItem": "The dragged compendium object is not an item.",
+      "InvalidRollFormula": "Not a valid damage roll formula."
     },
     "Warnings": {
       "ActorMissingItem": "Your controlled Actor does not have an item with id: _ITEM_ID_",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -24,7 +24,8 @@
       "ResultingStat": "Resulting stat",
       "UnallocatedDamage": "Unallocated damage",
       "CharacterIsDead": "Character is dead",
-      "DealDamageTo": "Deal damage to _ACTOR_NAME_"
+      "DealDamageTo": "Deal damage to _ACTOR_NAME_",
+      "DamageFormula": "Damage Formula"
     },
     "Dialogs": {
       "ROFPickerTitle": "Select a rate of fire",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -356,6 +356,7 @@ h2 {
   border-style: solid;
   border-radius: 2ch;
   border-color: var(--s2d6-default-color);
+  background-color: var(--s2d6-background-nearly-opaque);
 }
 
 .npc-skills, .npc-weapons {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -906,7 +906,7 @@ span.total-output {
   font-size: 15px;
   padding: 0.2em 0.2em 0.2em 0.5em;
   background-color: var(--s2d6-background-nearly-opaque);
-  border-radius: 1ch 1ch 0 0;
+  border-radius: 1.5ch 1.5ch 0 0;
 }
 .item-title {
   width: 207px;

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -32,7 +32,7 @@
           <span class="item-name centre">{{getComponentWeight this}}</span>
           <span class="item-name centre">{{getComponentPower this}}</span>
           <span class="item-name centre">{{#if item.data.data.availableQuantity}}{{item.data.data.availableQuantity}}/{{/if}}{{item.data.data.quantity}}</span>
-          <span class="item-name centre">{{twodsix_limitLength item.data.data.damage 7}}</span>
+          <span class="item-name centre roll-damage">{{twodsix_limitLength item.data.data.damage 7}}</span>
           <span class="item-name centre component-toggle">
             {{#iff item.data.data.status "===" 'operational'}} <i class="fas fa-check-circle" style="color: green;" title='{{localize "TWODSIX.Items.Component.operational"}}'></i>
             {{else}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Can't roll from valid damage value on ship component listing.
No way to change damage roll when clicking on actor sheet


* **What is the new behavior (if this is a feature change)?**
Allows damage roll and adds check for valid formula.
Prompts to confirm/change Roll formula.
Respects shift click function.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
