### PR TITLE
feat: add buttons to component hits list

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -209,6 +209,7 @@ export default class TwodsixItem extends Item {
       ui.notifications.error(game.i18n.localize("TWODSIX.Errors.NoDamageForWeapon"));
     }
     let rollFormula = weapon.damage;
+    console.log(rollFormula);
     if (confirmFormula) {
       rollFormula = await TwodsixItem.confirmRollFormula(rollFormula);
     }
@@ -270,7 +271,7 @@ export default class TwodsixItem extends Item {
       new Dialog({
         title: game.i18n.localize("TWODSIX.Damage.DamageFormula"),
         content:
-          `<label>Formula</label><input type="text" name="outputFormula" id="outputFormula" value= ${initFormula}></input>`,
+          `<label>Formula</label><input type="text" name="outputFormula" id="outputFormula" value="` + initFormula + `"></input>`,
         buttons: {
           Roll: {
             label: `<i class="fas fa-dice" alt="d6" ></i> ` + game.i18n.localize("TWODSIX.Rolls.Roll"),

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -282,6 +282,10 @@ export default function registerHandlebarsHelpers(): void {
     }
   });
 
+  Handlebars.registerHelper('getComponentMaxHits', () => {
+    return game.settings.get("twodsix", "maxComponentHits");
+  });
+
   // Handy for debugging
   Handlebars.registerHelper('debug', function (context) {
     console.log(context);

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -52,6 +52,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(stringChoiceSetting('showAlternativeCharacteristics', "base", TWODSIX.CharacteristicDisplayTypes));
     settings.push(stringSetting("alternativeShort1", "ALT1"));
     settings.push(stringSetting("alternativeShort2", "ALT2"));
+    settings.push(numberSetting('maxComponentHits', 3));
     return settings;
   }
 }

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -103,6 +103,7 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     html.find(".ship-deck-link").on("click", this._onDeckplanClick.bind(this));
     html.find(".ship-deck-unlink").on("click", this._onDeckplanUnlink.bind(this));
     html.find('.roll-damage').on('click', onRollDamage.bind(this));
+    html.find(".adjust-hits").on("click", this._onAdjustHitsCount.bind(this));
   }
 
   private _onShipPositionCreate():void {
@@ -160,6 +161,19 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
   private _onDeckplanUnlink() {
     if ((<Ship>this.actor.data.data)?.deckPlan) {
       this.actor.update({"data.deckPlan": ""});;
+    }
+  }
+
+  private async _onAdjustHitsCount(event): Promise<void> {
+    const modifier = parseInt(event.currentTarget["dataset"]["value"], 10);
+    const li = $(event.currentTarget).parents(".item");
+    const itemSelected = this.actor.items.get(li.data("itemId"));
+    const newHits = (<Component>itemSelected?.data.data).hits + modifier;
+    if (newHits <= <number>game.settings.get('twodsix', 'maxComponentHits') && newHits >= 0) {
+      await itemSelected?.update({"data.hits": newHits});
+    }
+    if (newHits === <number>game.settings.get('twodsix', 'maxComponentHits')) {
+      await itemSelected?.update({"data.status": "destroyed"});
     }
   }
 

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -168,12 +168,14 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     const modifier = parseInt(event.currentTarget["dataset"]["value"], 10);
     const li = $(event.currentTarget).parents(".item");
     const itemSelected = this.actor.items.get(li.data("itemId"));
-    const newHits = (<Component>itemSelected?.data.data).hits + modifier;
-    if (newHits <= <number>game.settings.get('twodsix', 'maxComponentHits') && newHits >= 0) {
-      await itemSelected?.update({"data.hits": newHits});
-    }
-    if (newHits === <number>game.settings.get('twodsix', 'maxComponentHits')) {
-      await itemSelected?.update({"data.status": "destroyed"});
+    if (itemSelected) {
+      const newHits = (<Component>itemSelected.data.data)?.hits + modifier;
+      if (newHits <= <number>game.settings.get('twodsix', 'maxComponentHits') && newHits >= 0) {
+        await itemSelected?.update({ "data.hits": newHits });
+      }
+      if (newHits === <number>game.settings.get('twodsix', 'maxComponentHits')) {
+        await itemSelected?.update({ "data.status": "destroyed" });
+      }
     }
   }
 

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -171,10 +171,10 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     if (itemSelected) {
       const newHits = (<Component>itemSelected.data.data)?.hits + modifier;
       if (newHits <= game.settings.get('twodsix', 'maxComponentHits') && newHits >= 0) {
-        await itemSelected?.update({ "data.hits": newHits });
+        await itemSelected.update({ "data.hits": newHits });
       }
       if (newHits === game.settings.get('twodsix', 'maxComponentHits')) {
-        await itemSelected?.update({ "data.status": "destroyed" });
+        await itemSelected.update({ "data.status": "destroyed" });
       }
     }
   }

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -170,10 +170,10 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     const itemSelected = this.actor.items.get(li.data("itemId"));
     if (itemSelected) {
       const newHits = (<Component>itemSelected.data.data)?.hits + modifier;
-      if (newHits <= <number>game.settings.get('twodsix', 'maxComponentHits') && newHits >= 0) {
+      if (newHits <= game.settings.get('twodsix', 'maxComponentHits') && newHits >= 0) {
         await itemSelected?.update({ "data.hits": newHits });
       }
-      if (newHits === <number>game.settings.get('twodsix', 'maxComponentHits')) {
+      if (newHits === game.settings.get('twodsix', 'maxComponentHits')) {
         await itemSelected?.update({ "data.status": "destroyed" });
       }
     }

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -313,6 +313,7 @@ export interface Component extends GearTemplate {
   rating:string;
   availableQuantity:string;
   damage:string;
+  hits: number;
   status:string;
   weightIsPct:boolean;
   isIllegal:boolean;

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -79,6 +79,7 @@ declare global {
       'twodsix.ruleset': string; //TODO Should be more specific, really
       'twodsix.alternativeShort1': string;
       'twodsix.alternativeShort2': string;
+      'twodsix.maxComponentHits':number;
       'twodsix.initiativeFormula': string;
       'twodsix.systemMigrationVersion': string;
       'twodsix.termForAdvantage': string;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -623,6 +623,10 @@
       "showIcons": {
         "hint": "Use icons instead of text for biographical information.  Icons always shown when using lifeblood and stamina.",
         "name": "Use icons for biographical information."
+      },
+      "maxComponentHits": {
+        "hint": "The number of hits at which the component is destroyed",
+        "name": "Maximum hits for a component."
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1853,6 +1853,7 @@ a.ship-notes-tab.active {
   color: var(--s2d6-item-active);
   position: sticky;
   top:0%;
+  z-index: 20;
 }
 
 .components-stored-double {
@@ -2148,25 +2149,29 @@ a:hover {
   cursor: default;
 }
 
-.consumable-row .combined-buttons {
+.combined-buttons {
   width: 40px;
   font-size: 0;
 }
 
-.consumable-row .combined-buttons button {
+.combined-buttons button {
   width: 20px;
   height: 20px;
   margin: 0;
   padding: 0;
   line-height: normal;
   cursor: pointer;
+  margin-top: -2px;
+}
+.consumable-row .combined-buttons button {
+  margin-top: 0;
 }
 
-.consumable-row .left-button {
+.left-button {
   border-radius: 10px 0 0 10px;
 }
 
-.consumable-row .right-button {
+.right-button {
   border-left: 0 solid var(--s2d6-item-active);
   border-radius: 0 10px 10px 0;
 }

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1104,7 +1104,7 @@ img.ship-mask-bg {
   font-size: 18px;
   /*width: 2.5em;*/
   border: none;
-  background-color: transparent !important;
+  background-color: var(--s2d6-input-background);
 }
 
 .ship-state-grid {
@@ -1191,8 +1191,9 @@ img.ship-mask-bg {
 }
 
 .ship-mass input, .ship-tl input {
-  background-color: var(--s2d6-background-nearly-transparent) !important;
-  border: 1px solid;
+  background-color: var(--s2d6-input-background) !important;
+  border: 1px solid var(--color-text-dark-primary);
+  border-radius: 0.5ch;
 }
 
 .ship-mass input[type="text"] {
@@ -1756,25 +1757,29 @@ button.flexrow.flex-group-center.toggle-skills {
   cursor: default;
 }
 
-.consumable-row .combined-buttons {
+.combined-buttons {
   width: 40px;
   font-size: 0;
 }
 
-.consumable-row .combined-buttons button {
+.combined-buttons button {
   width: 20px;
   height: 20px;
   margin: 0;
   padding: 0;
   line-height: normal;
   cursor: pointer;
+  margin-top: -2px;
+}
+.consumable-row .combined-buttons button {
+  margin-top: 0;
 }
 
-.consumable-row .left-button {
+.left-button {
   border-radius: 10px 0 0 10px;
 }
 
-.consumable-row .right-button {
+.right-button {
   border-left: 0 solid var(--s2d6-item-active);
   border-radius: 0 10px 10px 0;
 }

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -35,10 +35,15 @@
           {{#iff item.data.data.subtype "===" "armament"}}
           <span class="item-name centre">
             {{#iff item.data.data.damage "!==" ""}}<span class="roll-damage orange">{{twodsix_limitLength item.data.data.damage 6}}</span> / {{/iff}}
-          {{item.data.data.hits}}</span>
+          {{item.data.data.hits}}<br>
           {{else}}
-          <span class="item-name centre">{{item.data.data.hits}}</span>
+          <span class="item-name centre">{{item.data.data.hits}}
           {{/iff}}
+          <span class="combined-buttons">
+            <button class="left-button adjust-hits" {{#iff currentCount "===" 0}}disabled{{/iff}} data-value="-1">-</button>
+            <button class="right-button adjust-hits" {{#iff currentCount "===" 9}}disabled{{/iff}} data-value="1">+</button>
+          </span>
+          </span>
           <span class="item-name centre component-toggle">
             {{#iff item.data.data.status "===" 'operational'}} <i class="fas fa-check-circle" style="color: green;" title='{{localize "TWODSIX.Items.Component.operational"}}'></i>
             {{else}}

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -118,7 +118,7 @@
     {{/iff}}
     <div class="item-hits">
       <label for="data.hits" class="resource-label">{{localize "TWODSIX.Items.Component.hits"}}
-        <input id="data.hits" type="number" name="data.hits" value="{{data.hits}}" step = "1" min = "0"/>
+        <input id="data.hits" type="number" name="data.hits" value="{{data.hits}}" step = "1" min = "0" max = "{{getComponentMaxHits}}"/>
       </label>
     </div>
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Hits to components must be entered on component data sheet.


* **What is the new behavior (if this is a feature change)?**
For the component single row listing on ship sheet, buttons have been added to adjust the hits without having to open the component sheet.  Also, added a ruleset setting for maximum component hits where the item is destroyed.  Default is three.  And, when this number of hits is reached, the component status is automatically set to destroyed.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
