### PR TITLE
feat: drag ruler integration

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -56,7 +56,9 @@ const RULESETS = Object.freeze({
       seriousWoundsRollModifier: 0,
       mortgagePayment: 240,
       massProductionDiscount: 0.10,
-      maxEncumbrance: "12 * @characteristics.strength.current"
+      maxEncumbrance: "12 * @characteristics.strength.current",
+      defaultMovement: 6,
+      defaultMovementUnits: "m"
     }
   },
   CEL: {
@@ -79,7 +81,9 @@ const RULESETS = Object.freeze({
       seriousWoundsRollModifier: 0,
       mortgagePayment: 240,
       massProductionDiscount: 0.10,
-      maxEncumbrance: "3 * @characteristics.strength.value"
+      maxEncumbrance: "3 * @characteristics.strength.value",
+      defaultMovement: 9,
+      defaultMovementUnits: "m"
     }
   },
   CEFTL: {
@@ -100,7 +104,9 @@ const RULESETS = Object.freeze({
       lifebloodInsteadOfCharacteristics: false,
       minorWoundsRollModifier: 0,
       seriousWoundsRollModifier: 0,
-      maxEncumbrance: "3 * @characteristics.strength.value"
+      maxEncumbrance: "3 * @characteristics.strength.value",
+      defaultMovement: 10,
+      defaultMovementUnits: "m"
     },
   },
   CEATOM: {
@@ -122,7 +128,9 @@ const RULESETS = Object.freeze({
       showContaminationBelowLifeblood: true,
       minorWoundsRollModifier: -1,
       seriousWoundsRollModifier: -1,
-      maxEncumbrance: "2 * @characteristics.endurance.value"
+      maxEncumbrance: "2 * @characteristics.endurance.value",
+      defaultMovement: 10,
+      defaultMovementUnits: "m"
     }
   },
   BARBARIC: {
@@ -144,7 +152,9 @@ const RULESETS = Object.freeze({
       showContaminationBelowLifeblood: false,
       minorWoundsRollModifier: -1,
       seriousWoundsRollModifier: -1,
-      maxEncumbrance: "2 * @characteristics.endurance.value"
+      maxEncumbrance: "2 * @characteristics.endurance.value",
+      defaultMovement: 10,
+      defaultMovementUnits: "m"
     },
   },
   CEQ: {
@@ -166,7 +176,9 @@ const RULESETS = Object.freeze({
       showContaminationBelowLifeblood: false,
       minorWoundsRollModifier: 0,
       seriousWoundsRollModifier: 0,
-      maxEncumbrance: "0"
+      maxEncumbrance: "0",
+      defaultMovement: 9,
+      defaultMovementUnits: "m"
     }
   },
   CD: {
@@ -196,7 +208,9 @@ const RULESETS = Object.freeze({
       seriousWoundsRollModifier: -2,
       mortgagePayment: 320,
       massProductionDiscount: 0.10,
-      maxEncumbrance: "3 * (7 + @characteristics.strength.mod)"
+      maxEncumbrance: "3 * (7 + @characteristics.strength.mod)",
+      defaultMovement: 10,
+      defaultMovementUnits: "m"
     }
   },
   CLU: {
@@ -222,7 +236,8 @@ const RULESETS = Object.freeze({
       ShowDamageType: false,
       ShowRateOfFire: true,
       ShowRecoil: true,
-      maxEncumbrance: "3*(7 + @characteristics.strength.mod)"
+      maxEncumbrance: "3*(7 + @characteristics.strength.mod)",
+      defaultMovementUnits: "m"
     }
   },
 
@@ -293,6 +308,15 @@ export const MovementUnits = {
   km: "TWODSIX.Actor.Movement.DistKm",
   pc: "TWODSIX.Actor.Movement.DistPc",
   gu: "TWODSIX.Actor.Movement.DistGU"
+};
+
+export const MovementUnitsUnLocalized = {
+  ft: "Feet",
+  mi: "Miles",
+  m: "Meters",
+  km: "Kilometers",
+  pc: "Parsecs",
+  gu: "Grid Units"
 };
 
 /**
@@ -369,6 +393,7 @@ export type TWODSIX = {
   RULESETS: typeof RULESETS,
   SHIP_ACTION_TYPE: typeof SHIP_ACTION_TYPE,
   MovementUnits: typeof MovementUnits,
+  MovementUnitsUnLocalized: typeof MovementUnitsUnLocalized,
   MovementType: typeof MovementTypes,
   PricingOptions: typeof PricingOptions,
   HullPricingOptions: typeof HullPricingOptions,
@@ -386,6 +411,7 @@ export const TWODSIX = {
   RULESETS: RULESETS,
   SHIP_ACTION_TYPE: SHIP_ACTION_TYPE,
   MovementUnits: MovementUnits,
+  MovementUnitsUnLocalized: MovementUnitsUnLocalized,
   MovementType: MovementTypes,
   PricingOptions: PricingOptions,
   HullPricingOptions: HullPricingOptions,

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -104,7 +104,7 @@ const RULESETS = Object.freeze({
       lifebloodInsteadOfCharacteristics: false,
       minorWoundsRollModifier: 0,
       seriousWoundsRollModifier: 0,
-      maxEncumbrance: "3 * @characteristics.strength.value",
+      maxEncumbrance: "0",
       defaultMovement: 10,
       defaultMovementUnits: "m"
     },
@@ -236,7 +236,12 @@ const RULESETS = Object.freeze({
       ShowDamageType: false,
       ShowRateOfFire: true,
       ShowRecoil: true,
+      minorWoundsRollModifier: -1,
+      seriousWoundsRollModifier: -2,
+      mortgagePayment: 320,
+      massProductionDiscount: 0.10,
       maxEncumbrance: "3*(7 + @characteristics.strength.mod)",
+      defaultMovement: 10,
       defaultMovementUnits: "m"
     }
   },

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -286,7 +286,9 @@ export default class TwodsixActor extends Actor {
             "token.disposition": CONST.TOKEN_DISPOSITIONS.FRIENDLY,
             "token.bar1": {
               attribute: "hits"
-            }
+            },
+            "data.movement.walk": game.settings.get("twodsix", "defaultMovement"),
+            "data.movement.units": game.settings.get("twodsix", "defaultMovementUnits")
           });
         }
         await this.createUntrainedSkill();

--- a/src/module/hooks/dragRulerIntegration.ts
+++ b/src/module/hooks/dragRulerIntegration.ts
@@ -1,3 +1,5 @@
+import { Traveller } from "src/types/template";
+
 Hooks.once("dragRuler.ready", (SpeedProvider) => {
   class TwodsixSpeedProvider extends SpeedProvider {
     get colors() {
@@ -26,24 +28,51 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
         }
       } else if (actorType === "traveller") {
         movementSpeed = token.actor.data.data.movement.walk;
+        const actorData = (<Traveller>actor.data.data);
         switch (rulesSet) {
-          case "CD":
-          case "CA":
-          case "CEQ":
-          case "CEFTL":
-          case "CEL":
           case "CEATOM":
-          case "CLU":
+          case "BARBARIC":
+            if ((actorData.encumbrance.value > actorData.encumbrance.max) && game.settings.get("twodsix", "useEncumbrance")) {
+              return [];
+            } else if ((actorData.encumbrance.value > actorData.encumbrance.max / 2) && game.settings.get("twodsix", "useEncumbrance")) {
+              movementSpeed *= 0.5;
+            }
             return [
               { range: movementSpeed, color: "walk" },
               { range: movementSpeed * 2, color: "dash" }
             ];
+          case "CD":
+          case "CEL":
+          case "CLU":
+            if ((actorData.encumbrance.value > actorData.encumbrance.max) && game.settings.get("twodsix", "useEncumbrance")) {
+              return [];
+            } else if ((actorData.encumbrance.value > actorData.encumbrance.max / 3) && game.settings.get("twodsix", "useEncumbrance")) {
+              return [
+                { range: movementSpeed, color: "walk" }
+              ];
+            } else {
+              return [
+                { range: movementSpeed, color: "walk" },
+                { range: movementSpeed * 2, color: "dash" }
+              ];
+            }
           case "CE":
+            if ((actorData.encumbrance.value > actorData.encumbrance.max) && game.settings.get("twodsix", "useEncumbrance")) {
+              return [];
+            } else if ((actorData.encumbrance.value > actorData.encumbrance.max / 2) && game.settings.get("twodsix", "useEncumbrance")) {
+              return [
+                { range: 1.5, color: "walk" }
+              ];
+            } else if ((actorData.encumbrance.value > actorData.encumbrance.max / 6) && game.settings.get("twodsix", "useEncumbrance")) {
+              movementSpeed *= 0.75;
+            }
             return [
               { range: movementSpeed, color: "walk" },
               { range: movementSpeed * 2, color: "dash" },
               { range: movementSpeed * 3, color: "run" }
             ];
+          case "CEQ":
+          case "CEFTL":
           default:
             return [
               { range: movementSpeed, color: "walk" },

--- a/src/module/hooks/dragRulerIntegration.ts
+++ b/src/module/hooks/dragRulerIntegration.ts
@@ -1,0 +1,58 @@
+Hooks.once("dragRuler.ready", (SpeedProvider) => {
+  class TwodsixSpeedProvider extends SpeedProvider {
+    get colors() {
+      return [
+        { id: "walk", default: 0x00FF00, name: "TWODSIX.speeds.walk" },
+        { id: "dash", default: 0xFFFF00, name: "TWODSIX.speeds.dash" },
+        { id: "run", default: 0xFF8000, name: "TWODSIX.speeds.run" },
+        { id: "jump", default: 0x00FF00, name: "TWODSIX.speeds.jump" }
+      ];
+    }
+
+    getRanges(token) {
+      const actor = (<TwodsixActor>token.actor);
+      const actorType = actor.type;
+      const rulesSet = game.settings.get("twodsix", "ruleset");
+      let movementSpeed = 0;
+
+      if (actorType === "ship") {
+        movementSpeed = token.actor.data.data.shipStats.drives.jDrive.rating;
+        if (token.scene.data.gridUnits === "pc") {
+          return [
+            { range: movementSpeed, color: "jump" },
+          ];
+        } else {
+          return [];
+        }
+      } else if (actorType === "traveller") {
+        movementSpeed = token.actor.data.data.movement.walk;
+        switch (rulesSet) {
+          case "CD":
+          case "CA":
+          case "CEQ":
+          case "CEFTL":
+          case "CEL":
+          case "CEATOM":
+          case "CLU":
+            return [
+              { range: movementSpeed, color: "walk" },
+              { range: movementSpeed * 2, color: "dash" }
+            ];
+          case "CE":
+            return [
+              { range: movementSpeed, color: "walk" },
+              { range: movementSpeed * 2, color: "dash" },
+              { range: movementSpeed * 3, color: "run" }
+            ];
+          default:
+            return [
+              { range: movementSpeed, color: "walk" },
+              { range: movementSpeed * 2, color: "dash" }
+            ];
+        }
+      }
+    }
+  }
+  //@ts-ignore
+  dragRuler.registerSystem("twodsix", TwodsixSpeedProvider);
+});

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -30,6 +30,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.push(booleanSetting('showWeightUsage', false));
     settings.push(booleanSetting('showItemReferences', true));
     settings.push(booleanSetting('showIcons', false));
+    settings.push(booleanSetting('useEncumbrance', false));
     return settings;
   }
 }

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -60,6 +60,8 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(numberSetting('massProductionDiscount', 0.10, true));
     settings.push(booleanSetting('reverseHealingOrder', false));
     settings.push(stringSetting("maxEncumbrance", DEFAULT_MAX_ENCUMBRANCE_FORMULA, false, "world"));
+    settings.push(numberSetting('defaultMovement', 10));
+    settings.push(stringChoiceSetting('defaultMovementUnits', "m", TWODSIX.MovementUnitsUnLocalized));
     return settings;
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -705,6 +705,10 @@
       "defaultMovementUnits": {
         "hint": "The default movement/walk units for new travellers (typically a minor action), e.g. m for 10m",
         "name": "The default movement units for the walk rate"
+      },
+      "useEncumbrance": {
+        "hint": "Use encumbarnce rules (if they exist) when displaying movement with drag ruler.",
+        "name": "Use system encumbrance rules for drag ruler"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -717,6 +717,12 @@
       "trait": "trait",
       "component": "component"
     },
+    "speeds": {
+      "walk": "walk",
+      "dash": "dash",
+      "run": "run",
+      "jump": "jump"
+    },
     "Errors": {
       "NoSkillForSkillRoll": "You tried to perform a skill roll without specifying a skill",
       "NoCharacteristicForRoll": "You tried to perform a characteristics roll without specifying a characteristic",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -697,6 +697,14 @@
       "allowDropOnIcon": {
         "hint": "Items can be dropped and added to actors directly on top of icon without opening actor sheet.  Duplicate items increase inventory quantity.  Chat damage items will apply damge.",
         "name": "Allow Items to be droped onto icons"
+      },
+      "defaultMovement": {
+        "hint": "The default movement/walk for new travellers (typically a minor action), e.g. 10 for 10m",
+        "name": "The default movement walk rate"
+      },
+      "defaultMovementUnits": {
+        "hint": "The default movement/walk units for new travellers (typically a minor action), e.g. m for 10m",
+        "name": "The default movement units for the walk rate"
       }
     },
     "CloseAndCreateNew": "Close and create new",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)

Can't use module drag ruler
No setting for default movement and units

* **What is the new behavior (if this is a feature change)?**
Drag ruler now supported with option encumbrance calc
Default movement and units settings are applied to new travellers.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
