### PR TITLE
Fix: roll settings for ship actions

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -211,7 +211,7 @@ export default class TwodsixItem extends Item {
     let rollFormula = weapon.damage;
     console.log(rollFormula);
     if (confirmFormula) {
-      rollFormula = await TwodsixItem.confirmRollFormula(rollFormula);
+      rollFormula = await TwodsixItem.confirmRollFormula(rollFormula, game.i18n.localize("TWODSIX.Damage.DamageFormula"));
     }
     const damageFormula = rollFormula + (bonusDamage ? "+" + bonusDamage : "");
 
@@ -266,10 +266,10 @@ export default class TwodsixItem extends Item {
     return returnValue;
   }
 
-  public static async confirmRollFormula(initFormula):Promise<string> {
+  public static async confirmRollFormula(initFormula:string, title:string):Promise<string> {
     const returnText:string = await new Promise((resolve) => {
       new Dialog({
-        title: game.i18n.localize("TWODSIX.Damage.DamageFormula"),
+        title: title,
         content:
           `<label>Formula</label><input type="text" name="outputFormula" id="outputFormula" value="` + initFormula + `"></input>`,
         buttons: {

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -247,7 +247,7 @@ export default class TwodsixItem extends Item {
         Object.assign(contentData, {
           flavor: flavor,
           roll: damage,
-          damage: damage.total ?? 0,
+          damage: damage.total,
           dice: damage.terms[0]["results"],
           armorPiercingValue: apValue ?? 0
         });

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -202,48 +202,65 @@ export default class TwodsixItem extends Item {
     return diceRoll;
   }
 
-  public async rollDamage(rollMode: DICE_ROLL_MODES, bonusDamage = "", showInChat = true, confirmFormula = false): Promise<Roll | void>{
+  public async rollDamage(rollMode: DICE_ROLL_MODES, bonusDamage = "", showInChat = true, confirmFormula = false): Promise<Roll | void> {
     const weapon = <Weapon | Component>this.data.data;
-    const doesDamage = weapon.damage != null;
-    if (!doesDamage) {
+
+    if (!weapon.damage) {
       ui.notifications.error(game.i18n.localize("TWODSIX.Errors.NoDamageForWeapon"));
-    }
-    let rollFormula = weapon.damage;
-    console.log(rollFormula);
-    if (confirmFormula) {
-      rollFormula = await TwodsixItem.confirmRollFormula(rollFormula, game.i18n.localize("TWODSIX.Damage.DamageFormula"));
-    }
-    const damageFormula = rollFormula + (bonusDamage ? "+" + bonusDamage : "");
+      return;
+    } else {
+      //Calc regular damage
+      let rollFormula = weapon.damage;
+      //console.log(rollFormula);
+      if (confirmFormula) {
+        rollFormula = await TwodsixItem.confirmRollFormula(rollFormula, game.i18n.localize("TWODSIX.Damage.DamageFormula"));
+      }
+      rollFormula += (bonusDamage ? "+" + bonusDamage : "");
 
-    if (Roll.validate(damageFormula)) {
-      const damageRoll = new Roll(damageFormula, this.actor?.data.data);
-      const damage: Roll = await damageRoll.evaluate({ async: true }); // async: true will be default in foundry 0.10
-      const apValue = TwodsixItem.getApValue(<Weapon>weapon, this.actor?.id || "");
+      let damage = <Roll>{};
+      let apValue = 0;
+      if (Roll.validate(rollFormula)) {
+        damage = new Roll(rollFormula, this.actor?.data.data);
+        await damage.evaluate({ async: true }); // async: true will be default in foundry 0.10
+        apValue = TwodsixItem.getApValue(<Weapon>weapon, this.actor?.id || "");
+      } else {
+        ui.notifications.error(game.i18n.localize("TWODSIX.Errors.InvalidRollFormula"));
+        return;
+      }
 
-      if (showInChat) {
-        const results = damage.terms[0]["results"];
-        const contentData = {
-          flavor: `${game.i18n.localize("TWODSIX.Rolls.DamageUsing")} ${this.name}`,
-          roll: damage,
-          damage: damage.total,
-          dice: results,
-          armorPiercingValue: apValue ?? 0
-        };
-
-        if ( this.data.type === "component") {
-          if (Roll.validate(this.data.data.radDamage)) {
-            const radDamageRoll = new Roll(this.data.data.radDamage, this.actor?.data.data);
-            const radDamage = await radDamageRoll.evaluate({ async: true });
-            contentData['radDamage'] = radDamage.total;
-            contentData['radRoll'] = radDamage;
-            contentData['radDice'] = radDamage.terms[0]["results"];
-          }
+      //Calc radiation damage
+      let radDamage = <Roll>{};
+      if (this.data.type === "component") {
+        if (Roll.validate(this.data.data.radDamage)) {
+          radDamage = new Roll(this.data.data.radDamage, this.actor?.data.data);
+          await radDamage.evaluate({ async: true });
         }
+      }
 
+      const contentData = {};
+      if (damage.total) {
+        let flavor = `${game.i18n.localize("TWODSIX.Rolls.DamageUsing")} ${this.name}`;
         if (apValue !== undefined) {
-          contentData.flavor += `, ${game.i18n.localize("TWODSIX.Damage.AP")}(${apValue})`;
+          flavor += `, ${game.i18n.localize("TWODSIX.Damage.AP")}(${apValue})`;
         }
 
+        Object.assign(contentData, {
+          flavor: flavor,
+          roll: damage,
+          damage: damage.total ?? 0,
+          dice: damage.terms[0]["results"],
+          armorPiercingValue: apValue ?? 0
+        });
+      }
+
+      if (radDamage.total) {
+        Object.assign(contentData, {
+          radDamage: radDamage.total,
+          radRoll: radDamage,
+          radDice: radDamage.terms[0]["results"]
+        });
+      }
+      if (showInChat) {
         const html = await renderTemplate('systems/twodsix/templates/chat/damage-message.html', contentData);
         const transfer = JSON.stringify(
           {
@@ -260,9 +277,7 @@ export default class TwodsixItem extends Item {
           }
         }, { rollMode: rollMode });
       }
-      return damage;
-    } else {
-      ui.notifications.error(game.i18n.localize("TWODSIX.Errors.InvalidRollFormula"));
+      return damage;  //probably should return contentData instead
     }
   }
   public static getApValue(weapon: Weapon, actorID = ""): number {
@@ -277,8 +292,8 @@ export default class TwodsixItem extends Item {
     return returnValue;
   }
 
-  public static async confirmRollFormula(initFormula:string, title:string):Promise<string> {
-    const returnText:string = await new Promise((resolve) => {
+  public static async confirmRollFormula(initFormula: string, title: string): Promise<string> {
+    const returnText: string = await new Promise((resolve) => {
       new Dialog({
         title: title,
         content:
@@ -288,7 +303,7 @@ export default class TwodsixItem extends Item {
             label: `<i class="fas fa-dice" alt="d6" ></i> ` + game.i18n.localize("TWODSIX.Rolls.Roll"),
             callback:
               (html: JQuery) => {
-                resolve( html.find('[name="outputFormula"]')[0]["value"]);
+                resolve(html.find('[name="outputFormula"]')[0]["value"]);
               }
           }
         },
@@ -366,7 +381,7 @@ export default class TwodsixItem extends Item {
    * @param {Event} event   The originating click event
    * @private
    */
-export async function onRollDamage(event): Promise < void> {
+export async function onRollDamage(event): Promise<void> {
   event.preventDefault();
   event.stopPropagation();
   const itemId = $(event.currentTarget).parents('.item').data('item-id');

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -268,6 +268,10 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
     //Link an actor skill with name defined by item.associatedSkillName
     if (itemData.data.associatedSkillName !== "") {
       itemData.data.skill = actor.items.getName(itemData.data.associatedSkillName)?.data._id;
+      //Try to link Untrained if no match
+      if (!itemData.data.skill) {
+        itemData.data.skill = (<TwodsixActor>actor).getUntrainedSkill().data._id;
+      }
     }
 
     // Create the owned item (TODO Add to type and remove the two lines below...)

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -85,7 +85,8 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
           ship: this.actor,
           event: event,
           actionName: action.name,
-          positionName: shipPosition?.name ?? ""
+          positionName: shipPosition?.name ?? "",
+          diceModifier: ""
         };
 
         TwodsixShipActions.availableMethods[action.type].action(action.command, extra);

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -76,7 +76,8 @@ export class TwodsixShipActions {
       const settings = {
         characteristic: shortLabel,
         displayLabel: displayLabel,
-        extraFlavor: game.i18n.localize("TWODSIX.Ship.MakesChatRollAction").replace( "_ACTION_NAME_", extra.actionName || game.i18n.localize("TWODSIX.Ship.Unknown")).replace("_POSITION_NAME_", (extra.positionName || game.i18n.localize("TWODSIX.Ship.Unknown")))
+        extraFlavor: game.i18n.localize("TWODSIX.Ship.MakesChatRollAction").replace( "_ACTION_NAME_", extra.actionName || game.i18n.localize("TWODSIX.Ship.Unknown")).replace("_POSITION_NAME_", (extra.positionName || game.i18n.localize("TWODSIX.Ship.Unknown"))),
+        diceModifier: extra.diceModifier ? parseInt(extra.diceModifier) : 0
       };
       if (diff) {
         settings["difficulty"] = Object.values(difficulties).filter((difficulty: Record<string, number>) => difficulty.target === parseInt(diff, 10))[0];
@@ -95,11 +96,16 @@ export class TwodsixShipActions {
 
   public static async fireEnergyWeapons(text: string, extra: ExtraData) {
     const [skilText, componentId] = text.split("=");
+    const component = extra.ship?.items.find(item => item.id === componentId && item.type === "component");
+    if ((<Component>component?.data.data).rollModifier) {
+      extra.diceModifier = (<Component>component?.data.data).rollModifier;
+    }
+
     const result = await TwodsixShipActions.skillRoll(skilText, extra);
     if (!result) {
       return false;
     }
-    const component = extra.ship?.items.find(item => item.id === componentId && item.type === "component");
+
     const usingCompStr = component ? (game.i18n.localize("TWODSIX.Ship.WhileUsing") + component.name +` `) : '';
     let radString = "";
     if (result.effect >= 0 && component) {

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -101,7 +101,7 @@ export class TwodsixShipActions {
 
   public static async fireEnergyWeapons(text: string, extra: ExtraData) {
     const [skilText, componentId] = text.split("=");
-    const component = extra.ship?.items.find(item => item.id === componentId && item.type === "component");
+    const component = extra.ship?.items.find(item => item.id === componentId);
     if ((<Component>component?.data.data)?.rollModifier) {
       extra.diceModifier = (<Component>component?.data.data)?.rollModifier;
     }

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -103,7 +103,7 @@ export class TwodsixShipActions {
     const [skilText, componentId] = text.split("=");
     const component = extra.ship?.items.find(item => item.id === componentId && item.type === "component");
     if ((<Component>component?.data.data)?.rollModifier) {
-      extra.diceModifier = (<Component>component?.data.data).rollModifier;
+      extra.diceModifier = (<Component>component?.data.data)?.rollModifier;
     }
 
     const result = await TwodsixShipActions.skillRoll(skilText, extra);

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -25,10 +25,15 @@ export class TwodsixShipActions {
     }
   };
 
-  public static chatMessage(msg: string, extra: ExtraData) {
+  public static async chatMessage(msg: string, extra: ExtraData) {
     const speakerData = ChatMessage.getSpeaker({ actor: extra.actor });
     if (msg.startsWith("/r") || msg.startsWith("/R")) {
-      const rollText = msg.substring(msg.indexOf(' ') + 1); /* return roll formula after first space */
+      let rollText = msg.substring(msg.indexOf(' ') + 1); /* return roll formula after first space */
+      const useInvertedShiftClick: boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
+      const showRollDiag = useInvertedShiftClick ? extra.event["shiftKey"] : !extra.event["shiftKey"];
+      if(showRollDiag) {
+        rollText = await TwodsixItem.confirmRollFormula(rollText, (extra.positionName + " " + game.i18n.localize("TWODSIX.Ship.ActionRollFormula")));
+      }
       if (Roll.validate(rollText)) {
         const rollData = extra.actor?.getRollData();
         const flavorTxt:string = game.i18n.localize("TWODSIX.Ship.MakesChatRollAction").replace( "_ACTION_NAME_", extra.actionName || game.i18n.localize("TWODSIX.Ship.Unknown")).replace("_POSITION_NAME_", (extra.positionName || game.i18n.localize("TWODSIX.Ship.Unknown")));
@@ -109,7 +114,7 @@ export class TwodsixShipActions {
     const usingCompStr = component ? (game.i18n.localize("TWODSIX.Ship.WhileUsing") + component.name +` `) : '';
     let radString = "";
     if (result.effect >= 0 && component) {
-      const stdDamage = await (<TwodsixItem>component).rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), "", false, false);
+      const stdDamage = await (<TwodsixItem>component).rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), "", true, false);
       const rollData = extra.actor?.getRollData();
       if (Roll.validate((<Component>component.data.data).radDamage)) {
         const radDamage = new Roll((<Component>component.data.data).radDamage, rollData).evaluate({async: false}).total;

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -102,7 +102,7 @@ export class TwodsixShipActions {
   public static async fireEnergyWeapons(text: string, extra: ExtraData) {
     const [skilText, componentId] = text.split("=");
     const component = extra.ship?.items.find(item => item.id === componentId && item.type === "component");
-    if ((<Component>component?.data.data).rollModifier) {
+    if ((<Component>component?.data.data)?.rollModifier) {
       extra.diceModifier = (<Component>component?.data.data).rollModifier;
     }
 

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -111,24 +111,13 @@ export class TwodsixShipActions {
       return false;
     }
 
-    const usingCompStr = component ? (game.i18n.localize("TWODSIX.Ship.WhileUsing") + component.name +` `) : '';
-    let radString = "";
-    if (result.effect >= 0 && component) {
-      const stdDamage = await (<TwodsixItem>component).rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), "", true, false);
-      const rollData = extra.actor?.getRollData();
-      if (Roll.validate((<Component>component.data.data).radDamage)) {
-        const radDamage = new Roll((<Component>component.data.data).radDamage, rollData).evaluate({async: false}).total;
-        if (radDamage) {
-          radString = ' ' + game.i18n.localize("TWODSIX.Ship.RadiationDamageOf") + ' ' + radDamage;
-        }
-      }
-      if(stdDamage?.total) {
-        TwodsixShipActions.chatMessage(game.i18n.localize("TWODSIX.Ship.ActionHitsAndDamage").replace("_WHILE_USING_", usingCompStr).replace("_EFFECT_VALUE_", result.effect.toString()).replace("_DAMAGE_TOTAL_", stdDamage.total.toString()) + radString, extra);
+    const usingCompStr = component ? (game.i18n.localize("TWODSIX.Ship.WhileUsing") + component.name + ` `) : '';
+    if (game.settings.get("twodsix", "automateDamageRollOnHit")) {
+      if (result.effect >= 0 && component) {
+        await (<TwodsixItem>component).rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), "", true, false);
       } else {
-        TwodsixShipActions.chatMessage(game.i18n.localize("TWODSIX.Ship.ActionHits").replace("_WHILE_USING_", usingCompStr).replace("_EFFECT_VALUE_", result.effect.toString()), extra);
+        TwodsixShipActions.chatMessage(game.i18n.localize("TWODSIX.Ship.ActionMisses").replace("_WHILE_USING_", usingCompStr).replace("_EFFECT_VALUE_", result.effect.toString()), extra);
       }
-    } else {
-      TwodsixShipActions.chatMessage(game.i18n.localize("TWODSIX.Ship.ActionMisses").replace("_WHILE_USING_", usingCompStr).replace("_EFFECT_VALUE_", result.effect.toString()), extra);
     }
   }
 }

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -93,6 +93,9 @@ declare global {
       'twodsix.mortgagePayment': number;
       'twodsix.massProductionDiscount': number;
       'twodsix.maxEncumbrance': string;
+      'twodsix.useEncumbrance': boolean;
+      'twodsix.defaultMovement': number;
+      'twodsix.defaultMovementUnits': string;
     }
   }
 }
@@ -113,6 +116,7 @@ declare interface ExtraData {
   event: Event;
   actionName?: string;
   positionName?: string;
+  diceModifier?: string;
 }
 
 declare interface AvailableShipActionData {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -340,6 +340,7 @@
     "Ship": {
       "Actions": "Actions",
       "ActionType": "Action Type",
+      "ActionRollFormula": "Action Roll Formula",
       "Unknown": "unknown",
       "ActorLacksSkill": "_ACTOR_NAME_ lacks the skill _SKILL_",
       "ActorMustBeSelectedForAction": "Since there are multiple actors, one must be selected to perform the action",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2153,6 +2153,10 @@ button.flexrow.flex-group-center.toggle-skills {
   margin-left: 0;
 }
 
+.mini-dice {
+  align-self: center;
+}
+
 /*--- Item Page ---*/
 
 .small-grid {

--- a/static/templates/chat/damage-message.html
+++ b/static/templates/chat/damage-message.html
@@ -1,6 +1,7 @@
 <div class='twodsix-message dice-roll' data-transfer='{{transfer}}'>
   <div class='damage-message'>
     <div class='prefix'>{{flavor}}</div>
+    {{#if roll.total}}
     <div class="dice-result">
       <div class="dice-formula">{{roll.formula}}</div>
       <div class="dice-tooltip">
@@ -20,6 +21,7 @@
       </div>
       <h4 class="dice-total">{{damage}}</h4>
     </div>
+    {{/if}}
     {{#if radRoll}}
     <br>
     {{localize "TWODSIX.Items.Component.RadiationDamage"}}

--- a/static/templates/chat/damage-message.html
+++ b/static/templates/chat/damage-message.html
@@ -1,7 +1,6 @@
 <div class='twodsix-message dice-roll' data-transfer='{{transfer}}'>
   <div class='damage-message'>
     <div class='prefix'>{{flavor}}</div>
-    <br/>
     <div class="dice-result">
       <div class="dice-formula">{{roll.formula}}</div>
       <div class="dice-tooltip">

--- a/static/templates/chat/damage-message.html
+++ b/static/templates/chat/damage-message.html
@@ -21,5 +21,29 @@
       </div>
       <h4 class="dice-total">{{damage}}</h4>
     </div>
+    {{#if radRoll}}
+    <br>
+    {{localize "TWODSIX.Items.Component.RadiationDamage"}}
+    <br>
+    <div class="dice-result">
+      <div class="dice-formula">{{radRoll.formula}}</div>
+      <div class="dice-tooltip">
+        <section class="tooltip-part">
+          <div class="dice">
+            <header class="part-header flexrow">
+              <span class="part-formula">{{radRoll.formula}}</span>
+              <span class="part-total">{{radRoll.total}}</span>
+            </header>
+            <ol class="dice-rolls">
+              {{#each radDice as |die|}}
+                <li class="roll">{{die.result}}</li>
+              {{/each}}
+            </ol>
+          </div>
+        </section>
+      </div>
+      <h4 class="dice-total">{{radDamage}}</h4>
+    </div>
+    {{/if}}
   </div>
 </div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fixes


* **What is the current behavior?** (You can also link to an open issue here)
No way to prompt for ship action rolls using chat roll
Alignment error for dice on actor sheet
Dice roll for ship weapons damage roll not shown
Component dice modifier not included in ship weapons rolls
No radiation damage rolls
Try to link dropped item to Untrained if the associated skill doesn't exist

* **What is the new behavior (if this is a feature change)?**
Fix the above


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Probably should move damage to an object on weapon to accommodate different damage types rather than special case for radiation.