### PR TITLE
add cargo capacity and weight fields

### DIFF
--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -32,6 +32,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.push(booleanSetting('showIcons', false));
     settings.push(booleanSetting('useEncumbrance', false));
     settings.push(booleanSetting('showStatusIcons', true));
+    settings.push(booleanSetting('showRangeSpeedNoUnits', false));
     return settings;
   }
 }

--- a/src/module/sheets/TwodsixVehicleSheet.ts
+++ b/src/module/sheets/TwodsixVehicleSheet.ts
@@ -23,7 +23,7 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
       classes: ["twodsix", "vehicle", "actor"],
       template: "systems/twodsix/templates/actors/vehicle-sheet.html",
       width: 835,
-      height: 645,
+      height: 675,
       resizable: true,
     });
   }

--- a/src/module/sheets/TwodsixVehicleSheet.ts
+++ b/src/module/sheets/TwodsixVehicleSheet.ts
@@ -12,7 +12,8 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
     context.dtypes = ["String", "Number", "Boolean"];
     AbstractTwodsixActorSheet._prepareItemContainers(this.actor.items, context);
     context.settings = <TwodsixVehicleSheetSettings>{
-      showHullAndArmor: game.settings.get('twodsix', 'showHullAndArmor')
+      showHullAndArmor: game.settings.get('twodsix', 'showHullAndArmor'),
+      showRangeSpeedNoUnits: game.settings.get('twodsix', 'showRangeSpeedNoUnits')
     };
 
     return context;

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -322,6 +322,7 @@ export interface ShipPosition {
 export interface Vehicle {
   name:string;
   cargoList:string;
+  cargoCapacity:string;
   cost: string;
   crew:VehcileCrew;
   damageStats:VehicleDamageStats;
@@ -334,6 +335,7 @@ export interface Vehicle {
   techLevel:string;
   traits:string;
   docReference:string;
+  weight:string;
 }
 
 export interface VehicleCrew {

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -103,6 +103,7 @@ declare global {
       'twodsix.showStatusIcons': boolean;
       'twodsix.showHullAndArmor': string;
       'twodsix.addEffectToManualDamage':boolean;
+      'twodsix.showRangeSpeedNoUnits':boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -806,6 +806,10 @@
       "addEffectToManualDamage": {
         "hint": "This option addts the effect to a manual damage roll from the most recent chat message.",
         "name": "Add effect when making manual damage"
+      },
+      "showRangeSpeedNoUnits": {
+        "hint": "Omit the range and speed units (e.g. km/hr) on vehicle sheet.",
+        "name": "Don't show range and speed units"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -453,7 +453,9 @@
     },
     "Vehicle": {
       "SystemStatus": "System Status",
-      "CargoNotes": "Cargo Notes",
+      "Cargo": "Cargo",
+      "CargoNotes": "Notes",
+      "CargoCapacity": "Capacity",
       "Speed": "Speed",
       "Range": "Range",
       "Agility": "Agility",
@@ -474,6 +476,7 @@
       },
       "Movement": "Movement",
       "Crew": "Crew",
+      "Weight": "Weight",
       "Armor": "Armor",
       "Hull": "Hull",
       "Structure": "Structure",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -455,7 +455,7 @@ h2 {
 .vehicle-content-container {
   display: grid;
   grid-template-columns: 19em 19em 17em;
-  grid-template-rows: 15em 9em 5em 9em;
+  grid-template-rows: 15em 11em 5em 9em;
   gap: 16px 16px;
   position: relative;
   grid-template-areas:
@@ -477,7 +477,7 @@ h2 {
   border-style: solid;
   border-radius: 2ch;
   border-color: var(--s2d6-default-color);
-  background-color: var(--s2d6-background-nearly-opaque);
+  /*background-color: var(--s2d6-background-nearly-opaque);*/
   border-width: 2px;
   max-height: 100%;
 }
@@ -545,7 +545,7 @@ h2 {
   text-align: center;
 }
 
-.vehicle-armor-name textarea {
+.vehicle-armor-name textarea, .vehicle-cargo-list textarea {
   border: 1px solid;
   border-radius: 1ch !important;
   border-color: var(--s2d6-default-color);

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -156,7 +156,7 @@ label.checkbox > input[type="checkbox"] {
 .vehicle-content-container {
   display: grid;
   grid-template-columns: 19em 19em 17em;
-  grid-template-rows: 15em 9em 5em 9em;
+  grid-template-rows: 15em 11em 5em 9em;
   gap: 16px 16px;
   position: relative;
   grid-template-areas:
@@ -240,7 +240,7 @@ label.checkbox > input[type="checkbox"] {
   text-align: center;
 }
 
-.vehicle-armor-name textarea {
+.vehicle-armor-name textarea, .vehicle-cargo-list textarea {
   border: 1px solid;
   border-radius: 1ch !important;
   /*text-align: center;*/
@@ -256,7 +256,7 @@ label.checkbox > input[type="checkbox"] {
   resize: none;
   scrollbar-width: thin;
   scrollbar-color: var(--s2d6-default-color);
-  height: 82%;
+  height: 86%;
   max-width: 100%;
   padding: 0 1ch;
   font-family: inherit;

--- a/static/template.json
+++ b/static/template.json
@@ -253,6 +253,7 @@
     },
     "vehicle": {
       "cargoList": "",
+      "cargoCapacity": "",
       "cost": "",
       "crew": {
         "operators": "",
@@ -303,7 +304,8 @@
       "weaponsType": "",
       "openVehicle": false,
       "techLevel": "",
-      "traits": ""
+      "traits": "",
+      "weight": ""
     }
   },
   "Item": {

--- a/static/templates/actors/vehicle-sheet.html
+++ b/static/templates/actors/vehicle-sheet.html
@@ -2,7 +2,7 @@
   <div class="vehicle-content-container">
     <div class="vehicle-name-photo">
       <div class="vehicle-photo">
-        <img class="profile-img" src="{{actor.img}}" {{#unless limited}}data-edit="img"{{/unless}} title="{{actor.name}}" alt='{{localize "TWODSIX.Actor.CharacterImage"}}'/>
+        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" alt='{{localize "TWODSIX.Actor.CharacterImage"}}'/>
       </div>
       <div class="vehicle-name"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}'
                                          onClick="this.select();"/></div>
@@ -20,8 +20,8 @@
         <span class="single-line vehicle-inset">{{localize "TWODSIX.Vehicle.Cost"}}:<input type="text" value="{{data.data.cost}}" name="data.cost"/></span>
       <fieldset class="vehicle-inset">
         <legend>{{localize "TWODSIX.Vehicle.Movement"}}</legend>
-        <span class="single-line">{{localize "TWODSIX.Vehicle.Speed"}}:<input type="text" value="{{data.data.maneuver.speed}}" name="data.maneuver.speed"/><input type="text" value="{{data.data.maneuver.speedUnits}}" name="data.maneuver.speedUnits"/></span>
-        <span class="single-line">{{localize "TWODSIX.Vehicle.Range"}}:<input type="text" value="{{data.data.maneuver.range}}" name="data.maneuver.range"/><input  type="text" value="{{data.data.maneuver.rangeUnits}}" name="data.maneuver.rangeUnits"/></span>
+        <span class="single-line">{{localize "TWODSIX.Vehicle.Speed"}}:<input type="text" value="{{data.data.maneuver.speed}}" name="data.maneuver.speed"/>{{#unless settings.showRangeSpeedNoUnits}}<input type="text" value="{{data.data.maneuver.speedUnits}}" name="data.maneuver.speedUnits"/>{{/unless}}</span>
+        <span class="single-line">{{localize "TWODSIX.Vehicle.Range"}}:<input type="text" value="{{data.data.maneuver.range}}" name="data.maneuver.range"/>{{#unless settings.showRangeSpeedNoUnits}}<input  type="text" value="{{data.data.maneuver.rangeUnits}}" name="data.maneuver.rangeUnits"/>{{/unless}}</span>
         <span class="single-line">{{localize "TWODSIX.Vehicle.Agility"}}:<input type="text" value="{{data.data.maneuver.agility}}" name="data.maneuver.agility"/></span>
       </fieldset>
       <fieldset class="vehicle-inset">

--- a/static/templates/actors/vehicle-sheet.html
+++ b/static/templates/actors/vehicle-sheet.html
@@ -16,6 +16,7 @@
     <div class="vehicle-stats">
       <span class="item-title-vehicle">Stats</span>
         <span class="single-line vehicle-inset">{{localize "TWODSIX.Vehicle.techLevel"}}:<input type="text" value="{{data.data.techLevel}}" name="data.techLevel"/></span>
+        <span class="single-line vehicle-inset">{{localize "TWODSIX.Vehicle.Weight"}}: <input type="text" value="{{data.data.weight}}" name="data.weight"/></span>
         <span class="single-line vehicle-inset">{{localize "TWODSIX.Vehicle.Cost"}}:<input type="text" value="{{data.data.cost}}" name="data.cost"/></span>
       <fieldset class="vehicle-inset">
         <legend>{{localize "TWODSIX.Vehicle.Movement"}}</legend>
@@ -31,8 +32,15 @@
       <span class="single-line vehicle-inset" data-label="{{data.data.skillToOperate}}"><label class="rollable orange">{{localize "TWODSIX.Vehicle.skillToOperate"}}:</label><input type="text" value="{{data.data.skillToOperate}}" name="data.skillToOperate"/></span>
     </div>
     <div class="vehicle-notes">
-      <span class="item-title-vehicle">{{localize "TWODSIX.Vehicle.CargoNotes"}}</span>
-      <div contenteditable="true" data-edit="data.cargoList">{{{data.data.cargoList}}}</div>
+      <span class="item-title-vehicle">{{localize "TWODSIX.Vehicle.Cargo"}}</span>
+      <span class="single-line vehicle-inset">{{localize "TWODSIX.Vehicle.CargoCapacity"}}: <input type="text" value="{{data.data.cargoCapacity}}" name="data.cargoCapacity"/></span>
+      <div class="vehicle-inset">
+        <span>{{localize "TWODSIX.Vehicle.CargoNotes"}}</span>
+        <span class="vehicle-cargo-list">
+          <textarea type="text" name="data.cargoList" value="{{data.data.cargoList}}">{{~data.data.cargoList~}}</textarea>
+        </span>
+        <!-- <div contenteditable="true" data-edit="data.cargoList">{{{data.data.cargoList}}}</div> -->
+      </div>
     </div>
     <div class="vehicle-systems">
       <span class="item-title-vehicle">{{localize "TWODSIX.Vehicle.SystemStatus"}}</span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix


* **What is the current behavior?** (You can also link to an open issue here)
no vehicle weight or cargo capacity fields
always show unit fields for range and speed


* **What is the new behavior (if this is a feature change)?**
add missing fields
add display option to not show units fields


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
