### PR TITLE
fix: specifying skills for ship actions

### DIFF
--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -1,3 +1,4 @@
+import { Skills } from "src/types/template";
 import { AvailableShipActionData, AvailableShipActions, ExtraData } from "../../types/twodsix";
 import { TWODSIX } from "../config";
 import TwodsixItem from "../entities/TwodsixItem";
@@ -37,6 +38,8 @@ export class TwodsixShipActions {
     if (parsedResult !== null) {
       const [, parsedSkill, char, diff] = parsedResult;
       let skill = extra.actor?.items.filter((itm: TwodsixItem) => itm.name === parsedSkill && itm.type === "skills")[0] as TwodsixItem;
+
+      /*if skill missing, try to use Untrained*/
       if (!skill) {
         skill = extra.actor?.items.filter((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained") && itm.type === "skills")[0] as TwodsixItem;
         if (!skill) {
@@ -44,8 +47,16 @@ export class TwodsixShipActions {
           return false;
         }
       }
+
+      /*get characteristic key, default to skill key if none specificed in formula */
+      let characteristicKey = "";
+      if(!char) {
+        characteristicKey = getKeyByValue(TWODSIX.CHARACTERISTICS, (<Skills>skill.data.data).characteristic);
+      } else {
+        characteristicKey = getCharacteristicFromDisplayLabel(char, extra.actor);
+      }
+
       const charObject = extra.actor?.data.data["characteristics"];
-      const characteristicKey = getCharacteristicFromDisplayLabel(char, extra.actor);
       let shortLabel = "NONE";
       let displayLabel = "NONE";
       if (charObject && characteristicKey) {

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -31,7 +31,7 @@ export class TwodsixShipActions {
     const useInvertedShiftClick: boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
     const showTrowDiag = useInvertedShiftClick ? extra.event["shiftKey"] : !extra.event["shiftKey"];
     const difficulties = TWODSIX.DIFFICULTIES[(<number>game.settings.get('twodsix', 'difficultyListUsed'))];
-    const re = new RegExp(/^(.+?)\/?([a-zA-Z]*?) ?(\d*?)\+?$/);
+    const re = new RegExp(/^(.[^/]+)\/?([a-zA-Z]{0,3}) ?(\d{0,2})\+? ?=? ?(.*?)$/);
     const parsedResult: RegExpMatchArray | null = re.exec(text);
 
     if (parsedResult !== null) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)

When specifying a skill for ship actions, a '/' must terminate the skill name 

* **What is the new behavior (if this is a feature change)?**
Skill name no longer needs slash if just specifying a skill and no modifiers


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
