### PR TITLE
fix: unable to set hull component as pct of hull value

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -96,7 +96,7 @@ export default class TwodsixActor extends Actor {
       },
       cost: {
         hullValue: 0,
-        hullOffset: 0,
+        hullOffset: 1.0,
         percentHull: 0,
         perHullTon: 0,
         componentValue: 0,
@@ -130,7 +130,7 @@ export default class TwodsixActor extends Actor {
     calcShipStats.weight.available = actorData.data.shipStats.mass.max - (calcShipStats.weight.vehicles ?? 0) - (calcShipStats.weight.cargo ?? 0)
       - (calcShipStats.weight.fuel ?? 0) - (calcShipStats.weight.systems ?? 0);
 
-    calcShipStats.cost.total = calcShipStats.cost.componentValue + calcShipStats.cost.hullValue * ( 1 + calcShipStats.cost.percentHull / 100 ) * ( 1 + calcShipStats.cost.hullOffset / 100 )
+    calcShipStats.cost.total = calcShipStats.cost.componentValue + calcShipStats.cost.hullValue * ( 1 + calcShipStats.cost.percentHull / 100 ) * calcShipStats.cost.hullOffset
       + calcShipStats.cost.perHullTon * (actorData.data.shipStats.mass.max || calcShipStats.weight.baseHull);
     if(actorData.data.isMassProduced) {
       calcShipStats.cost.total *= (1 - game.settings.get("twodsix", "massProductionDiscount"));
@@ -161,7 +161,7 @@ export default class TwodsixActor extends Actor {
                 calcShipStats.cost.hullValue += Number(anComponent.price) * weightForItem;
                 break;
               case "pctHull":
-                calcShipStats.cost.hullOffset += Number(anComponent.price);
+                calcShipStats.cost.hullOffset *= (1 + Number(anComponent.price) / 100);
                 break;
               case "perHullTon":
                 calcShipStats.cost.hullValue += (actorData.data.shipStats.mass.max || calcShipStats.weight.baseHull) * Number(anComponent.price);

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -96,6 +96,7 @@ export default class TwodsixActor extends Actor {
       },
       cost: {
         hullValue: 0,
+        hullOffset: 0,
         percentHull: 0,
         perHullTon: 0,
         componentValue: 0,
@@ -129,7 +130,7 @@ export default class TwodsixActor extends Actor {
     calcShipStats.weight.available = actorData.data.shipStats.mass.max - (calcShipStats.weight.vehicles ?? 0) - (calcShipStats.weight.cargo ?? 0)
       - (calcShipStats.weight.fuel ?? 0) - (calcShipStats.weight.systems ?? 0);
 
-    calcShipStats.cost.total = calcShipStats.cost.componentValue + calcShipStats.cost.hullValue * ( 1 + calcShipStats.cost.percentHull / 100 )
+    calcShipStats.cost.total = calcShipStats.cost.componentValue + calcShipStats.cost.hullValue * ( 1 + calcShipStats.cost.percentHull / 100 ) * ( 1 + calcShipStats.cost.hullOffset / 100 )
       + calcShipStats.cost.perHullTon * (actorData.data.shipStats.mass.max || calcShipStats.weight.baseHull);
     if(actorData.data.isMassProduced) {
       calcShipStats.cost.total *= (1 - game.settings.get("twodsix", "massProductionDiscount"));
@@ -148,8 +149,25 @@ export default class TwodsixActor extends Actor {
 
     function _calculateComponentCost(anComponent: Component, weightForItem: number): void {
       if (anComponent.subtype !== "fuel" && anComponent.subtype !== "cargo") {
-        if (anComponent.subtype === "hull") {
-          calcShipStats.cost.hullValue += (actorData.data.shipStats.mass.max || calcShipStats.weight.baseHull) * Number(anComponent.price);
+        if (anComponent.subtype === "hull" ) {
+          if (anComponent.isBaseHull) {
+            calcShipStats.cost.hullValue += (actorData.data.shipStats.mass.max || calcShipStats.weight.baseHull) * Number(anComponent.price);
+          } else {
+            switch (anComponent.pricingBasis) {
+              case "perUnit":
+                calcShipStats.cost.hullValue += Number(anComponent.price) * anComponent.quantity;
+                break;
+              case "perCompTon":
+                calcShipStats.cost.hullValue += Number(anComponent.price) * weightForItem;
+                break;
+              case "pctHull":
+                calcShipStats.cost.hullOffset += Number(anComponent.price);
+                break;
+              case "perHullTon":
+                calcShipStats.cost.hullValue += (actorData.data.shipStats.mass.max || calcShipStats.weight.baseHull) * Number(anComponent.price);
+                break;
+            }
+          }
         } else {
           switch (anComponent.pricingBasis) {
             case "perUnit":

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -31,7 +31,7 @@
     {{/iff}}
 
     <div class="item-subtype">
-      <label for="data.subtype" class="resource-label">{{localize "TWODSIX.Actor.Items.Subtype"}}:</label>
+      <label for="data.subtype" class="resource-label">{{localize "TWODSIX.Actor.Items.Subtype"}}: </label>
       <select id="data.subtype" name="data.subtype">
         {{selectOptions data.config.ComponentTypes selected = data.subtype localize = true}}
       </select>
@@ -124,9 +124,13 @@
 
     <div class="item-price">
       <label for = "data.price" class="resource-label short-label">{{localize "TWODSIX.Items.Component.PricingBasis"}}: <input class="short-label" id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/></label>
+      {{#if data.isBaseHull}}
+        {{localize "TWODSIX.Items.Component.perHullTon"}}
+      {{else}}
       <select id = "data.pricingBasis" name = "data.pricingBasis" >
         {{selectOptions data.config.PricingOptions selected = data.pricingBasis localize = true}}
       </select>
+      {{/if}}
     </div>
 
     {{else}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix


* **What is the current behavior?** (You can also link to an open issue here)
When specifying a hull component that changes the base hull weight by a percentage, the calculations don't work.


* **What is the new behavior (if this is a feature change)?**
Allow a hull component to be a percentage of the hull value.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
The base hull value MUST be a value times the weight (e.g. per hull ton).


* **Other information**:
