### PR TITLE
fix:Allow untrained skills in training to show on list when hide untraine…

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -100,8 +100,8 @@ export default function registerHandlebarsHelpers(): void {
     }
   });
 
-  Handlebars.registerHelper('twodsix_hideUntrainedSkills', (value) => {
-    return value && (game.settings.get('twodsix', 'hideUntrainedSkills') && value < 0);
+  Handlebars.registerHelper('twodsix_hideUntrainedSkills', (data) => {
+    return data.value && (game.settings.get('twodsix', 'hideUntrainedSkills') && data.value < 0  && data.trainingNotes === "");
   });
 
   Handlebars.registerHelper('twodsix_burstModes', (weapon) => {

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -6,7 +6,10 @@ Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>)
     if (actor.isToken) {
       applyWoundedEffect(<Token>canvas.tokens?.ownedTokens?.find(t => t.id === actor.token?.id));
     } else {
-      applyWoundedEffect(<Token>canvas.tokens?.ownedTokens.find(t => t.data.actorId === actor.id));
+      const actorToken = <Token>canvas.tokens?.ownedTokens.find(t => t.data.actorId === actor.id);
+      if (actorToken) {
+        applyWoundedEffect(actorToken);
+      }
     }
   }
 });

--- a/static/templates/actors/npc-sheet.html
+++ b/static/templates/actors/npc-sheet.html
@@ -29,13 +29,13 @@
             <input type="number" value="{{jackOfAllTrades}}" id="joat-skill-input" style="text-align: center; width: 3ch;"/>,
         </span>
       {{#each_sort_by_name data.skills as |item id|}}
-        {{#if (twodsix_hideUntrainedSkills item.data.data.value)}}
+        {{#if (twodsix_hideUntrainedSkills item.data.data)}}
           <!-- Hiding {{item.name}} -->
         {{else}}
           {{#if (twodsix_filterSkills item)}}
               <span class="item" data-item-id="{{item.id}}" style = "display: inline-block;">
                 <span class="item-name rollable" data-label="{{item.name}}" title="{{twodsix_invertSkillRollShiftClick}}">{{item.name}}</span>
-                <input style="width: 3ch;" class= "item-value-edit" type="number" value="{{item.data.data.value}}"/>, 
+                <input style="width: 3ch;" class= "item-value-edit" type="number" value="{{item.data.data.value}}"/>,
               </span>
           {{/if}}
        {{/if}}

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -31,7 +31,7 @@
 </div>
 
 {{#each_sort_by_name data.skills as |item id|}}
-    {{#if (twodsix_hideUntrainedSkills item.data.data.value)}}
+    {{#if (twodsix_hideUntrainedSkills item.data.data)}}
     <!-- Hiding {{item.name}} -->
     {{else}}
       {{#if (twodsix_filterSkills item)}}


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Can't see untrained skills in skill list when being trained if hide unskilled active

* **What is the new behavior (if this is a feature change)?**
Allow untrained skills to be listed if training and settings to hide unskilled is active


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
