### PR TITLE
fix: component list single line layout

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -228,7 +228,6 @@
         "availableQuantity": "Available Quantity",
         "damage": "Damage",
         "RadiationDamage": "Radiation Damage",
-        "damageHits": "Damage / Hits",
         "hits": "Hits",
         "weightIsPct": "Weight is Percentage?",
         "purchasePrice": "Purchase Price",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2042,10 +2042,10 @@ a.ship-notes-tab.active {
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 12em 3em 7em 3em 4em 4em 4em 4.5em 4.5em 4em 3em;
+  grid-template-columns: 12.5em 3em 7em 3em 4em 4em 4em 4.5em 4.5em 4em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
-  grid-template-areas: ". . . . . . . . . .";
+  grid-template-areas: ". . . . . . . . . . .";
 }
 
 .grid-columns-single-row:nth-of-type(even) {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2042,7 +2042,7 @@ a.ship-notes-tab.active {
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 16em 4em 4em 4em 4em 4em 4em 4.5em 4em 3em;
+  grid-template-columns: 12em 3em 7em 3em 4em 4em 4em 4.5em 4.5em 4em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
   grid-template-areas: ". . . . . . . . . .";

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1605,7 +1605,7 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 16em 4em 4em 4em 4em 4em 4em 4.5em 4em 3em;
+  grid-template-columns: 12em 3em 7em 3em 4em 4em 4em 4.5em 4.5em 4em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
   grid-template-areas: ". . . . . . . . . .";
@@ -1914,6 +1914,9 @@ select.form-input, input.form-input, span.form-input {
 }
 
 /*--- Chat Log ---*/
+#sidebar {
+  width: 320px;
+}
 /*
 #sidebar-tabs.tabs .item.active {
   text-shadow: 0 0 2em var(--default-color);

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1605,10 +1605,10 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 12em 3em 7em 3em 4em 4em 4em 4.5em 4.5em 4em 3em;
+  grid-template-columns: 12.5em 3em 7em 3em 4em 4em 4em 4.5em 4.5em 4em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
-  grid-template-areas: ". . . . . . . . . .";
+  grid-template-areas: ". . . . . . . . . . .";
 }
 
 .grid-columns-single-row:nth-of-type(even) {

--- a/static/templates/actors/parts/ship/ship-components-single.html
+++ b/static/templates/actors/parts/ship/ship-components-single.html
@@ -8,7 +8,8 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.Power"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
-      <span class="item-name centre">{{localize "TWODSIX.Items.Component.damageHits"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Items.Component.damage"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Items.Component.hits"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Items.Component.status"}}</span>
       <span class="item-name centre"><a class="item-control item-create" title='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="component" data-subtype = {{@key}}> <i class="fas fa-plus"></i></a></span>
     </div>
@@ -34,16 +35,18 @@
           <span class="item-name centre">{{getComponentWeight this}}</span>
           <span class="item-name centre">{{getComponentPower this}}</span>
           <span class="item-name centre">{{#if item.data.data.availableQuantity}}{{item.data.data.availableQuantity}}/{{/if}}{{item.data.data.quantity}}</span>
-          {{#iff item.data.data.subtype "===" "armament"}}
+
           <span class="item-name centre">
-            {{#iff item.data.data.damage "!==" ""}}<span class="roll-damage orange">{{twodsix_limitLength item.data.data.damage 6}}</span> / {{/iff}}
-          {{item.data.data.hits}}{{#iff item.data.data.damage "!==" ""}}<br>{{/iff}}
-          {{else}}
+            {{#iff item.data.data.subtype "===" "armament"}}
+              {{#iff item.data.data.damage "!==" ""}}<span class="roll-damage orange">{{twodsix_limitLength item.data.data.damage 3}}{{else}}&mdash;{{/iff}}</span>
+            {{else}}
+             &mdash;
+            {{/iff}}
+          </span>
           <span class="item-name centre">{{item.data.data.hits}}
-          {{/iff}}
           <span class="combined-buttons">
-            <button class="left-button adjust-hits" {{#iff currentCount "===" 0}}disabled{{/iff}} data-value="-1">-</button>
-            <button class="right-button adjust-hits" {{#iff currentCount "===" 9}}disabled{{/iff}} data-value="1">+</button>
+            <button class="left-button adjust-hits" {{#iff currentCount "===" 0}}disabled{{/iff}} data-value="-1" style="width: 18px;">-</button>
+            <button class="right-button adjust-hits" {{#iff currentCount "===" 9}}disabled{{/iff}} data-value="1" style="width: 18px;">+</button>
           </span>
           </span>
           <span class="item-name centre component-toggle">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix:

* **What is the current behavior?** (You can also link to an open issue here)

Damage and hits combined into one field cause some rows to be double height

* **What is the new behavior (if this is a feature change)?**

Split damage and hits listings

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
