### PR TITLE
fix: bad token update arguments and add flavor to ship skill rolls

### DIFF
--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -95,8 +95,8 @@ async function setConditionState(effectLabel: string, targetToken: Record<string
 
 async function setEffectState(effectLabel: string, targetToken: Record<string, any>, state: boolean, tint: string): Promise<void> {
   const isAlreadySet = await targetToken?.actor?.effects.find(eff => eff.data.label === effectLabel);
-  if (isAlreadySet != undefined && state === false) {
-    targetToken.actor.deleteEmbeddedDocuments("ActiveEffect", [isAlreadySet.id]);
+  if (isAlreadySet && state === false) {
+    await targetToken.actor.deleteEmbeddedDocuments("ActiveEffect", [isAlreadySet.id]);
   } else {
     let woundModifier = 0;
     switch (tint) {

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -12,7 +12,6 @@ Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>)
 });
 
 Hooks.on('updateToken', async (token: TokenDocument, actorData:Record<string, any> , update: Record<string, any>) => {
-  console.log(token, actorData, update);
   if (checkForWounds(update?.data)) {
     applyWoundedEffect(<Token>canvas.tokens?.ownedTokens.find(t => t.id === token.id));
   }

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -1,3 +1,4 @@
+//import { ActorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/module.mjs";
 import TwodsixActor from "../entities/TwodsixActor";
 
 Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>) => {
@@ -10,9 +11,10 @@ Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>)
   }
 });
 
-Hooks.on('updateToken', async (scene, token: Record<string, any>, update: Record<string, any>) => {
-  if (checkForWounds(update.actorData?.data)) {
-    applyWoundedEffect(<Token>canvas.tokens?.ownedTokens.find(t => t.id === token._id));
+Hooks.on('updateToken', async (token: TokenDocument, actorData:Record<string, any> , update: Record<string, any>) => {
+  console.log(token, actorData, update);
+  if (checkForWounds(update?.data)) {
+    applyWoundedEffect(<Token>canvas.tokens?.ownedTokens.find(t => t.id === token.id));
   }
 });
 

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -11,7 +11,7 @@ Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>)
   }
 });
 
-Hooks.on('updateToken', async (token: TokenDocument, actorData:Record<string, any> , update: Record<string, any>) => {
+Hooks.on('updateToken', async (token: TokenDocument, update: Record<string, any>) => {
   if (checkForWounds(update?.data)) {
     applyWoundedEffect(<Token>canvas.tokens?.ownedTokens.find(t => t.id === token.id));
   }

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -142,7 +142,8 @@ export class TwodsixDiceRoll {
     const difficulties:CEL_DIFFICULTIES | CE_DIFFICULTIES = TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))];
     const difficulty = game.i18n.localize(getKeyByValue(difficulties, this.settings.difficulty));
 
-    let flavor = `${rollingString}: ${difficulty}`;
+    let flavor = this.settings.extraFlavor ? this.settings.extraFlavor + `<br>` : ``;
+    flavor += `${rollingString}: ${difficulty}`;
 
     if (game.settings.get('twodsix', 'difficultiesAsTargetNumber')) {
       flavor += `(${this.settings.difficulty.target}+)`;

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -16,6 +16,7 @@ export class TwodsixRollSettings {
   skillRoll:boolean;
   difficulties:CE_DIFFICULTIES | CEL_DIFFICULTIES;
   displayLabel:string;
+  extraFlavor:string;
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   constructor(settings?:Record<string,any>, aSkill?:TwodsixItem, anItem?:TwodsixItem) {
@@ -34,6 +35,7 @@ export class TwodsixRollSettings {
     this.characteristic = settings?.characteristic ?? characteristic;
     this.skillRoll = !!(settings?.skillRoll ?? aSkill);
     this.displayLabel = settings?.displayLabel ?? "";
+    this.extraFlavor = settings?.extraFlavor ?? "";
   }
 
   public static async create(showThrowDialog:boolean, settings?:Record<string,any>, skill?:TwodsixItem, item?:TwodsixItem):Promise<TwodsixRollSettings> {

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -73,7 +73,8 @@ export class TwodsixShipActions {
       }
       const settings = {
         characteristic: shortLabel,
-        displayLabel: displayLabel
+        displayLabel: displayLabel,
+        extraFlavor: game.i18n.localize("TWODSIX.Ship.MakesChatRollAction").replace( "_ACTION_NAME_", extra.actionName || game.i18n.localize("TWODSIX.Ship.Unknown")).replace("_POSITION_NAME_", (extra.positionName || game.i18n.localize("TWODSIX.Ship.Unknown")))
       };
       if (diff) {
         settings["difficulty"] = Object.values(difficulties).filter((difficulty: Record<string, number>) => difficulty.target === parseInt(diff, 10))[0];


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix


* **What is the current behavior?** (You can also link to an open issue here)

onTokenUpdate uses old argument references
ship action skill rolls don't reference position in flavor

* **What is the new behavior (if this is a feature change)?**
Use correct argument references of onTokenUpdate
add reference to position in flavor

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
