### PR TITLE
feat: add timeframe option to skill rolls

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -60,7 +60,8 @@ const RULESETS = Object.freeze({
       defaultMovement: 6,
       defaultMovementUnits: "m",
       addEffectForShipDamage: false,
-      unarmedDamage: "1d6"
+      unarmedDamage: "1d6",
+      showTimeframe: true
     }
   },
   CEL: {
@@ -87,7 +88,8 @@ const RULESETS = Object.freeze({
       defaultMovement: 9,
       defaultMovementUnits: "m",
       addEffectForShipDamage: false,
-      unarmedDamage: "max(@characteristics.strength.mod, 1)"
+      unarmedDamage: "max(@characteristics.strength.mod, 1)",
+      showTimeframe: false
     }
   },
   CEFTL: {
@@ -112,7 +114,8 @@ const RULESETS = Object.freeze({
       defaultMovement: 10,
       defaultMovementUnits: "m",
       addEffectForShipDamage: false,
-      unarmedDamage: "max(@characteristics.strength.mod, 1)"
+      unarmedDamage: "max(@characteristics.strength.mod, 1)",
+      showTimeframe: false
     },
   },
   CEATOM: {
@@ -137,7 +140,8 @@ const RULESETS = Object.freeze({
       maxEncumbrance: "2 * @characteristics.endurance.value",
       defaultMovement: 10,
       defaultMovementUnits: "m",
-      unarmedDamage: "max(@characteristics.strength.mod, 1)"
+      unarmedDamage: "max(@characteristics.strength.mod, 1)",
+      showTimeframe: false
     }
   },
   BARBARIC: {
@@ -162,7 +166,8 @@ const RULESETS = Object.freeze({
       maxEncumbrance: "2 * @characteristics.endurance.value",
       defaultMovement: 10,
       defaultMovementUnits: "m",
-      unarmedDamage: "1d6"
+      unarmedDamage: "1d6",
+      showTimeframe: false
     },
   },
   CEQ: {
@@ -188,7 +193,8 @@ const RULESETS = Object.freeze({
       defaultMovement: 9,
       defaultMovementUnits: "m",
       addEffectForShipDamage: false,
-      unarmedDamage: "max(@characteristics.strength.mod, 1)"
+      unarmedDamage: "max(@characteristics.strength.mod, 1)",
+      showTimeframe: false
     }
   },
   CD: {
@@ -222,7 +228,8 @@ const RULESETS = Object.freeze({
       defaultMovement: 10,
       defaultMovementUnits: "m",
       addEffectForShipDamage: false,
-      unarmedDamage: "max(@characteristics.strength.mod, 1)"
+      unarmedDamage: "max(@characteristics.strength.mod, 1)",
+      showTimeframe: false
     }
   },
   CLU: {
@@ -256,7 +263,8 @@ const RULESETS = Object.freeze({
       defaultMovement: 10,
       defaultMovementUnits: "m",
       addEffectForShipDamage: false,
-      unarmedDamage: "max(@characteristics.strength.mod, 1)"
+      unarmedDamage: "max(@characteristics.strength.mod, 1)",
+      showTimeframe: false
     }
   },
 
@@ -403,6 +411,19 @@ export const ComponentTypes = {
   vehicle: "TWODSIX.Items.Component.vehicle"
 };
 
+/**
+ * The valid time units.
+ */
+export const TimeUnits = {
+  none: "TWODSIX.Actor.Skills.Timeframe.none",
+  sec: "TWODSIX.Actor.Skills.Timeframe.secs",
+  min: "TWODSIX.Actor.Skills.Timeframe.mins",
+  hrs: "TWODSIX.Actor.Skills.Timeframe.hrs",
+  days: "TWODSIX.Actor.Skills.Timeframe.days",
+  weeks: "TWODSIX.Actor.Skills.Timeframe.weeks",
+  rounds: "TWODSIX.Actor.Skills.Timeframe.rounds"
+};
+
 export type TWODSIX = {
   CHARACTERISTICS: typeof CHARACTERISTICS,
   CONSUMABLES: typeof CONSUMABLES,
@@ -418,7 +439,8 @@ export type TWODSIX = {
   HullPricingOptions: typeof HullPricingOptions,
   ComponentStates: typeof ComponentStates,
   ComponentTypes: typeof ComponentTypes,
-  CharacteristicDisplayTypes: typeof CharacteristicDisplayTypes
+  CharacteristicDisplayTypes: typeof CharacteristicDisplayTypes,
+  TimeUnts: typeof TimeUnits
 };
 
 export const TWODSIX = {
@@ -436,8 +458,8 @@ export const TWODSIX = {
   HullPricingOptions: HullPricingOptions,
   ComponentStates: ComponentStates,
   ComponentTypes: ComponentTypes,
-  CharacteristicDisplayTypes: CharacteristicDisplayTypes
+  CharacteristicDisplayTypes: CharacteristicDisplayTypes,
+  TimeUnits: TimeUnits
 };
 
 export const EQUIPPED_STATES = ["equipped", "ship", "backpack"];
-

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -421,6 +421,7 @@ export const TimeUnits = {
   hrs: "TWODSIX.Actor.Skills.Timeframe.hrs",
   days: "TWODSIX.Actor.Skills.Timeframe.days",
   weeks: "TWODSIX.Actor.Skills.Timeframe.weeks",
+  months: "TWODSIX.Actor.Skills.Timeframe.months",
   rounds: "TWODSIX.Actor.Skills.Timeframe.rounds"
 };
 

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -225,6 +225,10 @@ export default function registerHandlebarsHelpers(): void {
     return (game.settings.get('twodsix', 'useTinyMCEditor'));
   });
 
+  Handlebars.registerHelper('twodsix_showTimeframe', () => {
+    return game.settings.get('twodsix', 'showTimeframe');
+  });
+
   Handlebars.registerHelper("concat", (...args) => args.slice(0, args.length - 1).join(''));
 
   Handlebars.registerHelper('each_sort_by_name', (array, options) => {

--- a/src/module/hooks/renderChatMessage.ts
+++ b/src/module/hooks/renderChatMessage.ts
@@ -16,7 +16,14 @@ Hooks.on('renderChatMessage', (app, html) => {
     if (!isNaN(Number(effect))) {
       const sumString = game.i18n.localize('TWODSIX.Rolls.sum').capitalize();
       const effectString = game.i18n.localize('TWODSIX.Rolls.Effect');
-      diceTotal.text(`${sumString}: ${diceTotal.text()} ${effectString}: ${effect}`);
+
+      if (game.settings.get("twodsix", "showTimeframe") && <string>app.getFlag("twodsix", "timeframe") !== '' && <string>app.getFlag("twodsix", "timeframe")) {
+        const timeframe = <string>app.getFlag("twodsix", "timeframe");
+        const timeString = game.i18n.localize('TWODSIX.Rolls.Timeframe');
+        diceTotal.text(`${sumString}: ${diceTotal.text()} ${effectString}: ${effect}\n${timeString}: ${timeframe}`);
+      } else {
+        diceTotal.text(`${sumString}: ${diceTotal.text()} ${effectString}: ${effect}`);
+      }
     }
 
     // Color crits

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -64,6 +64,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(stringChoiceSetting('defaultMovementUnits', "m", TWODSIX.MovementUnitsUnLocalized));
     settings.push(booleanSetting('addEffectForShipDamage', false));
     settings.push(stringSetting("unarmedDamage", "1d6", false, "world"));
+    settings.push(booleanSetting("showTimeframe", false));
     return settings;
   }
 }

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -142,7 +142,25 @@ export class TwodsixDiceRoll {
     const difficulties:CEL_DIFFICULTIES | CE_DIFFICULTIES = TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))];
     const difficulty = game.i18n.localize(getKeyByValue(difficulties, this.settings.difficulty));
 
-    let flavor = this.settings.extraFlavor ? this.settings.extraFlavor + `<br>` : ``;
+    let flavor = this.settings.extraFlavor ? this.settings.extraFlavor + `.` : ``;
+
+    // Add timeframe if requred
+    if (game.settings.get("twodsix", "showTimeframe")  && this.settings.selectedTimeUnit !== "none") {
+      if (Roll.validate(this.settings.timeRollFormula)) {
+        const timeToComplete = new Roll(this.settings.timeRollFormula).evaluate({async: false}).total;
+        const timeUnits = game.i18n.localize(TWODSIX.TimeUnits[this.settings.selectedTimeUnit]);
+        // add spacing if necessary
+        if (flavor !== ``) {
+          flavor += `  `;
+        }
+        flavor += game.i18n.localize("TWODSIX.Chat.Roll.taskDuration").replace("_TIME_", timeToComplete.toString()).replace("_UNITS_", timeUnits);
+      }
+    }
+    // add a line break if necessary
+    if (flavor !== ``) {
+      flavor += `<br>`;
+    }
+
     flavor += `${rollingString}: ${difficulty}`;
 
     if (game.settings.get('twodsix', 'difficultiesAsTargetNumber')) {

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -142,25 +142,7 @@ export class TwodsixDiceRoll {
     const difficulties:CEL_DIFFICULTIES | CE_DIFFICULTIES = TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))];
     const difficulty = game.i18n.localize(getKeyByValue(difficulties, this.settings.difficulty));
 
-    let flavor = this.settings.extraFlavor ? this.settings.extraFlavor + `.` : ``;
-
-    // Add timeframe if requred
-    if (game.settings.get("twodsix", "showTimeframe")  && this.settings.selectedTimeUnit !== "none") {
-      if (Roll.validate(this.settings.timeRollFormula)) {
-        const timeToComplete = new Roll(this.settings.timeRollFormula).evaluate({async: false}).total;
-        const timeUnits = game.i18n.localize(TWODSIX.TimeUnits[this.settings.selectedTimeUnit]);
-        // add spacing if necessary
-        if (flavor !== ``) {
-          flavor += `  `;
-        }
-        flavor += game.i18n.localize("TWODSIX.Chat.Roll.taskDuration").replace("_TIME_", timeToComplete.toString()).replace("_UNITS_", timeUnits);
-      }
-    }
-    // add a line break if necessary
-    if (flavor !== ``) {
-      flavor += `<br>`;
-    }
-
+    let flavor = this.settings.extraFlavor ? this.settings.extraFlavor + `<br>`: ``;
     flavor += `${rollingString}: ${difficulty}`;
 
     if (game.settings.get('twodsix', 'difficultiesAsTargetNumber')) {
@@ -197,6 +179,14 @@ export class TwodsixDiceRoll {
       flavor += ` ${usingString} ${charShortName}(${characteristicValue})`;
     }
 
+    // Add timeframe if requred
+    let timeToComplete = ``;
+    if (game.settings.get("twodsix", "showTimeframe")  && this.settings.selectedTimeUnit !== "none") {
+      if (Roll.validate(this.settings.timeRollFormula)) {
+        timeToComplete = new Roll(this.settings.timeRollFormula).evaluate({async: false}).total.toString() + ` ` + game.i18n.localize(TWODSIX.TimeUnits[this.settings.selectedTimeUnit]);
+      }
+    }
+
     await this.roll?.toMessage(
       {
         speaker: ChatMessage.getSpeaker({actor: this.actor}),
@@ -205,7 +195,8 @@ export class TwodsixDiceRoll {
         flags: {
           "core.canPopout": true,
           "twodsix.crit": this.getCrit(),
-          "twodsix.effect": this.effect
+          "twodsix.effect": this.effect,
+          "twodsix.timeframe": timeToComplete
         }
       },
       {rollMode: this.settings.rollMode}

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -17,6 +17,8 @@ export class TwodsixRollSettings {
   difficulties:CE_DIFFICULTIES | CEL_DIFFICULTIES;
   displayLabel:string;
   extraFlavor:string;
+  selectedTimeUnit:string;
+  timeRollFormula:string;
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   constructor(settings?:Record<string,any>, aSkill?:TwodsixItem, anItem?:TwodsixItem) {
@@ -36,6 +38,8 @@ export class TwodsixRollSettings {
     this.skillRoll = !!(settings?.skillRoll ?? aSkill);
     this.displayLabel = settings?.displayLabel ?? "";
     this.extraFlavor = settings?.extraFlavor ?? "";
+    this.selectedTimeUnit = "none";
+    this.timeRollFormula = "";
   }
 
   public static async create(showThrowDialog:boolean, settings?:Record<string,any>, skill?:TwodsixItem, item?:TwodsixItem):Promise<TwodsixRollSettings> {
@@ -57,6 +61,7 @@ export class TwodsixRollSettings {
       }
 
       await twodsixRollSettings._throwDialog(title, skill);
+      console.log(twodsixRollSettings);
 
       //Get display label
       if (skill && skill.actor) {
@@ -90,7 +95,10 @@ export class TwodsixRollSettings {
       diceModifier: this.diceModifier,
       characteristicList: _genTranslatedSkillList(<TwodsixActor>skill?.actor),
       initialChoice: this.characteristic,
-      skillRoll: this.skillRoll
+      skillRoll: this.skillRoll,
+      timeUnits: TWODSIX.TimeUnits,
+      selectedTimeUnit: this.selectedTimeUnit,
+      timeRollFormula: this.timeRollFormula
     };
 
     const buttons = {
@@ -104,6 +112,8 @@ export class TwodsixRollSettings {
           this.rollMode = buttonHtml.find('[name="rollMode"]').val();
           this.characteristic = this.skillRoll ? buttonHtml.find('[name="characteristic"]').val() : this.characteristic;
           this.diceModifier = parseInt(buttonHtml.find('[name="diceModifier"]').val(), 10);
+          this.selectedTimeUnit = buttonHtml.find('[name="timeUnit"]').val();
+          this.timeRollFormula = buttonHtml.find('[name="timeRollFormula"]').val();
         }
       },
       cancel: {

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -39,7 +39,7 @@ export class TwodsixRollSettings {
     this.displayLabel = settings?.displayLabel ?? "";
     this.extraFlavor = settings?.extraFlavor ?? "";
     this.selectedTimeUnit = "none";
-    this.timeRollFormula = "";
+    this.timeRollFormula = "1d6";
   }
 
   public static async create(showThrowDialog:boolean, settings?:Record<string,any>, skill?:TwodsixItem, item?:TwodsixItem):Promise<TwodsixRollSettings> {

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -99,6 +99,7 @@ declare global {
       'twodsix.addEffectForShipDamage': boolean;
       'twodsix.unarmedDamage': string;
       'twodsix.autoAddUnarmed': boolean;
+      'twodsix.showTimeframe': boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -123,7 +123,16 @@
         "Untrained": "Untrained",
         "SkillRollTooltip": "Shows the skill roll dialog. Shift-clicking rolls a skill check applying no modifier and assumes a difficulty of 8",
         "InvertedSkillRollTooltip": "Rolls a skill check applying no modifier and assumes a difficulty of 8. Shift-clicking shows the skill roll dialog",
-        "JOAT": "Jack of all trades"
+        "JOAT": "Jack of all trades",
+        "Timeframe": {
+          "none": "---",
+          "secs": "second(s)",
+          "mins": "minute(s)",
+          "hrs": "hour(s)",
+          "days": "day(s)",
+          "weeks": "week(s)",
+          "rounds": "round(s)"
+        }
       },
       "Species": "Species",
       "Tabs": {
@@ -161,10 +170,14 @@
     },
     "Chat": {
       "Roll": {
-        "Difficulty": "Roll difficulty",
-        "Mode": "Roll mode",
+        "Difficulty": "Difficulty",
+        "Mode": "Mode",
         "OtherModifiers": "Other modifiers",
-        "Type": "Roll type"
+        "Type": "Type",
+        "RollDetails": "Roll Details",
+        "Timeframe": "Timeframe",
+        "RollFormula": "Roll Formula",
+        "Units": "Units"
       }
     },
     "Create": "Create",
@@ -727,6 +740,10 @@
       "unarmedDamage": {
         "hint": "Dice formula for unarmed damage used when Unarmed is automatically added to actors.",
         "name": "Unarmed Damage Formula"
+      },
+      "showTimeframe": {
+        "hint": "Add timeframe options to skill / characteristic rolls/",
+        "name": "Show Timeframe in Roll Dialog"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -131,6 +131,7 @@
           "hrs": "hour(s)",
           "days": "day(s)",
           "weeks": "week(s)",
+          "months": "month(s)",
           "rounds": "round(s)"
         }
       },
@@ -400,7 +401,7 @@
       "JDrive": "J-Drive",
       "Jump": "Jump",
       "MacroSkill": "Macro/Skill",
-      "MakesChatRollAction": "Takes the _ACTION_NAME_ action from the _POSITION_NAME_ position",
+      "MakesChatRollAction": "Uses the _ACTION_NAME_ action from the _POSITION_NAME_ position.",
       "ActionHits": "Hits _WHILE_USING_with an effect of _EFFECT_VALUE_",
       "ActionHitsAndDamage": "Hits _WHILE_USING_with an effect of _EFFECT_VALUE_ causing _DAMAGE_TOTAL_ points of standard damage",
       "ActionMisses": "Misses _WHILE_USING_with an effect of _EFFECT_VALUE_",
@@ -474,7 +475,8 @@
       "using": "using {characteristic}",
       "Wounds": "Wounds",
       "AttackDM": "Atack DM",
-      "BonusDamage": "Bonus Damage"
+      "BonusDamage": "Bonus Damage",
+      "Timeframe": "Time"
     },
     "Settings": {
       "absoluteBonusValueForEachTimeIncrement": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -177,7 +177,8 @@
         "RollDetails": "Roll Details",
         "Timeframe": "Timeframe",
         "RollFormula": "Roll Formula",
-        "Units": "Units"
+        "Units": "Units",
+        "taskDuration": "The task takes _TIME_ _UNITS_ to complete."
       }
     },
     "Create": "Create",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2399,6 +2399,10 @@ background: var(--s2d6-sidebar-background);
   font-size: inherit;
 }
 
+.dice-total {
+  white-space: pre-wrap;
+}
+
 .dice-roll .dice-total.crit-fail-roll {
   color: var(--s2d6-crit-fail);
 }

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1979,6 +1979,9 @@ background: var(--sidebar-background);
   word-break: break-all;
   font-size: inherit;
 }*/
+.dice-total {
+  white-space: pre-wrap;
+}
 
 .dice-roll .dice-total.crit-fail-roll {
   color: var(--s2d6-crit-fail);

--- a/static/templates/chat/throw-dialog.html
+++ b/static/templates/chat/throw-dialog.html
@@ -1,52 +1,72 @@
 <!-- TODO Move this file -->
 <form>
-  <div class="form-group">
-    <label>{{localize "TWODSIX.Chat.Roll.Difficulty"}}
-      <select name="difficulty">
-        {{#select difficulty}}
-          {{#each difficulties}}
-            <option value="{{@key}}">{{localize @key}} (
-              {{#if (twodsix_difficultiesAsTargetNumber)}} {{this.target}} {{else}} {{this.mod}} {{/if}})
-            </option>
-          {{/each}}
-        {{/select}}
-      </select>
-    </label>
-  </div>
-  <div class="form-group">
-    <label>{{localize "TWODSIX.Chat.Roll.Type"}}
-      <select name="rollType">
-        {{#select rollType}}
-          {{#each rollTypes as |type|}}
-            <option value="{{type.key}}">{{localize (twodsix_advantageDisadvantageTerm type.key)}}</option>
-          {{/each}}
-        {{/select}}
-      </select>
-    </label>
-  </div>
-  {{#if skillRoll}}
-  <div class="form-group">
-    <label>{{localize "TWODSIX.Items.Skills.Modifier"}}
-      <select class="select-mod" name="characteristic" value={{characteristic}}>
-        {{selectOptions characteristicList selected=initialChoice}}
-      </select>
-    </label>
-  </div>
+  <fieldset>
+  <legend>{{localize "TWODSIX.Chat.Roll.RollDetails"}}</legend>
+    <div class="form-group">
+      <label>{{localize "TWODSIX.Chat.Roll.Difficulty"}}
+        <select name="difficulty">
+          {{#select difficulty}}
+            {{#each difficulties}}
+              <option value="{{@key}}">{{localize @key}} (
+                {{#if (twodsix_difficultiesAsTargetNumber)}} {{this.target}} {{else}} {{this.mod}} {{/if}})
+              </option>
+            {{/each}}
+          {{/select}}
+        </select>
+      </label>
+    </div>
+    <div class="form-group">
+      <label>{{localize "TWODSIX.Chat.Roll.Type"}}
+        <select name="rollType">
+          {{#select rollType}}
+            {{#each rollTypes as |type|}}
+              <option value="{{type.key}}">{{localize (twodsix_advantageDisadvantageTerm type.key)}}</option>
+            {{/each}}
+          {{/select}}
+        </select>
+      </label>
+    </div>
+    {{#if skillRoll}}
+    <div class="form-group">
+      <label>{{localize "TWODSIX.Items.Skills.Modifier"}}
+        <select class="select-mod" name="characteristic" value={{characteristic}}>
+          {{selectOptions characteristicList selected=initialChoice}}
+        </select>
+      </label>
+    </div>
+    {{/if}}
+    <div class="form-group">
+      <label>{{localize "TWODSIX.Chat.Roll.OtherModifiers"}}
+        <input type="number" name="diceModifier" value="{{diceModifier}}" placeholder="0" onClick="this.select();" style="width: 8ch;"/>
+      </label>
+    </div>
+    <div class="form-group">
+      <label>{{localize "TWODSIX.Chat.Roll.Mode"}}
+        <select name="rollMode">
+          {{#select rollMode}}
+            {{#each rollModes as |label mode|}}
+              <option value="{{mode}}">{{localize label}}</option>
+            {{/each}}
+          {{/select}}
+        </select>
+      </label>
+    </div>
+  </fieldset>
+  <br>
+  {{#if (twodsix_showTimeframe)}}
+  <fieldset>
+    <legend>{{localize "TWODSIX.Chat.Roll.Timeframe"}}</legend>
+    <div class="form-group">
+      <label>{{localize "TWODSIX.Chat.Roll.RollFormula"}}<br>
+        <input type="text" name="timeRollFormula" value="{{timeRollFormula}}" placeholder="1d6" onClick="this.select();"/>
+      </label>
+      <label>{{localize "TWODSIX.Chat.Roll.Units"}}<br>
+        <select class="select-timeUnits" name="timeUnit" value={{selectedTimeUnit}}>
+          {{selectOptions timeUnits selected=selectedTimeUnit localize=true}}
+        </select>
+      </label>
+    </div>
+  </fieldset>
+  <br>
   {{/if}}
-  <div class="form-group">
-    <label>{{localize "TWODSIX.Chat.Roll.OtherModifiers"}}
-      <input type="number" name="diceModifier" value="{{diceModifier}}" placeholder="0" onClick="this.select();"/>
-    </label>
-  </div>
-  <div class="form-group">
-    <label>{{localize "TWODSIX.Chat.Roll.Mode"}}
-      <select name="rollMode">
-        {{#select rollMode}}
-          {{#each rollModes as |label mode|}}
-            <option value="{{mode}}">{{localize label}}</option>
-          {{/each}}
-        {{/select}}
-      </select>
-    </label>
-  </div>
 </form>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Must make manual rolls for timeframe associated with skill rolls


* **What is the new behavior (if this is a feature change)?**
option to add timeframe to rolls included


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
