### PR TITLE
feat: improve item sheet layouts

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -133,9 +133,6 @@ export default class TwodsixActor extends Actor {
       _allocatePower(anComponent, powerForItem, item);
 
       /* Allocate Weight*/
-      if (anComponent.weightIsPct && anComponent.isBaseHull) {
-        item.update({'data.weightIsPct': false});
-      }
       _allocateWeight(anComponent, weightForItem);
 
       /*Calculate Cost*/

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -2,7 +2,7 @@ import { AbstractTwodsixItemSheet } from "./AbstractTwodsixItemSheet";
 import { TWODSIX } from "../config";
 import TwodsixItem from "../entities/TwodsixItem";
 import { getDataFromDropEvent, getItemDataFromDropData } from "../utils/sheetUtils";
-import { GearTemplate } from "src/types/template";
+import { Component, GearTemplate } from "src/types/template";
 
 /**
  * Extend the basic ItemSheet with some very simple modifications
@@ -80,12 +80,32 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
     this.handleContentEditable(html);
     html.find('.open-link').on('click', this._openPDFReference.bind(this));
     html.find(`[name="data.subtype"]`).on('change', this._changeSubtype.bind(this));
+    html.find(`[name="data.isBaseHull"]`).on('change', this._changeIsBaseHull.bind(this));
   }
   private async _changeSubtype(event) {
+    /*Update from default other image*/
     if (this.item.img === "systems/twodsix/assets/icons/components/otherInternal.svg" || this.item.img === "systems/twodsix/assets/icons/components/other.svg") {
       await this.item.update({
         img: "systems/twodsix/assets/icons/components/" + event.currentTarget.selectedOptions[0].value + ".svg"
       });
+    }
+
+    /*Prevent cargo from using %hull weight*/
+    const anComponent = <Component> this.item.data.data;
+    if (anComponent.weightIsPct && event.currentTarget.value === "cargo") {
+      this.item.update({'data.weightIsPct': false});
+    }
+    /*Unset isBaseHull if not hull component*/
+    if (event.currentTarget.value !== "hull" && anComponent.isBaseHull) {
+      this.item.update({'data.isBaseHull': false});
+    }
+  }
+
+  private async _changeIsBaseHull() {
+    const anComponent = <Component> this.item.data.data;
+    /*Unset isWeightPct if changing to base hull*/
+    if (!anComponent.isBaseHull && anComponent.weightIsPct) {
+      this.item.update({'data.weightIsPct': false});
     }
   }
 

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -334,7 +334,7 @@ export interface Component extends GearTemplate {
   rating:string;
   availableQuantity:string;
   damage:string;
-  hits: number;
+  hits:number;
   status:string;
   weightIsPct:boolean;
   isIllegal:boolean;
@@ -345,6 +345,7 @@ export interface Component extends GearTemplate {
   features:string;
   pricingBasis:string;
   isBaseHull:boolean;
+  rollModifier:string;
 }
 
 export interface Consumable extends GearTemplate {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -242,7 +242,9 @@
         "perCompTon": "MCr per component ton",
         "perHullTon": "MCr per hull ton",
         "pctHull": "Percent of base hull value",
-        "isBaseHull":"Is Baseline Hull?"
+        "isBaseHull":"Is Baseline Hull?",
+        "RollModifier":"Roll Modifier",
+        "DM":"DM"
       },
       "Equipment": {
         "AssignSkill": "Assign Skill",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2201,7 +2201,7 @@ a:hover {
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
 .item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-reference, .item-features, .item-subtype, .item-type,
 .item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
-.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description {
+.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .form-section {
   margin-top: 0.3em;
   display: grid;
   grid-template-columns: 1fr 2fr;
@@ -2212,7 +2212,7 @@ select.form-input, input.form-input, span.form-input {
   align-self: center;
 }
 
-.mini-grid, .form-section, .item-descr {
+.mini-grid, .item-descr {
   margin-top: 0.5em;
 }
 

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -318,8 +318,13 @@ form .form-group span.units {
   cursor: pointer;
 }
 
+.item-name {
+  align-self: center;
+}
+
 .centre {
   text-align: center;
+  align-self: center;
 }
 
 .component-toggle:hover {
@@ -2022,10 +2027,10 @@ a.ship-notes-tab.active {
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 20em 4em 4em 4em 4em 4em 4.5em 4em 3em;
+  grid-template-columns: 16em 4em 4em 4em 4em 4em 4em 4.5em 4em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
-  grid-template-areas: ". . . . . . . . .";
+  grid-template-areas: ". . . . . . . . . .";
 }
 
 .grid-columns-single-row:nth-of-type(even) {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1191,11 +1191,17 @@ span.total-output {
 }
 
 .resource-label {
-  padding-top: 0.2em;
+  text-align: right;
+  align-self: center;
+}
+
+.open-link {
+  text-align: left;
+  align-self: center;
 }
 
 .short-label input[type='text'], .short-label input[type='number'] {
-  max-width: 18ch;
+  max-width: 14ch;
 }
 
 .multi-line {
@@ -2191,86 +2197,21 @@ a:hover {
   text-shadow: 0 0 5px var(--s2d6-default-color);
 }
 
-.item-type {
-  position: relative;
-  float: right;
-  margin-bottom: 0.4em;
+.item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
+.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-reference, .item-features, .item-subtype, .item-type,
+.item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
+.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description {
+  margin-top: 0.3em;
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 1ch;
 }
 
-.item-tl {
-  margin-top: 0.5em;
+select.form-input, input.form-input, span.form-input {
+  align-self: center;
 }
 
-.item-price {
-  margin-top: 0.5em;
-}
-
-.item-skill {
-  margin-top: 0.5em;
-}
-
-.item-skillModifier {
-  margin-top: 0.5em;
-}
-
-.item-ammo {
-  margin-top: 0.5em;
-}
-
-.item-qty {
-  margin-top: 0.5em;
-}
-
-.item-weight {
-  margin-top: 0.5em;
-}
-
-.item-power {
-  margin-top: 0.5em;
-}
-
-.item-damage {
-  margin-top: 0.5em;
-}
-
-.form-section {
-  margin-top: 0.5em;
-}
-
-.item-range {
-  margin-top: 0.5em;
-}
-
-.item-descr {
-  margin-top: 0.5em;
-}
-
-.item-lawLevel {
-  margin-top: 0.5em;
-}
-
-.item-rangeBand {
-  margin-top: 0.5em;
-}
-
-.item-weaponType {
-  margin-top: 0.5em;
-}
-
-.item-damageType {
-  margin-top: 0.5em;
-}
-
-.item-rateOfFire {
-  margin-top: 0.5em;
-}
-
-.item-recoil {
-  margin-top: 0.5em;
-}
-
-.item-short, .item-armor, .item-secondaryArmor, .item-radiationProtection, .item-lvl, .item-prereq, .mini-grid, .item-reference, .item-hits,
-.item-features, .item-subtype {
+.mini-grid, .form-section, .item-descr {
   margin-top: 0.5em;
 }
 
@@ -2279,8 +2220,7 @@ a:hover {
 }
 
 .item-descr div[contenteditable] {
-  min-height: 140px;
-  background: rgba(0, 0, 0, 0.22);
+  min-height: 10ch;
   border: none;
   padding: 0.5em;
 }

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -120,6 +120,7 @@ input[type='text']:focus, input[type='number']:focus, input[type='password']:foc
 
 input[type= 'checkbox'] {
   vertical-align: middle;
+  align-self: center;
 }
 
 label.checkbox > input[type="checkbox"] {
@@ -2201,7 +2202,7 @@ a:hover {
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
 .item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-reference, .item-features, .item-subtype, .item-type,
 .item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
-.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .form-section {
+.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .item-data {
   margin-top: 0.3em;
   display: grid;
   grid-template-columns: 1fr 2fr;
@@ -2212,7 +2213,7 @@ select.form-input, input.form-input, span.form-input {
   align-self: center;
 }
 
-.mini-grid, .item-descr {
+.mini-grid, .item-descr, .form-section {
   margin-top: 0.5em;
 }
 

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2283,7 +2283,7 @@ select.form-input, input.form-input, span.form-input {
   padding: 0;
   line-height: normal;
   cursor: pointer;
-  margin-top: -2px;
+  /*margin-top: -2px;*/
 }
 .consumable-row .combined-buttons button {
   margin-top: 0;

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1198,6 +1198,7 @@ span.total-output {
 .open-link {
   text-align: left;
   align-self: center;
+  color: var(--color-text-hyperlink);
 }
 
 .short-label input[type='text'], .short-label input[type='number'] {
@@ -2213,10 +2214,6 @@ select.form-input, input.form-input, span.form-input {
 
 .mini-grid, .form-section, .item-descr {
   margin-top: 0.5em;
-}
-
-.open-link {
-  color: var(--color-text-hyperlink);
 }
 
 .item-descr div[contenteditable] {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -28,6 +28,7 @@
 
 input[type= 'checkbox'] {
   vertical-align: middle;
+  align-self: center;
 }
 
 label.checkbox > input[type="checkbox"] {
@@ -1789,7 +1790,7 @@ button.flexrow.flex-group-center.toggle-skills {
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
 .item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-reference, .item-features, .item-subtype, .item-type,
 .item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
-.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .form-section {
+.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .item-data {
   margin-top: 0.3em;
   display: grid;
   grid-template-columns: 1fr 2fr;
@@ -1800,7 +1801,7 @@ select.form-input, input.form-input, span.form-input {
   align-self: center;
 }
 
-.mini-grid, .item-descr {
+.mini-grid, .item-descr, .form-section {
   margin-top: 0.5em;
 }
 

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -47,10 +47,6 @@ label.checkbox > input[type="checkbox"] {
   cursor: pointer;
 }
 
-.item-name {
-  align-self: center;
-}
-
 .centre {
   text-align: center;
   align-self: center;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1874,7 +1874,7 @@ select.form-input, input.form-input, span.form-input {
   padding: 0;
   line-height: normal;
   cursor: pointer;
-  margin-top: -2px;
+  /*margin-top: -2px;*/
 }
 .consumable-row .combined-buttons button {
   margin-top: 0;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -47,8 +47,13 @@ label.checkbox > input[type="checkbox"] {
   cursor: pointer;
 }
 
+.item-name {
+  align-self: center;
+}
+
 .centre {
   text-align: center;
+  align-self: center;
 }
 
 .item-name {
@@ -797,6 +802,7 @@ input.item-value-edit {
 
 .item-controls {
   align-self: center;
+  padding-left: 1ch;
 }
 
 .skill:nth-of-type(even) {
@@ -1588,10 +1594,10 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 20em 4em 4em 4em 4em 4em 4.5em 4em 3em;
+  grid-template-columns: 16em 4em 4em 4em 4em 4em 4em 4.5em 4em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
-  grid-template-areas: ". . . . . . . . .";
+  grid-template-areas: ". . . . . . . . . .";
 }
 
 .grid-columns-single-row:nth-of-type(even) {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -52,6 +52,7 @@ label.checkbox > input[type="checkbox"] {
 
 .item-name {
   align-self: center;
+  padding-left: 1ch;
 }
 
 .left {
@@ -843,11 +844,17 @@ span.total-output {
 }
 
 .resource-label {
-  padding-top: 0.2em;
+  text-align: right;
+  align-self: center;
+}
+
+.open-link {
+  text-align: left;
+  align-self: center;
 }
 
 .short-label input[type='text'], .short-label input[type='number'] {
-  max-width: 18ch;
+  max-width: 14ch;
 }
 
 .multi-line {
@@ -1412,7 +1419,6 @@ input.power-total {
 }
 
 a.ship-positions-tab, a.ship-crew-tab, a.ship-storage-tab, a.ship-component-tab, a.ship-cargo-tab, a.ship-finance-tab, a.ship-notes-tab {
-  /*display: block;*/
   border: solid;
   border-radius: 2ch;
   vertical-align: middle;
@@ -1779,14 +1785,21 @@ button.flexrow.flex-group-center.toggle-skills {
   text-shadow: 0 0 5px /*var(--default-color);
 }*/
 
-.item-type {
-  position: relative;
-  float: right;
-  margin-bottom: 0.4em;
+.item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
+.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-reference, .item-features, .item-subtype, .item-type,
+.item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
+.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description {
+  margin-top: 0.3em;
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 1ch;
 }
 
-.item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
-.item-secondaryArmor, .item-radiationProtection, .item-prereq, .mini-grid, .form-section, .item-reference, .item-features, .item-subtype {
+select.form-input, input.form-input, span.form-input {
+  align-self: center;
+}
+
+.mini-grid, .form-section, .item-descr {
   margin-top: 0.5em;
 }
 
@@ -1794,41 +1807,17 @@ button.flexrow.flex-group-center.toggle-skills {
   color: var(--color-text-hyperlink);
 }
 
-.item-descr {
-  margin-top: 0.5em;
-}
-
-.item-lawLevel {
-  margin-top: 0.5em;
-}
-
-.item-rangeBand {
-  margin-top: 0.5em;
-}
-
-.item-weaponType {
-  margin-top: 0.5em;
-}
-
-.item-damageType {
-  margin-top: 0.5em;
-}
-
-.item-rateOfFire {
-  margin-top: 0.5em;
-}
-
-.item-recoil {
-  margin-top: 0.5em;
-}
-
 .item-descr div[contenteditable] {
-  min-height: 140px;
+  min-height: 10ch;
   /*background: rgba(0, 0, 0, 0.22);*/
   border: 1px solid var(--color-border-light-tertiary);
   border-radius: 3px;
   padding: 0.5em;
   background: var(--s2d6-input-background);
+}
+
+.item-img {
+  object-fit: contain;
 }
 
 .pusher {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1789,7 +1789,7 @@ button.flexrow.flex-group-center.toggle-skills {
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
 .item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-reference, .item-features, .item-subtype, .item-type,
 .item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
-.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description {
+.item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .form-section {
   margin-top: 0.3em;
   display: grid;
   grid-template-columns: 1fr 2fr;
@@ -1800,7 +1800,7 @@ select.form-input, input.form-input, span.form-input {
   align-self: center;
 }
 
-.mini-grid, .form-section, .item-descr {
+.mini-grid, .item-descr {
   margin-top: 0.5em;
 }
 

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -851,6 +851,7 @@ span.total-output {
 .open-link {
   text-align: left;
   align-self: center;
+  color: var(--color-text-hyperlink);
 }
 
 .short-label input[type='text'], .short-label input[type='number'] {
@@ -1801,10 +1802,6 @@ select.form-input, input.form-input, span.form-input {
 
 .mini-grid, .form-section, .item-descr {
   margin-top: 0.5em;
-}
-
-.open-link {
-  color: var(--color-text-hyperlink);
 }
 
 .item-descr div[contenteditable] {

--- a/static/template.json
+++ b/static/template.json
@@ -373,7 +373,8 @@
       "isRefined": false,
       "features": "",
       "pricingBasis": "perUnit",
-      "isBaseHull": false
+      "isBaseHull": false,
+      "rollModifier": ""
     },
     "ship_position": {
       "name": "",

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -4,6 +4,7 @@
       <span class="item-name">{{localize "TWODSIX.Items.Component.componentName"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.rating"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Items.Component.DM"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.Power"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
@@ -29,6 +30,7 @@
           <span class="item-name">{{item.name}}</span>
           <span class="item-name centre">{{#iff item.data.data.techLevel ">" "0"}}{{item.data.data.techLevel}}{{else}}&mdash;{{/iff}}</span>
           <span class="item-name centre">{{item.data.data.rating}}</span>
+          <span class="item-name centre">{{item.data.data.rollModifier}}</span>
           <span class="item-name centre">{{getComponentWeight this}}</span>
           <span class="item-name centre">{{getComponentPower this}}</span>
           <span class="item-name centre">{{#if item.data.data.availableQuantity}}{{item.data.data.availableQuantity}}/{{/if}}{{item.data.data.quantity}}</span>

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -29,8 +29,8 @@
         <li class="item components-stored-single " data-item-id="{{item.id}}">
           <span class="item-name">{{item.name}}</span>
           <span class="item-name centre">{{#iff item.data.data.techLevel ">" "0"}}{{item.data.data.techLevel}}{{else}}&mdash;{{/iff}}</span>
-          <span class="item-name centre">{{item.data.data.rating}}</span>
-          <span class="item-name centre">{{item.data.data.rollModifier}}</span>
+          <span class="item-name centre">{{#iff item.data.data.rating "!==" ""}}{{item.data.data.rating}}{{else}}&mdash;{{/iff}}</span>
+          <span class="item-name centre">{{#iff item.data.data.rollModifier "!==" ""}}{{item.data.data.rollModifier}}{{else}}&mdash;{{/iff}}</span>
           <span class="item-name centre">{{getComponentWeight this}}</span>
           <span class="item-name centre">{{getComponentPower this}}</span>
           <span class="item-name centre">{{#if item.data.data.availableQuantity}}{{item.data.data.availableQuantity}}/{{/if}}{{item.data.data.quantity}}</span>

--- a/static/templates/items/armor-sheet.html
+++ b/static/templates/items/armor-sheet.html
@@ -3,40 +3,29 @@
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
     <div class="item-armor">
-      <label for="data.armor" class="resource-label">{{localize "TWODSIX.Items.Armor.Armor"}}
-        <input id="data.armor" type="text" name="data.armor" value="{{data.armor}}" data-dtype="Number"/>
-      </label>
+      <label for="data.armor" class="resource-label">{{localize "TWODSIX.Items.Armor.Armor"}}</label>
+      <input class="form-input" id="data.armor" type="text" name="data.armor" value="{{data.armor}}" data-dtype="Number"/>
     </div>
 
     <!-- This is to handle armors like reflec with 0/14. I.e. put the 14 here. -->
     <div class="item-secondaryArmor">
-      <label for="data.secondaryArmor.value" class="resource-label">{{localize "TWODSIX.Items.Armor.SecondaryArmor"}}
-        <input id="data.secondaryArmor.value" type="text" name="data.secondaryArmor.value" value="{{data.secondaryArmor.value}}" data-dtype="Number"/>
-      </label>
+      <label for="data.secondaryArmor.value" class="resource-label">{{localize "TWODSIX.Items.Armor.SecondaryArmor"}}</label>
+      <input class="form-input" id="data.secondaryArmor.value" type="text" name="data.secondaryArmor.value" value="{{data.secondaryArmor.value}}" data-dtype="Number"/>
     </div>
 
     <div class="item-radiationProtection">
-      <label for="data.radiationProtection.value" class="resource-label">{{localize "TWODSIX.Items.Armor.RadProt"}}
-        <input id="data.radiationProtection.value" type="text" name="data.radiationProtection.value" value="{{data.radiationProtection.value}}" data-dtype="Number"/>
-      </label>
+      <label for="data.radiationProtection.value" class="resource-label">{{localize "TWODSIX.Items.Armor.RadProt"}}</label>
+      <input class="form-input" id="data.radiationProtection.value" type="text" name="data.radiationProtection.value" value="{{data.radiationProtection.value}}" data-dtype="Number"/>
     </div>
 
     <div class="item-qty">
-      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
-        <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
-      </label>
+      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
+      <input class="form-input" id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
 
     <div class="item-weight">
-      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
-        <input id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
-    </div>
-
-    <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}</label>
+      <input class="form-input" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/augment-sheet.html
+++ b/static/templates/items/augment-sheet.html
@@ -1,22 +1,14 @@
 <form class="{{cssClass}}" autocomplete="off">
   <div class="item-sheet">
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
-
-    <div class="small-grid">
-      <!-- Labels -->
-      <div class="item-bonus item-label">
+      <div class="item-bonus">
         <label for="data.bonus" class="resource-label">{{localize "TWODSIX.Items.Augmentation.AugEffect"}}</label>
+        <input class="form-input" id="data.bonus" type="text" name="data.bonus" value="{{data.bonus}}"/>
       </div>
 
       <div class="item-augmentLoc">
         <label for="item.auglocation" class="resource-label">{{localize "TWODSIX.Items.Augmentation.AugLocation"}}</label>
-      </div>
-
-      <!-- Inputs -->
-      <div class="item-bonus item-label"><input id="data.bonus" type="text" name="data.bonus" value="{{data.bonus}}"/></div>
-
-      <div class="item-augmentLoc">
-        <select name="data.auglocation" value={{data.auglocation}}>
+        <select class="form-input" name="data.auglocation" value={{data.auglocation}}>
           {{#select data.auglocation}}
           <option value="Head">{{localize "TWODSIX.Items.Augmentation.Head"}}</option>
           <option value="Torso">{{localize "TWODSIX.Items.Augmentation.Torso"}}</option>
@@ -27,12 +19,9 @@
         </select>
       </div>
 
-    </div>
-
     <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
+      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -47,76 +47,68 @@
     {{/iff}}
 
     <div class="item-qty">
-      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Component.totalQuantity"}}
-        <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
-      </label>
+      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Component.totalQuantity"}}</label>
+      <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
     {{#iff data.subtype "!==" "cargo" }}
     <div class="item-qty">
-      <label for="data.availableQuantity" class="resource-label">{{localize "TWODSIX.Items.Component.availableQuantity"}}
-        <input id="data.availableQuantity" type="text" name="data.availableQuantity" value="{{data.availableQuantity}}" data-dtype="Number"/>
-      </label>
+      <label for="data.availableQuantity" class="resource-label">{{localize "TWODSIX.Items.Component.availableQuantity"}}</label>
+      <input id="data.availableQuantity" type="text" name="data.availableQuantity" value="{{data.availableQuantity}}" data-dtype="Number"/>
     </div>
     {{/iff}}
+
     <div class="item-weight">
       {{#iff data.subtype "===" "hull" }}
         <label for="data.isBaseHull" class="resource-label short-label">{{localize "TWODSIX.Items.Component.isBaseHull"}}
-          <input type="checkbox" class="checkbox" name="data.isBaseHull" {{checked data.isBaseHull}} data-dtype="Boolean" />
-        </label>
+        <input type="checkbox" class="checkbox" name="data.isBaseHull" {{checked data.isBaseHull}} data-dtype="Boolean" /></label>
       {{/iff}}
-    <div class="item-weight multi-line">
+
       {{#if data.isBaseHull}}
       <label for="data.weight" class="resource-label short-label">{{localize "TWODSIX.Items.Component.unitWeight"}}
-        <input class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
+      <input class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/></label>
+
       {{else}}
         {{#iff data.subtype "!==" "cargo" }}
           <label for="data.weightIsPct" class="resource-label short-label">{{localize "TWODSIX.Items.Component.weightIsPct"}}
-          <input type="checkbox" class="checkbox" name="data.weightIsPct" {{checked data.weightIsPct}} data-dtype="Boolean" />
-          </label>
-        {{/iff}}
+          <input type="checkbox" class="checkbox" name="data.weightIsPct" {{checked data.weightIsPct}} data-dtype="Boolean" /></label>
 
-          <label for="data.weight" class="resource-label short-label">
+        {{/iff}}
+          <label for="data.weight" class="short-label" style="align-self: center;">
           {{#if data.weightIsPct}}
             {{localize "TWODSIX.Items.Component.pctDisplacement"}}
           {{else}}
             {{localize "TWODSIX.Items.Component.unitWeight"}}
           {{/if}}
-          <input class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>{{#if data.weightIsPct}}%{{/if}}
-          </label>
-
+          <input class = "form-input" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>{{#if data.weightIsPct}}%{{/if}}</label>
       {{/if}}
     </div>
 
     {{#iff data.subtype "===" "fuel" }}
     <div class="refined">
-      <label for="data.isRefined" class="resource-label short-label">{{localize "TWODSIX.Items.Component.IsRefined"}}
-        <input type="checkbox" class="checkbox" name="data.isRefined" {{checked data.isRefined}} data-dtype="Boolean" />
-      </label>
+      <label for="data.isRefined" class="resource-label short-label">{{localize "TWODSIX.Items.Component.IsRefined"}}</label>
+      <input type="checkbox" class="checkbox" name="data.isRefined" {{checked data.isRefined}} data-dtype="Boolean" />
     </div>
     {{/iff}}
 
     {{#iff data.subtype "!==" "cargo"}}
     {{#iff data.subtype "!==" "fuel"}}
-    <div class="item-power multi-line">
+    <div class="item-power">
       <label for="data.generatesPower" class="resource-label short-label">{{localize "TWODSIX.Items.Component.GeneratesPower"}}
-        <input type="checkbox" class="checkbox" name="data.generatesPower" {{checked data.generatesPower}} data-dtype="Boolean" />
-      </label>
-      <label for="data.powerDraw" class="resource-label short-label">
+      <input type="checkbox" class="checkbox" name="data.generatesPower" {{checked data.generatesPower}} data-dtype="Boolean" /></label>
+
+      <label for="data.powerDraw" class="short-label" style="align-self: center;">
       {{#if data.generatesPower}}
         {{localize "TWODSIX.Items.Component.powerGenerated"}}
       {{else}}
         {{localize "TWODSIX.Items.Component.powerDraw"}}
       {{/if}}
-      <input class="resource-label short-label" id="data.powerDraw" type="number" name="data.powerDraw" value="{{data.powerDraw}}" data-dtype="Number"/>
-    </label>
+      <input class="short-label" id="data.powerDraw" type="number" name="data.powerDraw" value="{{data.powerDraw}}" data-dtype="Number"/></label>
     </div>
     {{/iff}}
     {{#iff data.subtype "===" "armament"}}
     <div class="item-damage">
-      <label for="data.damage" class="resource-label">{{localize "TWODSIX.Items.Component.damage"}}
-        <input id="data.damage" type="text" name="data.damage" value="{{data.damage}}"/>
-      </label>
+      <label for="data.damage" class="resource-label">{{localize "TWODSIX.Items.Component.damage"}}</label>
+      <input id="data.damage" type="text" name="data.damage" value="{{data.damage}}"/>
     </div>
     <div class="item-features">
       <span class="resource-label">{{localize "TWODSIX.Items.Component.Features"}}</span>
@@ -124,51 +116,45 @@
     </div>
     {{/iff}}
     <div class="item-hits">
-      <label for="data.hits" class="resource-label">{{localize "TWODSIX.Items.Component.hits"}}
-        <input id="data.hits" type="number" name="data.hits" value="{{data.hits}}" step = "1" min = "0" max = "{{getComponentMaxHits}}"/>
-      </label>
+      <label for="data.hits" class="resource-label">{{localize "TWODSIX.Items.Component.hits"}}</label>
+      <input id="data.hits" type="number" name="data.hits" value="{{data.hits}}" step = "1" min = "0" max = "{{getComponentMaxHits}}"/>
     </div>
 
     <div class="item-price">
-      <label for = "data.price" class="resource-label short-label">{{localize "TWODSIX.Items.Component.PricingBasis"}}: <input class="short-label" id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/></label>
-
-      <select id = "data.pricingBasis" name = "data.pricingBasis" >
-        {{#if data.isBaseHull}}
-          {{selectOptions data.config.HullPricingOptions selected = data.pricingBasis localize = true}}
-        {{else}}
-          {{selectOptions data.config.PricingOptions selected = data.pricingBasis localize = true}}
-        {{/if}}
-      </select>
+      <label for = "data.price" class="resource-label short-label">{{localize "TWODSIX.Items.Component.PricingBasis"}}:</label>
+      <span class="short-label">
+        <input class="short-label" id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/>
+        <select id = "data.pricingBasis" name = "data.pricingBasis" >
+          {{#if data.isBaseHull}}
+            {{selectOptions data.config.HullPricingOptions selected = data.pricingBasis localize = true}}
+          {{else}}
+            {{selectOptions data.config.PricingOptions selected = data.pricingBasis localize = true}}
+          {{/if}}
+        </select>
+      </span>
     </div>
 
     {{else}}
     <div class="item-price">
       <label for="data.price" class="resource-label">{{localize "TWODSIX.Items.Component.Value"}}</label>
-        <input id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/>
+      <input id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/>
     </div>
 
     <div class="item-price">
       <label for="data.purchasePrice" class="resource-label">{{localize "TWODSIX.Items.Component.purchasePrice"}}</label>
-        <input id="data.purchasePrice" type="text" name="data.purchasePrice" value="{{data.purchasePrice}}" data-dtype="Number"/>
+      <input id="data.purchasePrice" type="text" name="data.purchasePrice" value="{{data.purchasePrice}}" data-dtype="Number"/>
     </div>
 
-    <label for="data.isIllegal" class="resource-label short-label">{{localize "TWODSIX.Items.Component.isIllegal"}}
+    <label for="data.isIllegal" class="resource-label short-label">{{localize "TWODSIX.Items.Component.isIllegal"}}</label>
       <input type="checkbox" class="checkbox" name="data.isIllegal" {{checked data.isIllegal}} data-dtype="Boolean" />
-    </label>
+
 
     <div class="item-short">
-      <label for="data.cargoLocation" class="resource-label">{{localize "TWODSIX.Items.Component.CargoLocation"}}
-        <input id="data.cargoLocation" type="text" name="data.cargoLocation" value="{{data.cargoLocation}}"/>
-      </label>
+      <label for="data.cargoLocation" class="resource-label">{{localize "TWODSIX.Items.Component.CargoLocation"}}</label>
+      <input id="data.cargoLocation" type="text" name="data.cargoLocation" value="{{data.cargoLocation}}"/>
     </div>
 
     {{/iff}}
-
-    <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
-    </div>
 
     <div class="item-descr">
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -20,13 +20,13 @@
 
     <div class="item-tl">
         <label for="data.techLevel" class="resource-label">{{localize "TWODSIX.Items.Equipment.TL"}}</label>
-        <input id="data.techLevel" type="text" name="data.techLevel" value="{{data.techLevel}}" data-dtype="Number"/>
+        <input class="form-input" id="data.techLevel" type="text" name="data.techLevel" value="{{data.techLevel}}" data-dtype="Number"/>
     </div>
 
     {{#iff data.subtype "!==" "cargo" }}
     <div class="item-tl">
         <label for="data.rating" class="resource-label">{{localize "TWODSIX.Items.Component.rating"}}</label>
-        <input id="data.rating" type="text" name="data.rating" value="{{data.rating}}"/>
+        <input class="form-input" id="data.rating" type="text" name="data.rating" value="{{data.rating}}"/>
     </div>
     {{/iff}}
 
@@ -48,40 +48,48 @@
 
     <div class="item-qty">
       <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Component.totalQuantity"}}</label>
-      <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
+      <input class="form-input" id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
     {{#iff data.subtype "!==" "cargo" }}
     <div class="item-qty">
       <label for="data.availableQuantity" class="resource-label">{{localize "TWODSIX.Items.Component.availableQuantity"}}</label>
-      <input id="data.availableQuantity" type="text" name="data.availableQuantity" value="{{data.availableQuantity}}" data-dtype="Number"/>
+      <input class="form-input" id="data.availableQuantity" type="text" name="data.availableQuantity" value="{{data.availableQuantity}}" data-dtype="Number"/>
     </div>
     {{/iff}}
 
-    <div class="item-weight">
+
       {{#iff data.subtype "===" "hull" }}
-        <label for="data.isBaseHull" class="resource-label short-label">{{localize "TWODSIX.Items.Component.isBaseHull"}}
-        <input type="checkbox" class="checkbox" name="data.isBaseHull" {{checked data.isBaseHull}} data-dtype="Boolean" /></label>
+      <div class="item-weight">
+        <label for="data.isBaseHull" class="resource-label short-label">{{localize "TWODSIX.Items.Component.isBaseHull"}}</label>
+        <input type="checkbox" class="checkbox" name="data.isBaseHull" {{checked data.isBaseHull}} data-dtype="Boolean" />
+      </div>
       {{/iff}}
 
       {{#if data.isBaseHull}}
-      <label for="data.weight" class="resource-label short-label">{{localize "TWODSIX.Items.Component.unitWeight"}}
-      <input class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/></label>
+      <div class="item-weight">
+        <label for="data.weight" class="resource-label short-label">{{localize "TWODSIX.Items.Component.unitWeight"}}</label>
+        <input class="form-input" class = "short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
+      </div>
 
       {{else}}
         {{#iff data.subtype "!==" "cargo" }}
-          <label for="data.weightIsPct" class="resource-label short-label">{{localize "TWODSIX.Items.Component.weightIsPct"}}
-          <input type="checkbox" class="checkbox" name="data.weightIsPct" {{checked data.weightIsPct}} data-dtype="Boolean" /></label>
-
+        <div class="item-weight">
+          <label for="data.weightIsPct" class="resource-label short-label">{{localize "TWODSIX.Items.Component.weightIsPct"}}</label>
+          <input type="checkbox" class="checkbox" name="data.weightIsPct" {{checked data.weightIsPct}} data-dtype="Boolean" />
+        </div>
         {{/iff}}
-          <label for="data.weight" class="short-label" style="align-self: center;">
+        <div class="item-weight">
+          <label for="data.weight" class="resource-label">
           {{#if data.weightIsPct}}
             {{localize "TWODSIX.Items.Component.pctDisplacement"}}
           {{else}}
             {{localize "TWODSIX.Items.Component.unitWeight"}}
           {{/if}}
-          <input class = "form-input" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>{{#if data.weightIsPct}}%{{/if}}</label>
+          </label>
+          <span class="form-input"> <input class = "form-input short-label" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" style="max-width: 25ch; align-self: center;"/>{{#if data.weightIsPct}}%{{/if}}</span>
+        </div>
       {{/if}}
-    </div>
+
 
     {{#iff data.subtype "===" "fuel" }}
     <div class="refined">
@@ -108,20 +116,20 @@
     {{#iff data.subtype "===" "armament"}}
     <div class="item-damage">
       <label for="data.damage" class="resource-label">{{localize "TWODSIX.Items.Component.damage"}}</label>
-      <input id="data.damage" type="text" name="data.damage" value="{{data.damage}}"/>
+      <input class="form-input" id="data.damage" type="text" name="data.damage" value="{{data.damage}}"/>
     </div>
     <div class="item-features">
       <span class="resource-label">{{localize "TWODSIX.Items.Component.Features"}}</span>
-      <input type="text" name="data.features" value="{{data.features}}"/>
+      <input class="form-input" type="text" name="data.features" value="{{data.features}}"/>
     </div>
     {{/iff}}
     <div class="item-hits">
       <label for="data.hits" class="resource-label">{{localize "TWODSIX.Items.Component.hits"}}</label>
-      <input id="data.hits" type="number" name="data.hits" value="{{data.hits}}" step = "1" min = "0" max = "{{getComponentMaxHits}}"/>
+      <input class="form-input" id="data.hits" type="number" name="data.hits" value="{{data.hits}}" step = "1" min = "0" max = "{{getComponentMaxHits}}"/>
     </div>
 
     <div class="item-price">
-      <label for = "data.price" class="resource-label short-label">{{localize "TWODSIX.Items.Component.PricingBasis"}}:</label>
+      <label for = "data.price" class="resource-label short-label">{{localize "TWODSIX.Items.Component.PricingBasis"}}</label>
       <span class="short-label">
         <input class="short-label" id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/>
         <select id = "data.pricingBasis" name = "data.pricingBasis" >
@@ -137,21 +145,22 @@
     {{else}}
     <div class="item-price">
       <label for="data.price" class="resource-label">{{localize "TWODSIX.Items.Component.Value"}}</label>
-      <input id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/>
+      <input class="form-input" id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/>
     </div>
 
     <div class="item-price">
       <label for="data.purchasePrice" class="resource-label">{{localize "TWODSIX.Items.Component.purchasePrice"}}</label>
-      <input id="data.purchasePrice" type="text" name="data.purchasePrice" value="{{data.purchasePrice}}" data-dtype="Number"/>
+      <input class="form-input" id="data.purchasePrice" type="text" name="data.purchasePrice" value="{{data.purchasePrice}}" data-dtype="Number"/>
     </div>
 
-    <label for="data.isIllegal" class="resource-label short-label">{{localize "TWODSIX.Items.Component.isIllegal"}}</label>
+    <div class="item-price">
+      <label for="data.isIllegal" class="resource-label short-label">{{localize "TWODSIX.Items.Component.isIllegal"}}</label>
       <input type="checkbox" class="checkbox" name="data.isIllegal" {{checked data.isIllegal}} data-dtype="Boolean" />
-
+    </div>
 
     <div class="item-short">
       <label for="data.cargoLocation" class="resource-label">{{localize "TWODSIX.Items.Component.CargoLocation"}}</label>
-      <input id="data.cargoLocation" type="text" name="data.cargoLocation" value="{{data.cargoLocation}}"/>
+      <input class="form-input" id="data.cargoLocation" type="text" name="data.cargoLocation" value="{{data.cargoLocation}}"/>
     </div>
 
     {{/iff}}

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -142,6 +142,11 @@
       </span>
     </div>
 
+    <div class="item-data">
+      <label for="data.rollModifier" class="resource-label">{{localize "TWODSIX.Items.Component.RollModifier"}}</label>
+      <input class="form-input" id="data.rollModifier" type="text" name="data.rollModifier" value="{{data.rollModifier}}"/>
+    </div>
+
     {{else}}
     <div class="item-price">
       <label for="data.price" class="resource-label">{{localize "TWODSIX.Items.Component.Value"}}</label>

--- a/static/templates/items/consumable-sheet.html
+++ b/static/templates/items/consumable-sheet.html
@@ -3,28 +3,25 @@
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
     <div class="form-section">
-      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
-        <input type="number" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
+      <input class="form-input" id="data.quantity" type="number" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
 
     <div class="form-section">
-      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.ArmorPiercing"}}
-        <input type="number" name="data.armorPiercing" value="{{data.armorPiercing}}" data-dtype="Number" step ="1" oninput="this.value = Math.round(this.value);"/>
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.ArmorPiercing"}}</label>
+      <input class="form-input" id="data.armorPiercing" type="number" name="data.armorPiercing" value="{{data.armorPiercing}}" data-dtype="Number" step ="1" oninput="this.value = Math.round(this.value);"/>
     </div>
 
     <div class="form-section">
-      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Count"}}
+      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Count"}}</label>
         <div>
-          <input class="form-consumable-count" name="data.currentCount" type="number" value="{{data.currentCount}}" data-dtype="Number">
+          <input id="data.currentCount" class="form-consumable-count" name="data.currentCount" type="number" value="{{data.currentCount}}" data-dtype="Number">
           /
-          <input class="form-consumable-count" name="data.max" type="number" value="{{data.max}}" data-dtype="Number">
+          <input id="data.max" class="form-consumable-count" name="data.max" type="number" value="{{data.max}}" data-dtype="Number">
         </div>
-      </label>
     </div>
     <div class="form-section">
-      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Subtype"}}
+      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Subtype"}}</label>
         <select name="data.subtype" value={{data.subtype}}>
           {{#select data.subtype}}
           {{#each data.config.CONSUMABLES as |consumable|}}
@@ -32,22 +29,19 @@
           {{/each}}
           {{/select}}
         </select>
-      </label>
     </div>
 
     <div class="form-section">
-      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
-        <input type="number" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}</label>
+      <input class="form-input" id="data.weight" type="number" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
     </div>
 
     <div class="form-section">
-      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
+      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
-    <div class="form-section">
+    <div class="item-descr">
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>

--- a/static/templates/items/consumable-sheet.html
+++ b/static/templates/items/consumable-sheet.html
@@ -2,25 +2,25 @@
   <div class="item-sheet">
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
-    <div class="form-section">
+    <div class="item-data">
       <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
       <input class="form-input" id="data.quantity" type="number" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
 
-    <div class="form-section">
+    <div class="item-data">
       <label class="resource-label">{{localize "TWODSIX.Items.Consumable.ArmorPiercing"}}</label>
       <input class="form-input" id="data.armorPiercing" type="number" name="data.armorPiercing" value="{{data.armorPiercing}}" data-dtype="Number" step ="1" oninput="this.value = Math.round(this.value);"/>
     </div>
 
-    <div class="form-section">
+    <div class="item-data">
       <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Count"}}</label>
         <div>
-          <input id="data.currentCount" class="form-consumable-count" name="data.currentCount" type="number" value="{{data.currentCount}}" data-dtype="Number">
+          <input id="data.currentCount" class="form-consumable-count" name="data.currentCount" type="number" value="{{data.currentCount}}" data-dtype="Number"/>
           /
-          <input id="data.max" class="form-consumable-count" name="data.max" type="number" value="{{data.max}}" data-dtype="Number">
+          <input id="data.max" class="form-consumable-count" name="data.max" type="number" value="{{data.max}}" data-dtype="Number"/>
         </div>
     </div>
-    <div class="form-section">
+    <div class="item-data">
       <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Subtype"}}</label>
         <select name="data.subtype" value={{data.subtype}}>
           {{#select data.subtype}}
@@ -31,14 +31,9 @@
         </select>
     </div>
 
-    <div class="form-section">
+    <div class="item-data">
       <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}</label>
       <input class="form-input" id="data.weight" type="number" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-    </div>
-
-    <div class="form-section">
-      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
-      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/equipment-sheet.html
+++ b/static/templates/items/equipment-sheet.html
@@ -3,21 +3,18 @@
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
     <div class="item-qty">
-      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
-        <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
-      </label>
+      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
+      <input class="form-input" id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
 
     <div class="item-weight">
-      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
-        <input id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
+      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}</label>
+      <input class="form-input" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
     </div>
 
     <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
+      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/item-sheet.html
+++ b/static/templates/items/item-sheet.html
@@ -3,15 +3,13 @@
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
     <div class="item-qty">
-      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
-        <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
-      </label>
+      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
+      <input class="form-input" id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
 
     <div class="item-weight">
-      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
-        <input id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
+      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}</label>
+      <input class="form-input" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
     </div>
 
     <div class="item-type">
@@ -25,9 +23,8 @@
     </div>
 
     <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
+      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/junk-sheet.html
+++ b/static/templates/items/junk-sheet.html
@@ -3,21 +3,18 @@
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
     <div class="item-qty">
-      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
-        <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
-      </label>
+      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
+      <input class="form-input" id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
 
     <div class="item-weight">
-      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
-        <input id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
+      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}</label>
+      <input class="form-input" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
     </div>
 
     <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
+      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/parts/common-parts.html
+++ b/static/templates/items/parts/common-parts.html
@@ -9,17 +9,16 @@
       <th>
         <div class="item-name">
           <label for="data.name">{{localize "TWODSIX.Items.Equipment.ItemName"}}</label>
-          <input id="data.name" name="name" type="text" value="{{name}}"/>
+          <input class="form-input" id="data.name" name="name" type="text" value="{{name}}"/>
         </div>
       </th>
     </tr>
   </table>
 </div>
 
-<div class="mini-grid">
   <div class="item-type">
-    <label for="type" class="resource-label">{{localize "TWODSIX.Items.Items.ItemType"}}
-      <select id="type" name="type" value={{data.type}}>
+    <label for="type" class="resource-label">{{localize "TWODSIX.Items.Items.ItemType"}} </label>
+      <select class="form-input" id="type" name="type" value={{data.type}}>
         {{#select type}}
           <option value="augment">{{localize "TWODSIX.Items.Items.AssignAugment"}}</option>
           <option value="weapon">{{localize "TWODSIX.Items.Items.AssignWeapon"}}</option>
@@ -31,13 +30,12 @@
           <option value="storage">{{localize "TWODSIX.Items.Items.MoveStorage"}}</option>
         {{/select}}
       </select>
-    </label>
   </div>
 
 {{#if data.owner}}
     <div class="item-skill">
-      <label for="data.skill" class="resource-label">{{localize "TWODSIX.Items.Equipment.AssignSkill"}}:
-        <select id="data.skill" name="data.skill" value="{{data.skill}}">
+      <label for="data.skill" class="resource-label">{{localize "TWODSIX.Items.Equipment.AssignSkill"}}:</label>
+        <select class="form-input" id="data.skill" name="data.skill" value="{{data.skill}}">
           {{#select data.skill}}
             <option value="" >None</option>
             {{#if (twodsix_hideUntrainedSkills -1)}}
@@ -54,30 +52,25 @@
             {{/each}}
           {{/select}}
         </select>
-      </label>
     </div>
-  </div>
   <div class="item-skillModifier">
-    <span class="resource-label">{{localize "TWODSIX.Items.Equipment.SkillModifier"}}</span>
-    <input id="data.skillModifier" type="text" name="data.skillModifier" value="{{data.skillModifier}}"
+    <label for="data.skillModifier"  class="resource-label">{{localize "TWODSIX.Items.Equipment.SkillModifier"}}</label>
+    <input class="form-input" id="data.skillModifier" type="text" name="data.skillModifier" value="{{data.skillModifier}}"
            data-dtype="Number"/>
   </div>
   {{else}}
     <div class="item-skill">
-      <span class="resource-label">{{localize "TWODSIX.Items.Equipment.AssociatedSkillName"}}</span>
-      <input type="text" name="data.associatedSkillName" value="{{data.associatedSkillName}}" />
+      <label for = "data.associatedSkillName" class="resource-label">{{localize "TWODSIX.Items.Equipment.AssociatedSkillName"}}</label>
+      <input class="form-input" id = "data.associatedSkillName" type="text" name="data.associatedSkillName" value="{{data.associatedSkillName}}" />
     </div>
   {{/if}}
 
-
 <div class="item-tl">
-  <label for="data.techLevel" class="resource-label">{{localize "TWODSIX.Items.Equipment.TL"}}
-    <input id="data.techLevel" type="text" name="data.techLevel" value="{{data.techLevel}}" data-dtype="Number"/>
-  </label>
+  <label for="data.techLevel" class="resource-label">{{localize "TWODSIX.Items.Equipment.TL"}}</label>
+  <input class="form-input" id="data.techLevel" type="text" name="data.techLevel" value="{{data.techLevel}}" data-dtype="Number"/>
 </div>
 
 <div class="item-price">
-  <label for="data.price" class="resource-label">{{localize "TWODSIX.Items.Equipment.Price"}}
-    <input id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/>
-  </label>
+  <label for="data.price" class="resource-label">{{localize "TWODSIX.Items.Equipment.Price"}}</label>
+  <input class="form-input" id="data.price" type="text" name="data.price" value="{{data.price}}" data-dtype="Number"/>
 </div>

--- a/static/templates/items/parts/reference-footer.html
+++ b/static/templates/items/parts/reference-footer.html
@@ -1,6 +1,6 @@
 {{#if (twodsix_showReferences)}}
 <div class="item-reference">
   <a class="open-link">{{localize "TWODSIX.Items.DocumentReference"}}</a>
-  <input id="source" type="text" name="data.docReference" value="{{data.docReference}}"/>
+  <input class="form-input" id="source" type="text" name="data.docReference" value="{{data.docReference}}"/>
 </div>
 {{/if}}

--- a/static/templates/items/ship_position-sheet.html
+++ b/static/templates/items/ship_position-sheet.html
@@ -1,14 +1,12 @@
 <form class="{{cssClass}}" autocomplete="off">
   <div class="item-sheet">
-    <div class="item-name">
-      <label for="data.name" class="resource-label">{{localize "TWODSIX.Ship.PositionName"}}
-        <input id="data.name" type="text" name="name" value="{{name}}" />
-      </label>
+    <div class="item-data">
+      <label for="data.name" class="resource-label">{{localize "TWODSIX.Ship.PositionName"}}</label>
+      <input class="form-input" id="data.name" type="text" name="name" value="{{name}}" />
     </div>
-    <div class="item-name">
-      <label for="data.order" class="resource-label">{{localize "TWODSIX.Ship.Order"}}
-        <input id="data.order" type="number" name="data.order" value="{{data.order}}" data-dtype="Number" />
-      </label>
+    <div class="item-data">
+      <label for="data.order" class="resource-label">{{localize "TWODSIX.Ship.Order"}}</label>
+      <input class="form-input" id="data.order" type="number" name="data.order" value="{{data.order}}" data-dtype="Number" />
     </div>
     {{#if hasShipActor}}
     <div class="form-section">

--- a/static/templates/items/skills-sheet.html
+++ b/static/templates/items/skills-sheet.html
@@ -17,28 +17,29 @@
           </th>
         </tr>
       </table>
-      <div class="item-name">
-        <label for="data.name">{{localize "TWODSIX.Items.Skills.SimplifiedSkillName"}}:</label>
-        <input type="text" value="{{skillName name}}" readonly/>
-        <div class="simplified-skill-description">
-          {{{replace (localize "TWODSIX.Items.Skills.SimplifiedSkillNameDescription") "_SKILL_NAME_" (skillName name)}}}
-        </div>
+      <div class="item-simplifiedName">
+        <label class="resource-label" for="data.name">{{localize "TWODSIX.Items.Skills.SimplifiedSkillName"}}:</label>
+        <input class="form-input" type="text" value="{{skillName name}}" readonly/>
       </div>
+        <div class="simplified-skill-description">
+          <span class="resource-label">&nbsp</span>
+          <span class="form-input">{{{replace (localize "TWODSIX.Items.Skills.SimplifiedSkillNameDescription") "_SKILL_NAME_" (skillName name)}}}</span>
+        </div>
     </div>
     <div class="item-lvl">
-      <label for="data.value" class="resource-label">{{localize "TWODSIX.Items.Skills.Level"}}
-        <input id="data.value" type="text" name="data.value" value="{{data.value}}" data-dtype="Number"/></label>
+      <label for="data.value" class="resource-label">{{localize "TWODSIX.Items.Skills.Level"}}</label>
+      <input class="form-input" id="data.value" type="text" name="data.value" value="{{data.value}}" data-dtype="Number"/>
     </div>
-    <div class = "mini-grid">
-      <div class="item-type left">
+
+      <div class="item-type">
         <label for="data.characteristic" class="resource-label">{{localize "TWODSIX.Items.Skills.Modifier"}}</label>
-        <select class="select-mod" name="data.characteristic" value={{characteristic}}>
+        <select class="form-input" name="data.characteristic" value={{characteristic}}>
           {{selectOptions (getCharacteristicList data.owner) selected=data.characteristic }}
         </select>
       </div>
-      <div class="item-name left">
-        <label class="resource-label">{{localize "TWODSIX.Chat.Roll.Difficulty"}}
-          <select class="select-difficulty" name="data.difficulty" value={{difficulty}}>
+      <div class="item-rollDifficulty">
+        <label class="resource-label">{{localize "TWODSIX.Chat.Roll.Difficulty"}}</label>
+          <select class="form-input" name="data.difficulty" value={{difficulty}}>
             {{#select data.difficulty}}
             {{#each data.settings.DIFFICULTIES}}
             <option value="{{@key}}">{{localize @key}} (
@@ -47,25 +48,22 @@
             {{/each}}
             {{/select}}
           </select>
-        </label>
       </div>
-    </div>
-    <div class="mini-grid">
-      <label class="resource-label">{{localize "TWODSIX.Chat.Roll.Type"}}
-        <select class="select-rolltype" name="data.rolltype" value={{rolltype}}>
+
+    <div class="item-rollType">
+      <label class="resource-label">{{localize "TWODSIX.Chat.Roll.Type"}}</label>
+        <select class="form-input" name="data.rolltype" value={{rolltype}}>
           {{#select data.rolltype}}
             {{#each data.config.ROLLTYPES as |type|}}
               <option value="{{type.key}}">{{localize (twodsix_advantageDisadvantageTerm type.key)}}</option>
             {{/each}}
           {{/select}}
         </select>
-      </label>
     </div>
 
     <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
+      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/storage-sheet.html
+++ b/static/templates/items/storage-sheet.html
@@ -3,21 +3,18 @@
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
     <div class="item-qty">
-      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
-        <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
-      </label>
+      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
+      <input class="form-input" id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
 
     <div class="item-weight">
-      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
-        <input id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
+      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}</label>
+      <input class="form-input" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
     </div>
 
     <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
+      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/tool-sheet.html
+++ b/static/templates/items/tool-sheet.html
@@ -3,27 +3,23 @@
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
     <div class="item-qty">
-      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
-        <input id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
-      </label>
+      <label for="data.quantity" class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
+      <input class="form-input" id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
 
     <div class="item-weight">
-      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
-        <input id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
+      <label for="data.weight" class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}} </label>
+      <input class="form-input" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
     </div>
 
     <div class="item-bonus">
-      <label for="data.bonus" class="resource-label">{{localize "TWODSIX.Items.Tool.Bonus"}}
-        <input id="data.bonus" type="text" name="data.bonus" value="{{data.bonus}}" data-dtype="Number"/>
-      </label>
+      <label for="data.bonus" class="resource-label">{{localize "TWODSIX.Items.Tool.Bonus"}} </label>
+      <input class="form-input" id="data.bonus" type="text" name="data.bonus" value="{{data.bonus}}" data-dtype="Number"/>
     </div>
 
     <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
+      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/trait-sheet.html
+++ b/static/templates/items/trait-sheet.html
@@ -18,18 +18,16 @@
       </table>
     </div>
     <div class="item-lvl">
-      <label for="data.value" class="resource-label">{{localize "TWODSIX.Items.Skills.Level"}}
-        <input id="data.value" type="text" name="data.value" value="{{data.value}}" data-dtype="Number"/></label>
+      <label for="data.value" class="resource-label">{{localize "TWODSIX.Items.Skills.Level"}}</label>
+      <input class="form-input" id="data.value" type="text" name="data.value" value="{{data.value}}" data-dtype="Number"/>
     </div>
     <div class="item-prereq">
-      <label for="data.prereq" class="resource-label">{{localize "TWODSIX.Items.Traits.Prerequisite"}}
-        <input id="data.prereq" type="text" name="data.prereq" value="{{data.prereq}}"/>
-      </label>
+      <label for="data.prereq" class="resource-label">{{localize "TWODSIX.Items.Traits.Prerequisite"}}</label>
+      <input class="form-input" id="data.prereq" type="text" name="data.prereq" value="{{data.prereq}}"/>
     </div>
     <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
+      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/weapon-sheet.html
+++ b/static/templates/items/weapon-sheet.html
@@ -4,79 +4,71 @@
       data-actor-id="{{actor._id}}">
   <div class="item-sheet">
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
-    <div class="form-section">
-      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.MagazineCost"}}
-        <input type="number" name="data.magazineCost" value="{{data.magazineCost}}">
-      </label>
+    <div class="item-damage">
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.MagazineCost"}}</label>
+      <input class="form-input" id="data.magazineCost" type="number" name="data.magazineCost" value="{{data.magazineCost}}">
     </div>
 
     <div class="item-damage">
-      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Damage"}}
-        <input type="text" name="data.damage" value="{{data.damage}}">
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Damage"}}</label>
+      <input class="form-input" id="data.damage" type="text" name="data.damage" value="{{data.damage}}">
     </div>
 
     <div class="item-damage">
-      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.ArmorPiercing"}}
-        <input type="number" name="data.armorPiercing" value="{{data.armorPiercing}}" step="1" oninput="this.value = Math.round(this.value);">
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.ArmorPiercing"}}</label>
+      <input class="form-input" id="data.armorPiercing" type="number" name="data.armorPiercing" value="{{data.armorPiercing}}" step="1" oninput="this.value = Math.round(this.value);">
     </div>
 
     <div class="item-range">
       {{#if data.settings.ShowRangeBandAndHideRange}}
-      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.rangeBand"}}
-        <input type="text" name="data.rangeBand" value="{{data.rangeBand}}">
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.rangeBand"}}</label>
+      <input id="data.rangeBand" type="text" name="data.rangeBand" value="{{data.rangeBand}}">
       {{else}}
-      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Range"}}
-        <input type="text" name="data.range" value="{{data.range}}">
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Range"}}</label>
+      <input class="form-input" id="data.range" type="text" name="data.range" value="{{data.range}}">
       {{/if}}
     </div>
 
     <div class="item-ammo">
-      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Ammo"}}
-        <input type="text" name="data.ammo" value="{{data.ammo}}">
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Ammo"}}</label>
+      <input id ="data.ammo" type="text" name="data.ammo" value="{{data.ammo}}">
     </div>
 
     <div class="item-qty">
-      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}
-        <input type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
+      <input class="form-input" id="data.quantity" type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
     </div>
 
     <div class="item-weight">
-      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}
-        <input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}</label>
+      <input class="form-input" id="data.weight" type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number"/>
     </div>
 
     {{#if data.settings.ShowLawLevel}}
     <div class="item-lawLevel">
       <span class="resource-label">{{localize "TWODSIX.Items.Weapon.lawLevel"}}</span>
-      <input type="text" name="data.lawLevel" value="{{data.lawLevel}}">
+      <input class="form-input" type="text" name="data.lawLevel" value="{{data.lawLevel}}">
     </div>
     {{/if}}
 
     {{#if data.settings.ShowWeaponType}}
     <div class="item-weaponType">
-      <span class="resource-label">{{localize "TWODSIX.Items.Weapon.weaponType"}}</span>
-      <input type= "text" name="data.weaponType" value="{{data.weaponType}}">
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.weaponType"}}</label>
+      <input class="form-input" id="data.weaponType" type= "text" name="data.weaponType" value="{{data.weaponType}}">
     </div>
     {{/if}}
 
     {{#if data.settings.ShowDamageType}}
     <div class="item-damageType">
-      <span class="resource-label">{{localize "TWODSIX.Items.Weapon.damageType"}}</span>
-      <input type="text" name="data.damageType" value= "{{data.damageType}}"></div>
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.damageType"}}</label>
+      <input class="form-input" id="data.damageType" type="text" name="data.damageType" value= "{{data.damageType}}"></div>
     </div>
     {{/if}}
 
     {{#if data.settings.ShowRateOfFire}}
     <div class="item-rateOfFire">
-      <span class="resource-label">{{localize "TWODSIX.Items.Weapon.rateOfFire"}}</span>
-      <input type="text" name="data.rateOfFire" value="{{data.rateOfFire}}">
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.rateOfFire"}}</label>
+      <input class="form-input" id="data.rateOfFire" type="text" name="data.rateOfFire" value="{{data.rateOfFire}}">
     </div>
     {{/if}}
 
@@ -88,18 +80,12 @@
     {{/if}}
 
     <div class="item-features">
-      <span class="resource-label">{{localize "TWODSIX.Items.Weapon.Features"}}</span>
-      <input type="text" name="data.features" value="{{data.features}}">
-    </div>
-
-    <div class="item-short">
-      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}
-        <input type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
-      </label>
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.Features"}}</label>
+      <input class="form-input" id="data.features" type="text" name="data.features" value="{{data.features}}">
     </div>
 
     <div class="item-descr">
-      <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</label>
       <div contenteditable="true" data-edit="data.description">{{{data.description}}}</div>
     </div>
     {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature update


* **What is the current behavior?** (You can also link to an open issue here)
Item sheets display labels and data on separate lines making the item sheet long
Short descriptions are mainly unused except for traits
#874 
* **What is the new behavior (if this is a feature change)?**
display item label and data on a single line
remove short descriptions from sheets except for traits

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
