### PR TITLE
fix: wounded rolls for CE

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -356,18 +356,14 @@ export default class TwodsixActor extends Actor {
       } else {
         damageCharacteristics = getDamageCharacteristics();
       }
-
+      const charArray = {};
       for (const characteristic of damageCharacteristics) {
         const cur_damage = this.data.data.characteristics[characteristic].damage;
 
         if (cur_damage > 0) {
           const new_damage = Math.max(0, cur_damage - healing);
           const char_id = 'data.characteristics.' + characteristic + '.damage';
-
-          await this.update({
-            [char_id]: new_damage
-          });
-
+          charArray[char_id] = new_damage;
           healing -= cur_damage - new_damage;
         }
 
@@ -375,6 +371,7 @@ export default class TwodsixActor extends Actor {
           break;
         }
       }
+      await this.update(charArray);
     }
   }
 

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -371,7 +371,7 @@ export default class TwodsixActor extends Actor {
           break;
         }
       }
-      await this.update(charArray);
+      await this.update(charArray); /*update only once*/
     }
   }
 

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -31,6 +31,7 @@ function checkForWounds(data: Record<string, any>): boolean {
       case 'CEL':
       case 'CEFTL':
       case 'CE':
+      case 'OTHER':
         return !!(data.characteristics?.endurance || data.characteristics?.strength || data.characteristics?.dexterity);
       case 'CEQ':
       case 'CEATOM':
@@ -74,7 +75,7 @@ async function applyWoundedEffect(selectedToken: Record<string, any>): Promise<v
       await setConditionState(deadEffectLabel, selectedToken, false);
 
       if (oldWoundState?.data.tint !== DAMAGECOLORS.seriousWoundTint && !isAlreadyDead && tintToApply === DAMAGECOLORS.seriousWoundTint && !isAlreadyUnconscious) {
-        if (['CEQ', 'CEATOM', 'BARBARIC'].includes(game.settings.get('twodsix', 'ruleset').toString())) {
+        if (['CEQ', 'CEATOM', 'BARBARIC', 'OTHER'].includes(game.settings.get('twodsix', 'ruleset').toString())) {
           await setConditionState(unconsciousEffectLabel, selectedToken, true); // Automatic unconsciousness or out of combat
         } else {
           const displayShortChar = _genTranslatedSkillList(selectedToken.actor)['END'];
@@ -135,6 +136,7 @@ export function getIconTint(selectedActor: Record<string, any>): string {
     case 'CEL':
     case 'CEFTL':
     case 'CE':
+    case 'OTHER':
       return (getCEWoundTint(selectedActor));
     case 'CEQ':
     case 'CEATOM':

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -27,6 +27,7 @@ function checkForWounds(data: Record<string, any>): boolean {
   } else {
     switch (game.settings.get('twodsix', 'ruleset')) {
       case 'CD':
+      case 'CLU':
         return (!!data.characteristics?.lifeblood);
       case 'CEL':
       case 'CEFTL':

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -1,5 +1,6 @@
 //import { ActorData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/module.mjs";
 import TwodsixActor from "../entities/TwodsixActor";
+import { _genTranslatedSkillList } from "../utils/TwodsixRollSettings";
 
 Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>) => {
   if (checkForWounds(update.data)) {
@@ -76,7 +77,8 @@ async function applyWoundedEffect(selectedToken: Record<string, any>): Promise<v
         if (['CEQ', 'CEATOM', 'BARBARIC'].includes(game.settings.get('twodsix', 'ruleset').toString())) {
           await setConditionState(unconsciousEffectLabel, selectedToken, true); // Automatic unconsciousness or out of combat
         } else {
-          const returnRoll = await selectedToken.actor.characteristicRoll({ characteristic: 'END', difficulty: { mod: 0, target: 8 } }, false);
+          const displayShortChar = _genTranslatedSkillList(selectedToken.actor)['END'];
+          const returnRoll = await selectedToken.actor.characteristicRoll({ characteristic: 'END', displayLabel: displayShortChar, difficulty: { mod: 0, target: 8 } }, false);
           if (returnRoll.effect < 0) {
             await setConditionState(unconsciousEffectLabel, selectedToken, true);
           }

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -14,12 +14,12 @@ Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>)
     }
   }
 });
-
-Hooks.on('updateToken', async (token: TokenDocument, update: Record<string, any>) => {
+//A check for token update doesn't seem to be needed.  But keep code just in case
+/*Hooks.on('updateToken', async (token: TokenDocument, update: Record<string, any>) => {
   if (checkForWounds(update?.data)) {
     applyWoundedEffect(<Token>canvas.tokens?.ownedTokens.find(t => t.id === token.id));
   }
-});
+});*/
 
 function checkForWounds(data: Record<string, any>): boolean {
   if (!game.settings.get('twodsix', 'useWoundedStatusIndicators') || data === undefined) {
@@ -75,7 +75,7 @@ async function applyWoundedEffect(selectedToken: Record<string, any>): Promise<v
       await setConditionState(deadEffectLabel, selectedToken, false);
 
       if (oldWoundState?.data.tint !== DAMAGECOLORS.seriousWoundTint && !isAlreadyDead && tintToApply === DAMAGECOLORS.seriousWoundTint && !isAlreadyUnconscious) {
-        if (['CEQ', 'CEATOM', 'BARBARIC', 'OTHER'].includes(game.settings.get('twodsix', 'ruleset').toString())) {
+        if (['CEQ', 'CEATOM', 'BARBARIC', 'CE', 'OTHER'].includes(game.settings.get('twodsix', 'ruleset').toString())) {
           await setConditionState(unconsciousEffectLabel, selectedToken, true); // Automatic unconsciousness or out of combat
         } else {
           const displayShortChar = _genTranslatedSkillList(selectedToken.actor)['END'];
@@ -132,6 +132,7 @@ async function setEffectState(effectLabel: string, targetToken: Record<string, a
 export function getIconTint(selectedActor: Record<string, any>): string {
   switch (game.settings.get('twodsix', 'ruleset')) {
     case 'CD':
+    case 'CLU':
       return (getCDWoundTint(selectedActor));
     case 'CEL':
     case 'CEFTL':

--- a/src/module/utils/actorDamage.ts
+++ b/src/module/utils/actorDamage.ts
@@ -169,10 +169,12 @@ export class Stats {
     }
 
     let charName = '';
+    const charArray = {};
     for (const characteristic of this.damageCharacteristics) {
       charName = 'data.characteristics.' + characteristic + '.damage';
-      await this.actor.update({[charName]: this[characteristic].totalDamage()});
+      charArray[charName] = this[characteristic].totalDamage();
     }
+    await this.actor.update(charArray);
   }
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
CE-like rules setting cause unconsciousness saves to be rolled twice if multiple characteristics are damaged.
CE should not roll for unconsciousness
CLU not specified
OTHER follows no wounded scheme

* **What is the new behavior (if this is a feature change)?**

Only one roll now by making a single update to actor - not one for each characteristic
CE does not roll for unconsciousness
CLU included in settings
OTHER behaves like CE

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
