### PR TITLE
fix: allow more pricing options for hull component

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -286,13 +286,22 @@ export const MovementUnits = {
 };
 
 /**
- * The valid pricing bases for components.
+ * The valid pricing bases for components other than base hull.
  */
 export const PricingOptions = {
   perUnit: "TWODSIX.Items.Component.perUnit",
   perCompTon: "TWODSIX.Items.Component.perCompTon",
   perHullTon: "TWODSIX.Items.Component.perHullTon",
   pctHull: "TWODSIX.Items.Component.pctHull"
+};
+
+/**
+ * The valid pricing bases for base hull.
+ */
+export const HullPricingOptions = {
+  perUnit: "TWODSIX.Items.Component.perUnit",
+  perCompTon: "TWODSIX.Items.Component.perCompTon",
+  perHullTon: "TWODSIX.Items.Component.perHullTon"
 };
 
 /**
@@ -352,6 +361,7 @@ export type TWODSIX = {
   MovementUnits: typeof MovementUnits,
   MovementType: typeof MovementTypes,
   PricingOptions: typeof PricingOptions,
+  HullPricingOptions: typeof HullPricingOptions,
   ComponentStates: typeof ComponentStates,
   ComponentTypes: typeof ComponentTypes,
   CharacteristicDisplayTypes: typeof CharacteristicDisplayTypes
@@ -368,6 +378,7 @@ export const TWODSIX = {
   MovementUnits: MovementUnits,
   MovementType: MovementTypes,
   PricingOptions: PricingOptions,
+  HullPricingOptions: HullPricingOptions,
   ComponentStates: ComponentStates,
   ComponentTypes: ComponentTypes,
   CharacteristicDisplayTypes: CharacteristicDisplayTypes

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -160,24 +160,20 @@ export default class TwodsixActor extends Actor {
 
     function _calculateComponentCost(anComponent: Component, weightForItem: number): void {
       if (anComponent.subtype !== "fuel" && anComponent.subtype !== "cargo") {
-        if (anComponent.subtype === "hull" ) {
-          if (anComponent.isBaseHull) {
-            calcShipStats.cost.hullValue += (actorData.data.shipStats.mass.max || calcShipStats.weight.baseHull) * Number(anComponent.price);
-          } else {
-            switch (anComponent.pricingBasis) {
-              case "perUnit":
-                calcShipStats.cost.hullValue += Number(anComponent.price) * anComponent.quantity;
-                break;
-              case "perCompTon":
-                calcShipStats.cost.hullValue += Number(anComponent.price) * weightForItem;
-                break;
-              case "pctHull":
-                calcShipStats.cost.hullOffset *= (1 + Number(anComponent.price) / 100);
-                break;
-              case "perHullTon":
-                calcShipStats.cost.hullValue += (actorData.data.shipStats.mass.max || calcShipStats.weight.baseHull) * Number(anComponent.price);
-                break;
-            }
+        if (anComponent.subtype === "hull") {
+          switch (anComponent.pricingBasis) {
+            case "perUnit":
+              calcShipStats.cost.hullValue += Number(anComponent.price) * anComponent.quantity;
+              break;
+            case "perCompTon":
+              calcShipStats.cost.hullValue += Number(anComponent.price) * weightForItem;
+              break;
+            case "pctHull":
+              calcShipStats.cost.hullOffset *= (1 + Number(anComponent.price) / 100);
+              break;
+            case "perHullTon":
+              calcShipStats.cost.hullValue += (actorData.data.shipStats.mass.max || calcShipStats.weight.baseHull) * Number(anComponent.price);
+              break;
           }
         } else {
           switch (anComponent.pricingBasis) {

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -115,8 +115,13 @@ export default class TwodsixActor extends Actor {
       }
     };
 
-    if (!actorData.data.shipStats.mass.max || actorData.data.shipStats.mass.max < 0) {
-      actorData.data.shipStats.mass.max = _estimateDisplacement();
+    /* estimate displacement if missing */
+    if (!actorData.data.shipStats.mass.max || actorData.data.shipStats.mass.max <= 0) {
+      const calcDisplacement = _estimateDisplacement();
+      if (calcDisplacement && calcDisplacement > 0) {
+        actorData.update({"data.shipStats.mass.max": calcDisplacement});
+        /*actorData.data.shipStats.mass.max = calcDisplacement;*/
+      }
     }
 
     actorData.items.filter((item: TwodsixItem) => item.type === "component").forEach((item: TwodsixItem) => {
@@ -128,6 +133,9 @@ export default class TwodsixActor extends Actor {
       _allocatePower(anComponent, powerForItem, item);
 
       /* Allocate Weight*/
+      if (anComponent.weightIsPct && anComponent.isBaseHull) {
+        item.update({'data.weightIsPct': false});
+      }
       _allocateWeight(anComponent, weightForItem);
 
       /*Calculate Cost*/

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -374,7 +374,7 @@
       "JDrive": "J-Drive",
       "Jump": "Jump",
       "MacroSkill": "Macro/Skill",
-      "MakesChatRollAction": "Takes _ACTION_NAME_ action from _POSITION_NAME_ position",
+      "MakesChatRollAction": "Takes the _ACTION_NAME_ action from the _POSITION_NAME_ position",
       "MaintPM": "Maintenance P/M",
       "MANIFEST": "MANIFEST",
       "MAX": "MAX",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -606,9 +606,9 @@ span.bgi-age {
 span.bgi-armor, span.bgi-encumbrance, span.bgi-radExposure, span.bgi-charEdit {
   margin-right: 0.5em;
   height: 26px;
-  font-size: 16px;
+  /*font-size: 16px;
   font-weight: bold;
-  color: var(--s2d6-default-color) !important;
+  color: var(--s2d6-default-color) !important; */
 }
 
 span.bgi-charEdit {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1194,7 +1194,7 @@ span.total-output {
 }
 
 .short-label input[type='text'], .short-label input[type='number'] {
-  width: 18ch;
+  max-width: 18ch;
 }
 
 .multi-line {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -357,7 +357,7 @@ span.bgi-charEdit {
 
 .character-bgi span {
   display: inline-block;
-  font-weight: bold;
+  /*font-weight: bold;*/
 }
 
 .character-characteristics {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -847,7 +847,7 @@ span.total-output {
 }
 
 .short-label input[type='text'], .short-label input[type='number'] {
-  width: 18ch;
+  max-width: 18ch;
 }
 
 .multi-line {

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -58,27 +58,34 @@
       </label>
     </div>
     {{/iff}}
-
-    <div class="item-weight multi-line">
-      {{#iff data.subtype "!==" "cargo" }}
-      <label for="data.weightIsPct" class="resource-label short-label">{{localize "TWODSIX.Items.Component.weightIsPct"}}
-      <input type="checkbox" class="checkbox" name="data.weightIsPct" {{checked data.weightIsPct}} data-dtype="Boolean" />
-      </label>
-      {{/iff}}
-      <label for="data.weight" class="resource-label short-label">
-       {{#if data.weightIsPct}}
-         {{localize "TWODSIX.Items.Component.pctDisplacement"}}
-       {{else}}
-         {{localize "TWODSIX.Items.Component.unitWeight"}}
-       {{/if}}
-      <input class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>{{#if data.weightIsPct}}%{{/if}}
-      </label>
+    <div class="item-weight">
       {{#iff data.subtype "===" "hull" }}
-        <span class="short-label">
-        <label for="data.isBaseHull" class="resource-label short-label">{{localize "TWODSIX.Items.Component.isBaseHull"}} </label>
-        <input type="checkbox" class="checkbox" name="data.isBaseHull" {{checked data.isBaseHull}} data-dtype="Boolean" />
-        </span>
+        <label for="data.isBaseHull" class="resource-label short-label">{{localize "TWODSIX.Items.Component.isBaseHull"}}
+          <input type="checkbox" class="checkbox" name="data.isBaseHull" {{checked data.isBaseHull}} data-dtype="Boolean" />
+        </label>
       {{/iff}}
+    <div class="item-weight multi-line">
+      {{#if data.isBaseHull}}
+      <label for="data.weight" class="resource-label short-label">{{localize "TWODSIX.Items.Component.unitWeight"}}
+        <input class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
+      </label>
+      {{else}}
+        {{#iff data.subtype "!==" "cargo" }}
+          <label for="data.weightIsPct" class="resource-label short-label">{{localize "TWODSIX.Items.Component.weightIsPct"}}
+          <input type="checkbox" class="checkbox" name="data.weightIsPct" {{checked data.weightIsPct}} data-dtype="Boolean" />
+          </label>
+        {{/iff}}
+
+          <label for="data.weight" class="resource-label short-label">
+          {{#if data.weightIsPct}}
+            {{localize "TWODSIX.Items.Component.pctDisplacement"}}
+          {{else}}
+            {{localize "TWODSIX.Items.Component.unitWeight"}}
+          {{/if}}
+          <input class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>{{#if data.weightIsPct}}%{{/if}}
+          </label>
+
+      {{/if}}
     </div>
 
     {{#iff data.subtype "===" "fuel" }}

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -124,13 +124,14 @@
 
     <div class="item-price">
       <label for = "data.price" class="resource-label short-label">{{localize "TWODSIX.Items.Component.PricingBasis"}}: <input class="short-label" id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/></label>
-      {{#if data.isBaseHull}}
-        {{localize "TWODSIX.Items.Component.perHullTon"}}
-      {{else}}
+
       <select id = "data.pricingBasis" name = "data.pricingBasis" >
-        {{selectOptions data.config.PricingOptions selected = data.pricingBasis localize = true}}
+        {{#if data.isBaseHull}}
+          {{selectOptions data.config.HullPricingOptions selected = data.pricingBasis localize = true}}
+        {{else}}
+          {{selectOptions data.config.PricingOptions selected = data.pricingBasis localize = true}}
+        {{/if}}
       </select>
-      {{/if}}
     </div>
 
     {{else}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)

Can't specify fixed hull cost for baseline hull component

* **What is the new behavior (if this is a feature change)?**
Allow three options for base hull: MCr/unit MCr/hull ton, MCr/component ton.  Note that MCr/Hull and MCr/component are the same - both kept for backwards compatibility.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
