### PR TITLE
feat: add max encumbrance calc for traveller and range field for armament components 

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -55,7 +55,8 @@ const RULESETS = Object.freeze({
       minorWoundsRollModifier: 0,
       seriousWoundsRollModifier: 0,
       mortgagePayment: 240,
-      massProductionDiscount: 0.10
+      massProductionDiscount: 0.10,
+      maxEncumbrance: "12 * @characteristics.strength.current"
     }
   },
   CEL: {
@@ -77,7 +78,8 @@ const RULESETS = Object.freeze({
       minorWoundsRollModifier: 0,
       seriousWoundsRollModifier: 0,
       mortgagePayment: 240,
-      massProductionDiscount: 0.10
+      massProductionDiscount: 0.10,
+      maxEncumbrance: "3 * @characteristics.strength.value"
     }
   },
   CEFTL: {
@@ -97,7 +99,8 @@ const RULESETS = Object.freeze({
       showLifebloodStamina: false,
       lifebloodInsteadOfCharacteristics: false,
       minorWoundsRollModifier: 0,
-      seriousWoundsRollModifier: 0
+      seriousWoundsRollModifier: 0,
+      maxEncumbrance: "3 * @characteristics.strength.value"
     },
   },
   CEATOM: {
@@ -118,7 +121,8 @@ const RULESETS = Object.freeze({
       showLifebloodStamina: false,
       showContaminationBelowLifeblood: true,
       minorWoundsRollModifier: -1,
-      seriousWoundsRollModifier: -1
+      seriousWoundsRollModifier: -1,
+      maxEncumbrance: "2 * @characteristics.endurance.value"
     }
   },
   BARBARIC: {
@@ -139,7 +143,8 @@ const RULESETS = Object.freeze({
       showLifebloodStamina: false,
       showContaminationBelowLifeblood: false,
       minorWoundsRollModifier: -1,
-      seriousWoundsRollModifier: -1
+      seriousWoundsRollModifier: -1,
+      maxEncumbrance: "2 * @characteristics.endurance.value"
     },
   },
   CEQ: {
@@ -160,7 +165,8 @@ const RULESETS = Object.freeze({
       showLifebloodStamina: false,
       showContaminationBelowLifeblood: false,
       minorWoundsRollModifier: 0,
-      seriousWoundsRollModifier: 0
+      seriousWoundsRollModifier: 0,
+      maxEncumbrance: "0"
     }
   },
   CD: {
@@ -189,7 +195,8 @@ const RULESETS = Object.freeze({
       minorWoundsRollModifier: -1,
       seriousWoundsRollModifier: -2,
       mortgagePayment: 320,
-      massProductionDiscount: 0.10
+      massProductionDiscount: 0.10,
+      maxEncumbrance: "3 * (7 + @characteristics.strength.mod)"
     }
   },
   CLU: {
@@ -214,7 +221,8 @@ const RULESETS = Object.freeze({
       ShowWeaponType: true,
       ShowDamageType: false,
       ShowRateOfFire: true,
-      ShowRecoil: true
+      ShowRecoil: true,
+      maxEncumbrance: "3*(7 + @characteristics.strength.mod)"
     }
   },
 

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -31,6 +31,7 @@ export default class RulesetSettings extends AdvancedSettings {
     const DEFAULT_INITIATIVE_FORMULA = "2d6 + @characteristics.dexterity.mod";
     // TODO: With the new ship positions this should be changed to take the pilot's piloting skill into consideration.
     const DEFAULT_SHIP_INITIATIVE_FORMULA = "2d6";
+    const DEFAULT_MAX_ENCUMBRANCE_FORMULA = "12 * @characteristics.strength.current";
 
     const settings: string[] = [];
     settings.push(stringSetting('initiativeFormula', DEFAULT_INITIATIVE_FORMULA, false, 'world'));
@@ -58,6 +59,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(numberSetting('mortgagePayment', 240, true));
     settings.push(numberSetting('massProductionDiscount', 0.10, true));
     settings.push(booleanSetting('reverseHealingOrder', false));
+    settings.push(stringSetting("maxEncumbrance", DEFAULT_MAX_ENCUMBRANCE_FORMULA, false, "world"));
     return settings;
   }
 }

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -365,6 +365,8 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
           break;
       }
     });
+    // Calc Max Encumbrance
+    const maxEncumbrance = new Roll(game.settings.get('twodsix', 'maxEncumbrance'), sheetData.actor.data).evaluate({async: false});
 
     // Assign and return
     if (sheetData.actor.type === "traveller") {
@@ -381,6 +383,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       sheetData.data.secondaryArmor.value = secondaryArmor;
       sheetData.data.radiationProtection.value = radiationProtection;
       sheetData.data.encumbrance.value = Math.round(encumbrance * 10) / 10; /*Round value to nearest tenth*/
+      sheetData.data.encumbrance.max = Math.round((maxEncumbrance.total || 0)* 10) / 10;
     } else if (sheetData.actor.type === "ship") {
       sheetData.component = sortObj(component);
       sheetData.storage = storage;

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -335,6 +335,7 @@ export interface Component extends GearTemplate {
   availableQuantity:string;
   damage:string;
   hits:number;
+  range:string;
   status:string;
   weightIsPct:boolean;
   isIllegal:boolean;

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -92,6 +92,7 @@ declare global {
       'twodsix.seriousWoundsRollModifier': number;
       'twodsix.mortgagePayment': number;
       'twodsix.massProductionDiscount': number;
+      'twodsix.maxEncumbrance': string;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -680,6 +680,10 @@
       "reverseHealingOrder": {
         "hint": "Healing using token bar input heals in the same order that auto damage occurs. The first characteristic damaged is also the first healed.  If this setting is false, healing starts with last characterisic and works backwards.",
         "name": "Reverse characteristic healing order"
+      },
+      "maxEncumbrance": {
+        "hint": "Formula to calculate maximum encumbrance for actor.",
+        "name": "Maximum Encumbrance Formula"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -220,6 +220,7 @@
         "Power": "Power",
         "status": "Status",
         "rating": "Rating",
+        "Range": "Range",
         "totalQuantity": "Total Quantity",
         "availableQuantity": "Available Quantity",
         "damage": "Damage",

--- a/static/template.json
+++ b/static/template.json
@@ -364,6 +364,7 @@
       "availableQuantity": "",
       "hits": 0,
       "damage": "",
+      "range": "",
       "status": "operational",
       "weightIsPct": false,
       "isIllegal": false,

--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -30,7 +30,7 @@
         name="data.radiationProtection.value" type="number" value="{{data.radiationProtection.value}}" placeholder='0' readonly /></span>
 <span class="bgi-encumbrance" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:<input
       name="data.encumbrance.value" style="text-align: right;" type="number" value="{{data.encumbrance.value}}" placeholder='0' readonly/>
-      /<input name="data.encumbrance.max" type="number" value="{{data.encumbrance.max}}" placeholder='0' onClick="this.select();"/></span>
+      /<input name="data.encumbrance.max" type="number" value="{{data.encumbrance.max}}" placeholder='0' readonly/></span>
 <br>
 
 <!-- Damage Stats Information-->

--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -28,8 +28,12 @@
        readonly />/<input name="data.secondaryArmor.value" type="number" value="{{data.secondaryArmor.value}}" placeholder='0' readonly /></span>
 <span class="bgi-armor" title='{{localize "TWODSIX.Items.Armor.RadProt"}}'><i class="fas fa-radiation-alt"></i>:<input
         name="data.radiationProtection.value" type="number" value="{{data.radiationProtection.value}}" placeholder='0' readonly /></span>
-<span class="bgi-encumbrance" title='{{localize "TWODSIX.Items.Encumbrance"}}'><i class="fas fa-weight-hanging"></i>:<input
-      name="data.encumbrance.value" style="text-align: right;" type="number" value="{{data.encumbrance.value}}" placeholder='0' readonly/>
+<span class="bgi-encumbrance" title='{{localize "TWODSIX.Items.Encumbrance"}}'>
+  {{#iff data.encumbrance.value ">" data.encumbrance.max}}
+    <i class="fas fa-weight-hanging" style="color:brown;"></i>
+  {{else}}
+    <i class="fas fa-weight-hanging"></i>
+  {{/iff}}:<input name="data.encumbrance.value" style="text-align: right;" type="number" value="{{data.encumbrance.value}}" placeholder='0' readonly/>
       /<input name="data.encumbrance.max" type="number" value="{{data.encumbrance.max}}" placeholder='0' readonly/></span>
 <br>
 

--- a/static/templates/actors/parts/actor/actor-bgi-std.html
+++ b/static/templates/actors/parts/actor/actor-bgi-std.html
@@ -24,7 +24,7 @@
 
 <span class="bgi-encumbrance" title="{{localize 'TWODSIX.Items.Encumbrance'}}">{{localize "TWODSIX.Items.Enc"}}:<input name="data.encumbrance.value" style="text-align: right;"
     type="number" value="{{data.encumbrance.value}}" placeholder='0' readonly/>/<input name="data.encumbrance.max" type="number" value="{{data.encumbrance.max}}"
-    placeholder='0' onClick="this.select();"/></span>
+    placeholder='0' readonly/></span>
 
 <span class="bgi-radExposure" title="{{localize 'TWODSIX.Actor.RadiationExposure'}}">Rads:<input name="data.radiationDose.value" style="text-align: right;"
       type="number" value="{{data.radiationDose.value}}" placeholder='0' onClick="this.select();"/></span><br>

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -119,6 +119,10 @@
       <input class="form-input" id="data.damage" type="text" name="data.damage" value="{{data.damage}}"/>
     </div>
     <div class="item-features">
+      <span class="resource-label">{{localize "TWODSIX.Items.Component.Range"}}</span>
+      <input class="form-input" type="text" name="data.range" value="{{data.range}}"/>
+    </div>
+    <div class="item-features">
       <span class="resource-label">{{localize "TWODSIX.Items.Component.Features"}}</span>
       <input class="form-input" type="text" name="data.features" value="{{data.features}}"/>
     </div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
max carry weight must be manually entered
no range for ship armament components

* **What is the new behavior (if this is a feature change)?**

provide formula input and calc max carry weight
range field for armaments

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
