### PR TITLE
fix: showWounds

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -445,7 +445,8 @@ export default class TwodsixActor extends Actor {
         "type": "weapon",
         "damage": game.settings.get("twodsix", "unarmedDamage") || "1d6",
         "quantity": 1,
-        "skill": this.getUntrainedSkill().id || ""
+        "skill": this.getUntrainedSkill().id || "",
+        "equipped": "equipped"
       },
     };
     await (this.createEmbeddedDocuments("Item", [data]));

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -74,7 +74,7 @@ async function applyWoundedEffect(selectedActor: TwodsixActor): Promise<void> {
         } else {
           const displayShortChar = _genTranslatedSkillList(selectedActor)['END'];
           const returnRoll = await selectedActor.characteristicRoll({ characteristic: 'END', displayLabel: displayShortChar, difficulty: { mod: 0, target: 8 } }, false);
-          if (returnRoll && returnRoll?.effect < 0) {
+          if (returnRoll && returnRoll.effect < 0) {
             await setConditionState(unconsciousEffectLabel, selectedActor, true);
           }
         }
@@ -124,7 +124,7 @@ async function setEffectState(effectLabel: string, targetActor: TwodsixActor, st
         tint: tint,
         changes: [changeData]
       }]);
-      const newEffect = await targetActor?.effects.find(eff => eff.data.label === effectLabel);
+      const newEffect = await targetActor.effects.find(eff => eff.data.label === effectLabel);
       newEffect?.setFlag("core", "statusId", "bleeding"); /*FIX*/
     } else if (isAlreadySet && state === true) {
       await targetActor.updateEmbeddedDocuments('ActiveEffect', [{ _id: isAlreadySet.id, tint: tint, changes: [changeData] }]);

--- a/src/module/hooks/showWoundIcons.ts
+++ b/src/module/hooks/showWoundIcons.ts
@@ -212,7 +212,7 @@ export function getCEWoundTint(selectedActor: Record<string, any>): string {
     default:
       break;
   }
-  if ((testArray.filter(chr => chr.damage > 0).length) === 3) {
+  if ((testArray.filter(chr => chr.damage > 0).length) === 3 && returnVal !== DAMAGECOLORS.deadTint) {
     returnVal = DAMAGECOLORS.seriousWoundTint;
   }
   return returnVal;

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -31,6 +31,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.push(booleanSetting('showItemReferences', true));
     settings.push(booleanSetting('showIcons', false));
     settings.push(booleanSetting('useEncumbrance', false));
+    settings.push(booleanSetting('showStatusIcons', true));
     return settings;
   }
 }

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -47,8 +47,8 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(booleanSetting('criticalNaturalAffectsEffect', false));
     settings.push(numberSetting('absoluteCriticalEffectValue', 99));
     settings.push(booleanSetting('showLifebloodStamina', false));
-    settings.push(numberSetting('minorWoundsRollModifier', -1));
-    settings.push(numberSetting('seriousWoundsRollModifier', -2));
+    settings.push(numberSetting('minorWoundsRollModifier', 0));
+    settings.push(numberSetting('seriousWoundsRollModifier', 0));
     settings.push(booleanSetting('lifebloodInsteadOfCharacteristics', false));
     settings.push(booleanSetting('showContaminationBelowLifeblood', true));
     settings.push(booleanSetting('showHeroPoints', false));

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -45,7 +45,8 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
       showContaminationBelowLifeblood: game.settings.get('twodsix', 'showContaminationBelowLifeblood'),
       showLifebloodStamina: game.settings.get("twodsix", "showLifebloodStamina"),
       showHeroPoints: game.settings.get("twodsix", "showHeroPoints"),
-      showIcons: game.settings.get("twodsix", "showIcons")
+      showIcons: game.settings.get("twodsix", "showIcons"),
+      showStatusIcons: game.settings.get("twodsix", "showStatusIcons")
     };
     data.config = TWODSIX;
 

--- a/src/module/utils/actorDamage.ts
+++ b/src/module/utils/actorDamage.ts
@@ -148,7 +148,7 @@ export class Stats {
   }
 
   public async applyDamage(): Promise<void> {
-    if (this.actor.token && this.totalCurrent() === 0) {
+    /*if (this.actor.token && this.totalCurrent() === 0  && !game.settings.get("twodsix", "useWoundedStatusIndicators")) {
       const isDead = this.actor.effects.map((e: ActiveEffect) => {
         return e.getFlag("core", "statusId") === "dead";
       }).includes(true);
@@ -166,7 +166,7 @@ export class Stats {
           await combatant.update({defeated: true});
         }
       }
-    }
+    }*/
 
     let charName = '';
     const charArray = {};

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -100,6 +100,7 @@ declare global {
       'twodsix.unarmedDamage': string;
       'twodsix.autoAddUnarmed': boolean;
       'twodsix.showTimeframe': boolean;
+      'twodsix.showStatusIcons': boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -747,6 +747,10 @@
       "showTimeframe": {
         "hint": "Add timeframe options to skill / characteristic rolls/",
         "name": "Show Timeframe in Roll Dialog"
+      },
+      "showStatusIcons": {
+        "hint": "Overlay condition icons on side of actor images on sheets.",
+        "name": "Show condition icons on actor sheets"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -477,6 +477,22 @@ img.character-info-mask {
   z-index: -1;
 }
 
+.status-icons {
+  position: absolute;
+  left: 1em;
+  top: 1em;
+  z-index: 1;
+  flex-direction: column;
+  display: flex;
+  height: 20px;
+  width: 20px;
+}
+.condition-icon {
+  height: 20px;
+  width: 20px;
+  background-color: var(--s2d6-background-opaque);
+}
+
 .character-armor {
   position: absolute;
   top: 21.25em;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -187,6 +187,20 @@ img.character-info-mask {
   z-index: -1;
 }
 
+.status-icons {
+  position: absolute;
+  left: 1em;
+  top: 1em;
+  z-index: 1;
+  flex-direction: column;
+  display: flex;
+}
+.condition-icon {
+  height: 20px;
+  width: 20px;
+  background-color: var(--s2d6-background-opaque);
+}
+
 .character-armor {
   position: absolute;
   top: 21.25em;

--- a/static/templates/actors/actor-sheet.html
+++ b/static/templates/actors/actor-sheet.html
@@ -9,6 +9,14 @@
       {{/unless}}
       <div class="character-photo">
         <img class="profile-img" src="{{actor.img}}" {{#unless limited}}data-edit="img"{{/unless}} title="{{actor.name}}" alt='{{localize "TWODSIX.Actor.CharacterImage"}}'/>
+        {{#if actor.data.settings.showStatusIcons}}
+        <span class="status-icons">
+            {{#each actor.effects as |anEffect|}}
+            {{actor.effects}}
+              <img class="condition-icon" src="{{anEffect.icon}}" title="{{anEffect.label}}" style="border: 1px solid {{anEffect.tint}} !important;"/>
+            {{/each}}
+        {{/if}}
+        </span>
       </div>
       <div class="character-name"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}'
                                          onClick="this.select();"/></div>

--- a/static/templates/actors/npc-sheet.html
+++ b/static/templates/actors/npc-sheet.html
@@ -3,6 +3,13 @@
     <div class="npc-name-photo">
       <div class="character-photo npc">
         <img class="profile-img" src="{{actor.img}}" {{#unless limited}}data-edit="img"{{/unless}} title="{{actor.name}}" alt='{{localize "TWODSIX.Actor.CharacterImage"}}'/>
+        {{#if actor.data.settings.showStatusIcons}}
+        <span class="status-icons">
+            {{#each actor.effects as |anEffect|}}
+            {{actor.effects}}
+              <img class="condition-icon" src="{{anEffect.icon}}" title="{{anEffect.label}}" style="border: 1px solid {{anEffect.tint}} !important;"/>
+            {{/each}}
+        {{/if}}
       </div>
       <div class="character-name npc" style="width: 100% !important; height: 26px !important;"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}'
                                          onClick="this.select();"/></div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature & bug fix & refactor


* **What is the current behavior?** (You can also link to an open issue here)
Show wounded relies on token rather than actor.  
CE serious wounds not correct - set for two @ 0 rather than all three with at least 1 damage
No condition icons to overlay actor sheet
Unarmed skill not auto equipped
Dead actor not marked as defeated in combat tracker
Conflict with CUB

* **What is the new behavior (if this is a feature change)?**
Switch functions to purely actor based functions.
CE Serious wounds now displays correctly. Although no way to check for going unconscious the first time.
Add option to display condition icons on actor sheet
Fix equipped for Unarmed that is auto added
Mark dead actor as defeated
remove conflict with CUB when not using wounded icons (no longer auto add dead icon)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
Can't get icons on auto sheet to look like tokens - can't color 
