### PR TITLE
fix: save non-empty magazines when reloading

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -365,6 +365,17 @@ export default class TwodsixItem extends Item {
 
   public async refill(): Promise<void> {
     const consumable = <Consumable>this.data.data;
+
+    //Make a duplicate and add to inventory if not empty
+    if (consumable.currentCount > 0) {
+      const partialConsumable = duplicate(this.data);
+      (<Consumable>partialConsumable.data).quantity = 1;
+      if (partialConsumable) {
+        await this.actor?.createEmbeddedDocuments("Item", [partialConsumable]);
+      }
+    }
+
+    //refill quantity
     if (consumable.quantity > 1) {
       await this.update({
         "data.quantity": consumable.quantity - 1,

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -370,9 +370,7 @@ export default class TwodsixItem extends Item {
     if (consumable.currentCount > 0) {
       const partialConsumable = duplicate(this.data);
       (<Consumable>partialConsumable.data).quantity = 1;
-      if (partialConsumable) {
-        await this.actor?.createEmbeddedDocuments("Item", [partialConsumable]);
-      }
+      await this.actor?.createEmbeddedDocuments("Item", [partialConsumable]);
     }
 
     //refill quantity

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -365,22 +365,22 @@ export default class TwodsixItem extends Item {
 
   public async refill(): Promise<void> {
     const consumable = <Consumable>this.data.data;
-
-    //Make a duplicate and add to inventory if not empty
-    if (consumable.currentCount > 0) {
-      const partialConsumable = duplicate(this.data);
-      (<Consumable>partialConsumable.data).quantity = 1;
-      await this.actor?.createEmbeddedDocuments("Item", [partialConsumable]);
-    }
-
-    //refill quantity
-    if (consumable.quantity > 1) {
-      await this.update({
-        "data.quantity": consumable.quantity - 1,
-        "data.currentCount": consumable.max
-      }, {});
-    } else {
-      throw { name: 'TooLowQuantityError' };
+    if (consumable.currentCount < consumable.max) {
+      if (consumable.quantity > 1) {
+        //Make a duplicate and add to inventory if not empty
+        if (consumable.currentCount > 0 ) {
+          const partialConsumable = duplicate(this.data);
+          (<Consumable>partialConsumable.data).quantity = 1;
+          await this.actor?.createEmbeddedDocuments("Item", [partialConsumable]);
+        }
+        //refill quantity
+        await this.update({
+          "data.quantity": consumable.quantity - 1,
+          "data.currentCount": consumable.max
+        }, {});
+      } else {
+        throw { name: 'TooLowQuantityError' };
+      }
     }
   }
 }

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -9,7 +9,7 @@
         <button class="right-button adjust-consumable" {{#iff currentCount "===" max}}disabled{{/iff}} data-value="-1">+</button>
       </span>
     </span>
-    <button {{#iff currentCount "===" max}}disabled{{/iff}} class="refill-button">
+    <button {{#iff currentCount '>=' max}}disabled{{/iff}} class="refill-button">
       {{twodsix_refillText subtype quantity}}
     </button>
     {{/with}}

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -5,8 +5,8 @@
     <span class="consumable-count">
       <span>{{currentCount}}/{{max}}</span>
       <span class="combined-buttons">
-        <button class="left-button adjust-consumable" {{#iff currentCount "===" 0}}disabled{{/iff}} data-value="1">-</button>
-        <button class="right-button adjust-consumable" {{#iff currentCount "===" max}}disabled{{/iff}} data-value="-1">+</button>
+        <button class="left-button adjust-consumable" {{#iff currentCount "<=" 0}}disabled{{/iff}} data-value="1">-</button>
+        <button class="right-button adjust-consumable" {{#iff currentCount ">=" max}}disabled{{/iff}} data-value="-1">+</button>
       </span>
     </span>
     <button {{#iff currentCount '>=' max}}disabled{{/iff}} class="refill-button">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When reloading, partially filled magazines are lost

* **What is the new behavior (if this is a feature change)?**
Save partially filled magazine / energy cell in consumables inventory


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
