### PR TITLE
fix: get rid of extra comma on npc skill list

### DIFF
--- a/static/templates/actors/npc-sheet.html
+++ b/static/templates/actors/npc-sheet.html
@@ -35,14 +35,14 @@
           {{#if (twodsix_filterSkills item)}}
               <span class="item" data-item-id="{{item.id}}" style = "display: inline-block;">
                 <span class="item-name rollable" data-label="{{item.name}}" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
-                <input style="width: 3ch;" class= "item-value-edit" type="number" value="{{item.data.data.value}}"/>{{#unless @last}}, {{/unless}}
+                <input style="width: 3ch;" class= "item-value-edit" type="number" value="{{item.data.data.value}}"/>, 
               </span>
           {{/if}}
        {{/if}}
       {{/each_sort_by_name}}
       {{#if (twodsix_hideUntrainedSkills -1)}}
       <span class="item" data-item-id="{{untrainedSkill.id}}">
-          <text class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}">, {{untrainedSkill.name}}</text>
+          <text class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}"> {{untrainedSkill.name}}</text>
           <input style="width: 3ch;" class="item-value-edit" type="number" value= "{{untrainedSkill.data.data.value}}" readonly/>
       </span>
       {{/if}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Extra comma shown on skill list if unskilled last skill item


* **What is the new behavior (if this is a feature change)?**
Do not show extra comma


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
