### PR TITLE
fix: toggle fuel type

### DIFF
--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -107,6 +107,7 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     html.find('.roll-damage').on('click', onRollDamage.bind(this));
     html.find(".adjust-hits").on("click", this._onAdjustHitsCount.bind(this));
     html.find(".fuel-bar").on("click", this._onAdjustFuelType.bind(this));
+    html.find(".fuel-name").on("click", this._onAdjustFuelType.bind(this));
   }
 
   private _onShipPositionCreate():void {

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -106,6 +106,7 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
     html.find(".ship-deck-unlink").on("click", this._onDeckplanUnlink.bind(this));
     html.find('.roll-damage').on('click', onRollDamage.bind(this));
     html.find(".adjust-hits").on("click", this._onAdjustHitsCount.bind(this));
+    html.find(".fuel-bar").on("click", this._onAdjustFuelType.bind(this));
   }
 
   private _onShipPositionCreate():void {
@@ -154,6 +155,11 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
       itemSelected?.update({"data.status": stateTransitions[(<Component>itemSelected.data.data)?.status]});
     }
   }
+
+  private _onAdjustFuelType() {
+    this.actor.update({"data.shipStats.fuel.isRefined": !(<Ship>this.actor.data.data).shipStats.fuel.isRefined});
+  }
+
   private _onDeckplanClick() {
     if ((<Ship>this.actor.data.data)?.deckPlan) {
       game.scenes?.get((<Ship>this.actor.data.data).deckPlan)?.view();

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -166,7 +166,7 @@ export interface WeightStats {
 
 export interface ShipStats {
   hull:Hits;
-  fuel:Hits;
+  fuel:Fuel;
   power:Hits;
   armor:Staterooms;
   fuelTanks:Staterooms;
@@ -198,6 +198,13 @@ export interface Hits {
   value:number;
   min:number;
   max:number;
+}
+
+export interface Fuel {
+  value:number;
+  min:number;
+  max:number;
+  isRefined:boolean;
 }
 
 export interface Traveller {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -374,6 +374,8 @@
       "FINANCENOTES": "FINANCE NOTES",
       "SHIPVALUE": "SHIP VALUE",
       "Fuel": "Fuel",
+      "RefinedFuel": "Refined Fuel",
+      "UnrefinedFuel": "Unrefined Fuel",
       "Gs": "G",
       "InvalidDocumentForShipPosition": "This document type is invalid for ship positions. Only skills can be dropped here.",
       "IsMassProduced": "Ship is Mass Produced",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1569,6 +1569,7 @@ img.ship-mask-bg {
   width: 95%;
   height: 30px;
   /* align-self: center; */
+  cursor: pointer;
 }
 
 .ship-state-grid {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1571,6 +1571,9 @@ img.ship-mask-bg {
   /* align-self: center; */
   cursor: pointer;
 }
+.fuel-name {
+  cursor: pointer;
+}
 
 .ship-state-grid {
   display: grid;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1189,6 +1189,9 @@ img.ship-mask-bg {
   vertical-align: middle;
   cursor: pointer;
 }
+.fuel-name {
+  cursor: pointer;
+}
 
 .ship-state-grid {
   display: grid;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1187,6 +1187,7 @@ img.ship-mask-bg {
   width: 95%;
   height: 30px;
   vertical-align: middle;
+  cursor: pointer;
 }
 
 .ship-state-grid {

--- a/static/template.json
+++ b/static/template.json
@@ -214,7 +214,8 @@
         "fuel": {
           "value": 0,
           "min": 0,
-          "max": 0
+          "max": 0,
+          "isRefined": true
         },
         "power": {
           "value": 0,

--- a/static/templates/actors/parts/ship/ship-state-grid.html
+++ b/static/templates/actors/parts/ship/ship-state-grid.html
@@ -18,7 +18,7 @@
     </span>
   </div>
   <div class="ship-fuel">
-    <span>{{#if data.data.shipStats.fuel.isRefined}}{{localize "TWODSIX.Ship.RefinedFuel"}}{{else}}{{localize "TWODSIX.Ship.UnrefinedFuel"}}{{/if}}</span>
+    <span class = "fuel-name">{{#if data.data.shipStats.fuel.isRefined}}{{localize "TWODSIX.Ship.RefinedFuel"}}{{else}}{{localize "TWODSIX.Ship.UnrefinedFuel"}}{{/if}}</span>
     <span><meter class = "fuel-bar" value="{{data.data.shipStats.fuel.value}}" max = "{{data.data.shipStats.fuel.max}}" min="0" low= "{{twodsix_product data.data.shipStats.fuel.max 0.25}}" high = "{{twodsix_product data.data.shipStats.fuel.max 0.5}}" optimum = "{{twodsix_product data.data.shipStats.fuel.max 0.95}}">{{data.data.shipStats.fuel.value}}</meter></span>
     <span class="ship-fuel-value"><input type="number" value="{{data.data.shipStats.fuel.value}}" name="data.shipStats.fuel.value" placeholder="0" max = "{{data.data.shipStats.fuel.max}}" min = "0"/>/<input type="number" value="{{data.data.shipStats.fuel.max}}" name="data.shipStats.fuel.max" placeholder="0"/>
       <span class="small-font">{{localize "TWODSIX.Damage.Current"}}/{{localize "TWODSIX.Damage.Max"}}</span>

--- a/static/templates/actors/parts/ship/ship-state-grid.html
+++ b/static/templates/actors/parts/ship/ship-state-grid.html
@@ -18,7 +18,7 @@
     </span>
   </div>
   <div class="ship-fuel">
-    <span>{{localize "TWODSIX.Ship.Fuel"}}</span>
+    <span>{{#if data.data.shipStats.fuel.isRefined}}{{localize "TWODSIX.Ship.RefinedFuel"}}{{else}}{{localize "TWODSIX.Ship.UnrefinedFuel"}}{{/if}}</span>
     <span><meter class = "fuel-bar" value="{{data.data.shipStats.fuel.value}}" max = "{{data.data.shipStats.fuel.max}}" min="0" low= "{{twodsix_product data.data.shipStats.fuel.max 0.25}}" high = "{{twodsix_product data.data.shipStats.fuel.max 0.5}}" optimum = "{{twodsix_product data.data.shipStats.fuel.max 0.95}}">{{data.data.shipStats.fuel.value}}</meter></span>
     <span class="ship-fuel-value"><input type="number" value="{{data.data.shipStats.fuel.value}}" name="data.shipStats.fuel.value" placeholder="0" max = "{{data.data.shipStats.fuel.max}}" min = "0"/>/<input type="number" value="{{data.data.shipStats.fuel.max}}" name="data.shipStats.fuel.max" placeholder="0"/>
       <span class="small-font">{{localize "TWODSIX.Damage.Current"}}/{{localize "TWODSIX.Damage.Max"}}</span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Core ship sheet doesn't distinguish between refined and unrefined fuel


* **What is the new behavior (if this is a feature change)?**
Can toggle file bar to switch between refined and unrefined label


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
