### PR TITLE
fix: allow skills to be dropped with level if >=0

### DIFF
--- a/src/module/hooks/dropItemOnToken.ts
+++ b/src/module/hooks/dropItemOnToken.ts
@@ -73,14 +73,14 @@ function getTokensAtLocation(canvasObject: Canvas, x: number, y: number) {
 function handleDroppedSkills(actor: TwodsixActor, itemData: TwodsixItem) {
   // Handle item sorting within the same Actor
   const droppedSkill = duplicate(itemData);
-
-  if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
-    const skills:Skills = <Skills>game.system.template.Item?.skills;
-    (<Skills>droppedSkill.data).value = skills?.value;
-  } else {
-    (<Skills>droppedSkill.data).value = 0;
+  if ((<Skills>droppedSkill.data).value < 0) {
+    if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
+      const skills: Skills = <Skills>game.system.template.Item?.skills;
+      (<Skills>droppedSkill.data).value = skills?.value;
+    } else {
+      (<Skills>droppedSkill.data).value = 0;
+    }
   }
-
   actor.createEmbeddedDocuments("Item", [droppedSkill]);
   console.log(`Twodsix | Added Skill ${droppedSkill.name} to character`);
 }

--- a/src/module/hooks/dropItemOnToken.ts
+++ b/src/module/hooks/dropItemOnToken.ts
@@ -73,7 +73,7 @@ function getTokensAtLocation(canvasObject: Canvas, x: number, y: number) {
 function handleDroppedSkills(actor: TwodsixActor, itemData: TwodsixItem) {
   // Handle item sorting within the same Actor
   const droppedSkill = duplicate(itemData);
-  if ((<Skills>droppedSkill.data).value < 0) {
+  if ((<Skills>droppedSkill.data).value < 0 || !(<Skills>droppedSkill.data).value) {
     if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
       const skills: Skills = <Skills>game.system.template.Item?.skills;
       (<Skills>droppedSkill.data).value = skills?.value;

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -240,11 +240,13 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       return false;
     }
 
-    if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
-      const skills:Skills = <Skills>game.system.template.Item?.skills;
-      itemData.data.value = skills?.value;
-    } else {
-      itemData.data.value = 0;
+    if (itemData.data.value < 0) {
+      if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
+        const skills: Skills = <Skills>game.system.template.Item?.skills;
+        itemData.data.value = skills?.value;
+      } else {
+        itemData.data.value = 0;
+      }
     }
 
     await actor.createEmbeddedDocuments("Item", [itemData]);

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -240,7 +240,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       return false;
     }
 
-    if (itemData.data.value < 0) {
+    if (itemData.data.value < 0 || !itemData.data.value) {
       if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
         const skills: Skills = <Skills>game.system.template.Item?.skills;
         itemData.data.value = skills?.value;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Skills can't be dropped with a level (value >=0)

* **What is the new behavior (if this is a feature change)?**
level of dropped skill is preserved if >= 0



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
