### PR TITLE
feat: add training notes field and indicator

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -275,6 +275,23 @@ export default function registerHandlebarsHelpers(): void {
     return game.settings.get("twodsix", "maxComponentHits");
   });
 
+  Handlebars.registerHelper('makePieImage', (text: string) => {
+    const re = new RegExp(/([0-9]*\.?[0-9]*)\s*%/gm);
+    const parsedResult: RegExpMatchArray | null = re.exec(text);
+    let inputPercentage = 0.5;
+    if (parsedResult) {
+      inputPercentage = Number(parsedResult[1])/100;
+      if (inputPercentage > 1) {
+        inputPercentage = 1;
+      }
+      if (inputPercentage < 0 ) {
+        inputPercentage = 0;
+      }
+    }
+    const degrees = Math.round(inputPercentage * 360);
+    return `background-image: conic-gradient(var(--s2d6-pie-color) ${degrees}deg, var(--s2d6-pie-background-color) ${degrees}deg); border-radius: 50%; border:solid; width: 2ch; height: 2ch; align-self: center; margin-left: 0.8em;`;
+  });
+
   // Handy for debugging
   Handlebars.registerHelper('debug', function (context) {
     console.log(context);

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -276,11 +276,12 @@ export default function registerHandlebarsHelpers(): void {
   });
 
   Handlebars.registerHelper('makePieImage', (text: string) => {
-    const re = new RegExp(/([0-9]*\.?[0-9]*)\s*%/gm);
+    //const re = new RegExp(/([0-9]*\.?[0-9]*)\s*%/gm);
+    const re = new RegExp(/(\d+)(\s?)\/(\s?)(\d+)/gm);
     const parsedResult: RegExpMatchArray | null = re.exec(text);
     let inputPercentage = 0.5;
     if (parsedResult) {
-      inputPercentage = Number(parsedResult[1])/100;
+      inputPercentage = Number(parsedResult[1]) / Number(parsedResult[4]);
       if (inputPercentage > 1) {
         inputPercentage = 1;
       }

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -289,7 +289,7 @@ export default function registerHandlebarsHelpers(): void {
       }
     }
     const degrees = Math.round(inputPercentage * 360);
-    return `background-image: conic-gradient(var(--s2d6-pie-color) ${degrees}deg, var(--s2d6-pie-background-color) ${degrees}deg); border-radius: 50%; border:solid; width: 2ch; height: 2ch; align-self: center; margin-left: 0.8em;`;
+    return `background-image: conic-gradient(var(--s2d6-pie-color) ${degrees}deg, var(--s2d6-pie-background-color) ${degrees}deg); border-radius: 50%; border:solid;`;
   });
 
   // Handy for debugging

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -397,6 +397,7 @@ export interface Skills {
   key:string;
   difficulty:string;
   rolltype:string;
+  trainingNotes:string;
 }
 
 export interface Templates {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -294,7 +294,8 @@
         "LFB": "LFB",
         "STA": "STA",
         "ALT1": "ALT1",
-        "ALT2": "ALT2"
+        "ALT2": "ALT2",
+        "TrainingNotes": "Training Notes"
       },
       "Traits": {
         "Prerequisite": "Prerequisite",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1200,6 +1200,13 @@ span.total-output {
   align-self: center;
 }
 
+.pie-chart {
+  width: 2ch;
+  height: 2ch;
+  align-self: center;
+  margin-left: 0.8em;
+}
+
 .resource-label {
   text-align: right;
   align-self: center;

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1103,7 +1103,8 @@ a:hover, a.active {
 
 .skills input[type='number'] {
   width: 2em;
-;justify-self: center;}
+  justify-self: center;
+}
 
 input.item-value-edit {
   /*padding: initial;*/

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1103,7 +1103,7 @@ a:hover, a.active {
 
 .skills input[type='number'] {
   width: 2em;
-}
+;justify-self: center;}
 
 input.item-value-edit {
   /*padding: initial;*/
@@ -1139,10 +1139,6 @@ input.item-value-edit {
   overflow-x: hidden;
 }
 
-.skl.item-control.item-edit {
-  padding-right: 1.5em;
-}
-
 .item-controls .item-toggle i { display: none; }
 .item-controls .item-toggle .fa-hiking { display: inline; }
 .item-controls .item-toggle.ship .fa-hiking,
@@ -1163,7 +1159,7 @@ input.item-value-edit {
 
 .skill-container {
   display: grid;
-  grid-template-columns: 1.5em 15em 3.4em 4em 3em 6.5em;
+  grid-template-columns: 1.5em 12em 3.5em 2.5em 5em 4em 4em;
   grid-template-rows: 1fr;
   gap: 1px 1px;
 }
@@ -1195,6 +1191,10 @@ span.total-output {
 
 .skill-total {
   text-align: center;
+}
+
+.skill-title {
+  align-self: center;
 }
 
 .resource-label {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -54,6 +54,8 @@
   --s2d6-damage-red: rgba(255, 0, 0, 1);
   --s2d6-damage-stat-color: rgba(181, 44, 44, 1);
   --s2d6-damage-orange: rgba(255, 153, 0, 1);
+  --s2d6-pie-color: var(--s2d6-default-color);
+  --s2d6-pie-background-color: var(--s2d6-background-opaque);
 }
 
 body {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -850,6 +850,13 @@ span.total-output {
   align-self:center;
 }
 
+.pie-chart {
+  width: 2ch;
+  height: 2ch;
+  align-self: center;
+  margin-left: 0.8em;
+}
+
 .resource-label {
   text-align: right;
   align-self: center;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -24,6 +24,8 @@
   --s2d6-damage-stat-color: rgba(181, 44, 44, 1);
   --s2d6-damage-orange: rgba(255, 90, 0, 1);
   --s2d6-input-background: rgba(0, 0, 0, 0.05);
+  --s2d6-pie-color: var(--s2d6-background-opaque);
+  --s2d6-pie-background-color: var(--s2d6-background-transparent);
 }
 
 input[type= 'checkbox'] {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -685,7 +685,6 @@ a.skill-tab.active, a.item-tab.active, a.finances-tab.active, a.info-tab.active,
 
 .skill-list {
   padding: 0.3em 0 0;
-  height: 2em;
   border: 1px groove var(--s2d6-background-opaque);
   border-radius: 1ch 0 0;
   background-color: var(--s2d6-background-nearly-opaque);
@@ -750,6 +749,7 @@ a:hover, a.active {
 
 .skills input[type='number'] {
   width: 2em;
+  justify-self: center;
 }
 
 input.item-value-edit {
@@ -786,10 +786,6 @@ input.item-value-edit {
   overflow-x: hidden;
 }
 
-.skl.item-control.item-edit {
-  padding-right: 1.5em;
-}
-
 .item-controls .item-toggle i { display: none; }
 .item-controls .item-toggle .fa-hiking { display: inline; }
 .item-controls .item-toggle.ship .fa-hiking,
@@ -814,7 +810,7 @@ input.item-value-edit {
 
 .skill-container {
   display: grid;
-  grid-template-columns: 1.5em 15em 3.4em 4em 3em 6.1em;
+  grid-template-columns: 1.5em 12em 3.5em 2.5em 5em 4em 4em;
   grid-template-rows: 1fr;
   gap: 1px 1px;
 }
@@ -846,6 +842,10 @@ span.total-output {
 
 .skill-total {
   text-align: center;
+}
+
+.skill-title {
+  align-self:center;
 }
 
 .resource-label {

--- a/static/template.json
+++ b/static/template.json
@@ -335,7 +335,8 @@
       "reference": "",
       "key": "key",
       "difficulty": "Average",
-      "rolltype": "Normal"
+      "rolltype": "Normal",
+      "trainingNotes": ""
     },
     "trait": {
       "templates": ["skillsTemplate"],

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -45,7 +45,11 @@
                 </span>
                 <span class="item-name rollable" data-label="{{item.name}}" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
                 <input class= "item-value-edit" type="number" value="{{item.data.data.value}}"/>
-                <span class="item-name centre">{{#iff item.data.data.trainingNotes "!==" ""}}<i class="fas fa-solid fa-check"></i>{{/iff}}</span>
+                {{#iff item.data.data.trainingNotes "!==" ""}}
+                  <span style ='{{makePieImage item.data.data.trainingNotes}}'></span>
+                {{else}}
+                  <span></span>
+                {{/iff}}
                 <span class="item-name centre" for="skill-modifier">{{twodsix_skillCharacteristic ../actor item.data.data.characteristic}}</span>
                 <span class="total-output flex1 skill-mod">{{twodsix_skillTotal ../actor item.data.data.characteristic item.data.data.value}}</span>
                 <span class="item-controls centre">

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -46,7 +46,7 @@
                 <span class="item-name rollable" data-label="{{item.name}}" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
                 <input class= "item-value-edit" type="number" value="{{item.data.data.value}}"/>
                 {{#iff item.data.data.trainingNotes "!==" ""}}
-                  <span style ='{{makePieImage item.data.data.trainingNotes}}'></span>
+                  <span class="pie-chart" style ='{{makePieImage item.data.data.trainingNotes}}'></span>
                 {{else}}
                   <span></span>
                 {{/iff}}

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -8,7 +8,8 @@
   <span class="skill-container">
     <span></span>
     <span class="skill-title">{{localize "TWODSIX.Actor.Skills.SkillName"}}</span>
-    <span class="skill-level left">{{localize "TWODSIX.Actor.Skills.Level"}}</span>
+    <span class="skill-level centre">{{localize "TWODSIX.Actor.Skills.Level"}}</span>
+    <abbr class="skill-training centre" title="{{localize 'TWODSIX.Items.Skills.TrainingNotes'}}"><i class="fas fa-solid fa-school"></i></abbr>
     <span class="skill-mod centre">{{localize "TWODSIX.Actor.Skills.Modifier"}}</span>
     <span class="skill-total centre">{{localize "TWODSIX.Actor.Skills.Total"}}</span>
     <span class="skill-edit-remove centre">{{localize "TWODSIX.Actor.Skills.EditOrRemove"}}</span>
@@ -44,6 +45,7 @@
                 </span>
                 <span class="item-name rollable" data-label="{{item.name}}" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
                 <input class= "item-value-edit" type="number" value="{{item.data.data.value}}"/>
+                <span class="item-name centre">{{#iff item.data.data.trainingNotes "!==" ""}}<i class="fas fa-solid fa-check"></i>{{/iff}}</span>
                 <span class="item-name centre" for="skill-modifier">{{twodsix_skillCharacteristic ../actor item.data.data.characteristic}}</span>
                 <span class="total-output flex1 skill-mod">{{twodsix_skillTotal ../actor item.data.data.characteristic item.data.data.value}}</span>
                 <span class="item-controls centre">
@@ -67,6 +69,7 @@
           <span class="mini-dice centre rollable" title="{{twodsix_invertSkillRollShiftClick}}"><i class="fas fa-dice" alt="d6"></i></span>
           <span class="item-name rollable" title="{{twodsix_invertSkillRollShiftClick}}">{{untrainedSkill.name}}</span>
           <input class="item-value-edit" type="number" value= "{{untrainedSkill.data.data.value}}" readonly/>
+          <span class="centre">&mdash;</span>
           <span class="item-name centre" for="skill-modifier">{{localize "TWODSIX.Items.Skills.NONE"}}</span>
           <span class="total-output flex1 skill-mod">{{untrainedSkill.data.data.value}}</span>
         </span>

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -34,8 +34,8 @@
     {{#if (twodsix_hideUntrainedSkills item.data.data.value)}}
     <!-- Hiding {{item.name}} -->
     {{else}}
-    <div class="skill">
       {{#if (twodsix_filterSkills item)}}
+      <div class="skill">
         <span class="item skill-container">
           <ol class="ol-no-indent">
             <li class="item flexrow" data-item-id="{{item.id}}">
@@ -60,9 +60,9 @@
             </li>
           </ol>
         </span>
-        {{/if}}
-    </div>
-  {{/if}}
+      </div>
+      {{/if}}
+   {{/if}}
 {{/each_sort_by_name}}
 {{#if (twodsix_hideUntrainedSkills -1)}}
 <div class="skill">

--- a/static/templates/items/skills-sheet.html
+++ b/static/templates/items/skills-sheet.html
@@ -31,6 +31,11 @@
       <input class="form-input" id="data.value" type="text" name="data.value" value="{{data.value}}" data-dtype="Number"/>
     </div>
 
+    <div class="item-simplifiedName">
+      <label class="resource-label" for="data.inTraining">{{localize "TWODSIX.Items.Skills.TrainingNotes"}}</label>
+      <input class="form-input" id="data.trainingNotes" name="data.trainingNotes" type="text" value="{{data.trainingNotes}}"/>
+    </div>
+
       <div class="item-type">
         <label for="data.characteristic" class="resource-label">{{localize "TWODSIX.Items.Skills.Modifier"}}</label>
         <select class="form-input" name="data.characteristic" value={{characteristic}}>
@@ -59,11 +64,6 @@
             {{/each}}
           {{/select}}
         </select>
-    </div>
-
-    <div class="item-short">
-      <label for="data.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
-      <input class="form-input" id="data.shortdescr" type="text" name="data.shortdescr" value="{{data.shortdescr}}"/>
     </div>
 
     <div class="item-descr">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)

No way to track training

* **What is the new behavior (if this is a feature change)?**
Add a training notes field and indicator on skills list.  Indicator is based on a fraction entered somewhere in the new Training Notes field (e.g. 1/4).  It defaults to 50% if no fraction found.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
