### PR TITLE
feat: add option to include effect with ship weapon damage

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -58,7 +58,8 @@ const RULESETS = Object.freeze({
       massProductionDiscount: 0.10,
       maxEncumbrance: "12 * @characteristics.strength.current",
       defaultMovement: 6,
-      defaultMovementUnits: "m"
+      defaultMovementUnits: "m",
+      addEffectForShipDamage: false
     }
   },
   CEL: {
@@ -83,7 +84,8 @@ const RULESETS = Object.freeze({
       massProductionDiscount: 0.10,
       maxEncumbrance: "3 * @characteristics.strength.value",
       defaultMovement: 9,
-      defaultMovementUnits: "m"
+      defaultMovementUnits: "m",
+      addEffectForShipDamage: false
     }
   },
   CEFTL: {
@@ -106,7 +108,8 @@ const RULESETS = Object.freeze({
       seriousWoundsRollModifier: 0,
       maxEncumbrance: "0",
       defaultMovement: 10,
-      defaultMovementUnits: "m"
+      defaultMovementUnits: "m",
+      addEffectForShipDamage: false
     },
   },
   CEATOM: {
@@ -178,7 +181,8 @@ const RULESETS = Object.freeze({
       seriousWoundsRollModifier: 0,
       maxEncumbrance: "0",
       defaultMovement: 9,
-      defaultMovementUnits: "m"
+      defaultMovementUnits: "m",
+      addEffectForShipDamage: false
     }
   },
   CD: {
@@ -210,7 +214,8 @@ const RULESETS = Object.freeze({
       massProductionDiscount: 0.10,
       maxEncumbrance: "3 * (7 + @characteristics.strength.mod)",
       defaultMovement: 10,
-      defaultMovementUnits: "m"
+      defaultMovementUnits: "m",
+      addEffectForShipDamage: false
     }
   },
   CLU: {
@@ -242,7 +247,8 @@ const RULESETS = Object.freeze({
       massProductionDiscount: 0.10,
       maxEncumbrance: "3*(7 + @characteristics.strength.mod)",
       defaultMovement: 10,
-      defaultMovementUnits: "m"
+      defaultMovementUnits: "m",
+      addEffectForShipDamage: false
     }
   },
 

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -62,6 +62,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(stringSetting("maxEncumbrance", DEFAULT_MAX_ENCUMBRANCE_FORMULA, false, "world"));
     settings.push(numberSetting('defaultMovement', 10));
     settings.push(stringChoiceSetting('defaultMovementUnits', "m", TWODSIX.MovementUnitsUnLocalized));
+    settings.push(booleanSetting('addEffectForShipDamage', false));
     return settings;
   }
 }

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -114,7 +114,8 @@ export class TwodsixShipActions {
     const usingCompStr = component ? (game.i18n.localize("TWODSIX.Ship.WhileUsing") + component.name + ` `) : '';
     if (game.settings.get("twodsix", "automateDamageRollOnHit")) {
       if (result.effect >= 0 && component) {
-        await (<TwodsixItem>component).rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), "", true, false);
+        const bonusDamage = game.settings.get("twodsix", "addEffectForShipDamage") ? result.effect.toString() : "";
+        await (<TwodsixItem>component).rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamage, true, false);
       } else {
         TwodsixShipActions.chatMessage(game.i18n.localize("TWODSIX.Ship.ActionMisses").replace("_WHILE_USING_", usingCompStr).replace("_EFFECT_VALUE_", result.effect.toString()), extra);
       }

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -96,6 +96,7 @@ declare global {
       'twodsix.useEncumbrance': boolean;
       'twodsix.defaultMovement': number;
       'twodsix.defaultMovementUnits': string;
+      'twodsix.addEffectForShipDamage': boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -714,6 +714,10 @@
       "useEncumbrance": {
         "hint": "Use encumbarnce rules (if they exist) when displaying movement with drag ruler.",
         "name": "Use system encumbrance rules for drag ruler"
+      },
+      "addEffectForShipDamage": {
+        "hint": "The ship attack effect value is added to the damage roll.",
+        "name": "Add effect to ship damage"
       }
     },
     "CloseAndCreateNew": "Close and create new",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)

Ship weapon rolls do not have option to include effect with damage roll

* **What is the new behavior (if this is a feature change)?**
New ruleset setting now provides ability to include the effect with damage roll


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
