### PR TITLE
fix: movement units

### DIFF
--- a/src/migrations/2022_4_27_09_05_00_fix_move_units.ts
+++ b/src/migrations/2022_4_27_09_05_00_fix_move_units.ts
@@ -1,0 +1,34 @@
+import { Traveller } from "../types/template";
+import { applyToAllActors } from "../migration-utils";
+
+async function adjustMovementUnits (actor: TwodsixActor): Promise<void> {
+  const actorData = actor.data.data as Traveller;
+  if (actorData.movement?.units) {
+    console.log("Starting units: ", actorData.movement.units);
+    switch (actorData.movement?.units) {
+      case 'TWODSIX.Actor.Movement.DistFt':
+        await actor.update({ 'data.movement.units': 'ft' });
+        break;
+      case 'TWODSIX.Actor.Movement.DistMi':
+        await actor.update({ 'data.movement.units': 'mi' });
+        break;
+      case 'TWODSIX.Actor.Movement.DistM':
+        await actor.update({ 'data.movement.units': 'm' });
+        break;
+      case 'TWODSIX.Actor.Movement.DistKm':
+        await actor.update({ 'data.movement.units': 'km' });
+        break;
+      default:
+        console.log('nothing changed');
+        break;
+    }
+    console.log("Ending Units: ", actorData.movement?.units);
+  }
+  return Promise.resolve();
+}
+
+export async function migrate(): Promise<void> {
+  await applyToAllActors(adjustMovementUnits);
+
+  return Promise.resolve();
+}

--- a/src/migrations/2022_4_27_09_05_00_fix_move_units.ts
+++ b/src/migrations/2022_4_27_09_05_00_fix_move_units.ts
@@ -18,6 +18,12 @@ async function adjustMovementUnits (actor: TwodsixActor): Promise<void> {
       case 'TWODSIX.Actor.Movement.DistKm':
         await actor.update({ 'data.movement.units': 'km' });
         break;
+      case 'TWODSIX.Actor.Movement.DistPc':
+        await actor.update({ 'data.movement.units': 'pc' });
+        break;
+      case 'TWODSIX.Actor.Movement.DistGU':
+        await actor.update({ 'data.movement.units': 'gu' });
+        break;
       default:
         console.log('nothing changed');
         break;

--- a/src/migrations/2022_4_27_09_05_00_fix_move_units.ts
+++ b/src/migrations/2022_4_27_09_05_00_fix_move_units.ts
@@ -4,7 +4,7 @@ import { applyToAllActors } from "../migration-utils";
 async function adjustMovementUnits (actor: TwodsixActor): Promise<void> {
   const actorData = actor.data.data as Traveller;
   if (actorData.movement?.units) {
-    console.log("Starting units: ", actorData.movement.units);
+    //console.log("Starting units: ", actorData.movement.units);
     switch (actorData.movement?.units) {
       case 'TWODSIX.Actor.Movement.DistFt':
         await actor.update({ 'data.movement.units': 'ft' });
@@ -22,7 +22,7 @@ async function adjustMovementUnits (actor: TwodsixActor): Promise<void> {
         console.log('nothing changed');
         break;
     }
-    console.log("Ending Units: ", actorData.movement?.units);
+    //console.log("Ending Units: ", (<Traveller>actor.data.data).movement?.units);
   }
   return Promise.resolve();
 }

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -290,7 +290,9 @@ export const MovementUnits = {
   ft: "TWODSIX.Actor.Movement.DistFt",
   mi: "TWODSIX.Actor.Movement.DistMi",
   m: "TWODSIX.Actor.Movement.DistM",
-  km: "TWODSIX.Actor.Movement.DistKm"
+  km: "TWODSIX.Actor.Movement.DistKm",
+  pc: "TWODSIX.Actor.Movement.DistPc",
+  gu: "TWODSIX.Actor.Movement.DistGU"
 };
 
 /**

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -224,6 +224,17 @@ export interface Traveller {
   characteristics:Characteristics;
   woundedEffect:number;
   characteristicEdit:boolean;
+  movement:MovementData;
+}
+
+export interface MovementData {
+  burrow:number;
+  climb:number;
+  fly:number;
+  swim:number;
+  walk:number;
+  units:string;
+  hover:boolean;
 }
 
 export interface Age {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -149,6 +149,8 @@
         "DistKm": "Kilometers",
         "DistM": "Meters",
         "DistMi": "Miles",
+        "DistPc": "Parsecs",
+        "DistGU": "Grid Units",
         "MovementRate": "Movement Rate"
       },
       "CharDisplay": {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -581,7 +581,7 @@ img.character-info-mask {
 }
 
 .bgi-movement select {
-  width: 7ch;
+  width: 12ch;
   background-color: var(--s2d6-background-transparent) !important;
   border: none;
 }
@@ -619,7 +619,7 @@ span.bgi-armor, span.bgi-encumbrance, span.bgi-radExposure, span.bgi-charEdit {
 }
 
 span.bgi-charEdit {
-  margin-left: 1em;
+  margin-left: 0.5em;
 }
 
 .bgi-armor input {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -296,10 +296,11 @@ img.character-info-mask {
 }
 
 .bgi-movement select {
-  width: 7ch;
+  width: 12ch;
   background-color: var(--s2d6-background-transparent) !important;
   border: none;
-  height: 2.7ch;
+  /*height: 2.7ch;*/
+  font-size: inherit;
 }
 
 .bgi-char-narrow {
@@ -334,7 +335,7 @@ span.bgi-armor, span.bgi-encumbrance, span.bgi-radExposure {
 }
 
 span.bgi-charEdit {
-  margin-left: 1em;
+  margin-left: 0.5em;
 }
 
 .bgi-armor input {

--- a/static/templates/actors/parts/actor/actor-bgi-cd.html
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.html
@@ -59,7 +59,7 @@
 <span class="bgi-movement" title='{{localize "TWODSIX.Actor.Movement.MovementRate"}}: {{localize "TWODSIX.Actor.Movement.MovementWalk"}}'><i class="fas fa-walking"></i>:
   <input type="number" name="data.movement.walk" value="{{data.movement.walk}}"/>
   <select name="data.movement.units" >
-    {{selectOptions config.MovementUnits selected=data.movement.units inverted=true}}
+    {{selectOptions config.MovementUnits selected=data.movement.units localize=true inverted=false}}
   </select>
 </span>
 

--- a/static/templates/actors/parts/actor/actor-bgi-std.html
+++ b/static/templates/actors/parts/actor/actor-bgi-std.html
@@ -33,7 +33,7 @@
 <span class="bgi-movement" title='{{localize "TWODSIX.Actor.Movement.MovementRate"}}'>{{localize "TWODSIX.Actor.Movement.MovementWalk"}}:
   <input type="number" name="data.movement.walk" value="{{data.movement.walk}}"/>
   <select name="data.movement.units" >
-    {{selectOptions config.MovementUnits selected=data.movement.units inverted=true}}
+    {{selectOptions config.MovementUnits selected=data.movement.units localize=true inverted=false}}
   </select>
 </span>
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Movement units use incorrect key


* **What is the new behavior (if this is a feature change)?**
Fix the reference and migrate to correct key


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, will change unit reference for all traveller actors.  Some conversions may not work correctly.


* **Other information**:
