### PR TITLE
fix: don't auto roll damage for components without damage field

### DIFF
--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -112,7 +112,7 @@ export class TwodsixShipActions {
     }
 
     const usingCompStr = component ? (game.i18n.localize("TWODSIX.Ship.WhileUsing") + component.name + ` `) : '';
-    if (game.settings.get("twodsix", "automateDamageRollOnHit") && (<Component>component?.data.data).damage) {
+    if (game.settings.get("twodsix", "automateDamageRollOnHit") && (<Component>component?.data.data).subtype === "armament") {
       if (result.effect >= 0 && component) {
         const bonusDamage = game.settings.get("twodsix", "addEffectForShipDamage") ? result.effect.toString() : "";
         await (<TwodsixItem>component).rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamage, true, false);

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -112,7 +112,7 @@ export class TwodsixShipActions {
     }
 
     const usingCompStr = component ? (game.i18n.localize("TWODSIX.Ship.WhileUsing") + component.name + ` `) : '';
-    if (game.settings.get("twodsix", "automateDamageRollOnHit")) {
+    if (game.settings.get("twodsix", "automateDamageRollOnHit") && (<Component>component?.data.data).damage) {
       if (result.effect >= 0 && component) {
         const bonusDamage = game.settings.get("twodsix", "addEffectForShipDamage") ? result.effect.toString() : "";
         await (<TwodsixItem>component).rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamage, true, false);

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -112,7 +112,7 @@ export class TwodsixShipActions {
     }
 
     const usingCompStr = component ? (game.i18n.localize("TWODSIX.Ship.WhileUsing") + component.name + ` `) : '';
-    if (game.settings.get("twodsix", "automateDamageRollOnHit") && (<Component>component?.data.data).subtype === "armament") {
+    if (game.settings.get("twodsix", "automateDamageRollOnHit") && (<Component>component?.data.data)?.subtype === "armament") {
       if (result.effect >= 0 && component) {
         const bonusDamage = game.settings.get("twodsix", "addEffectForShipDamage") ? result.effect.toString() : "";
         await (<TwodsixItem>component).rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamage, true, false);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When using fire weapons for non-armament component error message occurs that no valid damage field.

* **What is the new behavior (if this is a feature change)?**
Do not auto roll damage for non armament components.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
