### PR TITLE
feat: display trait info on name click

### DIFF
--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -96,6 +96,9 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     html.find(".item-value-edit").on("click", (event) => {
       $(event.currentTarget).trigger("select");
     });
+
+    //display trait item to chat
+    html.find(".showChat").on("click", this._onSendToChat.bind(this));
   }
 
 
@@ -289,6 +292,20 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
       } else if (itemSelected.type === "consumable") {
         itemSelected.update({"data.quantity": newValue});
       }
+    }
+  }
+
+  /**
+   * Handle send to chat.
+   * @param {Event} event   The originating click event
+   * @private
+   */
+  private async _onSendToChat(event): Promise<void> {
+    const item = <TwodsixItem>this.getItem(event);
+    const picture = item.data.img;
+    if (item.type === "trait") {
+      const msg = `<div style ="display: table-cell"><img src="${picture}" alt="" height=40px max-width=40px></img>  <strong>${item.name}</strong></div><br>${item.data.data["description"]}`;
+      ChatMessage.create({ content: msg, speaker: ChatMessage.getSpeaker({ actor: this.actor }) });
     }
   }
 }

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1404,6 +1404,10 @@ span.total-output {
   padding: 0.2em;
 }
 
+.showChat {
+  cursor: pointer;
+}
+
 /*-------- Notes Tab ----*/
 
 .notes-container {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1015,6 +1015,9 @@ span.total-output {
   height: 10em;
 }
 
+.showChat {
+  cursor: pointer;
+}
 /*-------- Notes Tab ----*/
 
 .notes-container {

--- a/static/templates/actors/parts/actor/actor-info.html
+++ b/static/templates/actors/parts/actor/actor-info.html
@@ -14,7 +14,7 @@
     <ol class="ol-no-indent">
       <li class="item flexrow" data-item-id="{{item.id}}">
         <span class="items-traits">
-          <span class="item-name">{{item.name}}</span>
+          <span class="item-name showChat">{{item.name}}</span>
           <span class="item-name centre">{{item.data.data.value}}</span>
           <span class="item-name centre">{{item.data.data.shortdescr}}</span>
           <span class="item-controls centre">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
No way to share trait descriptions easily


* **What is the new behavior (if this is a feature change)?**
Trait description is shared in chat when clicking on name.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
