### PR TITLE
fix: add setting to display reaction and morale on animal sheet

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -66,7 +66,8 @@ const RULESETS = Object.freeze({
       showSpells: false,
       useNationality: false,
       animalsUseHits: false,
-      animalsUseLocations: false
+      animalsUseLocations: false,
+      displayReactionMorale: true
     }
   },
   CEL: {
@@ -99,7 +100,8 @@ const RULESETS = Object.freeze({
       showSpells: false,
       useNationality: false,
       animalsUseHits: false,
-      animalsUseLocations: false
+      animalsUseLocations: false,
+      displayReactionMorale: false
     }
   },
   CEFTL: {
@@ -130,7 +132,8 @@ const RULESETS = Object.freeze({
       showSpells: false,
       useNationality: false,
       animalsUseHits: false,
-      animalsUseLocations: false
+      animalsUseLocations: false,
+      displayReactionMorale: false
     },
   },
   CEATOM: {
@@ -161,7 +164,8 @@ const RULESETS = Object.freeze({
       showSpells: false,
       useNationality: true,
       animalsUseHits: false,
-      animalsUseLocations: true
+      animalsUseLocations: true,
+      displayReactionMorale: true
     }
   },
   BARBARIC: {
@@ -191,7 +195,8 @@ const RULESETS = Object.freeze({
       showSpells: true,
       useNationality: true,
       animalsUseHits: false,
-      animalsUseLocations: true
+      animalsUseLocations: true,
+      displayReactionMorale: true
     },
   },
   CEQ: {
@@ -223,7 +228,8 @@ const RULESETS = Object.freeze({
       showSpells: false,
       useNationality: false,
       animalsUseHits: false,
-      animalsUseLocations: false
+      animalsUseLocations: false,
+      displayReactionMorale: false
     }
   },
   CD: {
@@ -263,7 +269,8 @@ const RULESETS = Object.freeze({
       showSpells: false,
       useNationality: false,
       animalsUseHits: false,
-      animalsUseLocations: false
+      animalsUseLocations: false,
+      displayReactionMorale: true
     }
   },
   CLU: {
@@ -303,7 +310,8 @@ const RULESETS = Object.freeze({
       showSpells: false,
       useNationality: false,
       animalsUseHits: false,
-      animalsUseLocations: false
+      animalsUseLocations: false,
+      displayReactionMorale: true
     }
   },
 
@@ -344,7 +352,8 @@ const RULESETS = Object.freeze({
       showSpells: true,
       useNationality: true,
       animalsUseHits: false,
-      animalsUseLocations: false
+      animalsUseLocations: false,
+      displayReactionMorale: true
     }
   },
 

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -70,6 +70,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(booleanSetting("useNationality", false));
     settings.push(booleanSetting("animalsUseHits", false));
     settings.push(booleanSetting("animalsUseLocations", false));
+    settings.push(booleanSetting("displayReactionMorale", false));
     return settings;
   }
 }

--- a/src/module/sheets/TwodsixAnimalSheet.ts
+++ b/src/module/sheets/TwodsixAnimalSheet.ts
@@ -59,7 +59,8 @@ export class TwodsixAnimalSheet extends AbstractTwodsixActorSheet {
       showSpells: game.settings.get('twodsix', 'showSpells'),
       animalsUseHits: game.settings.get('twodsix', 'animalsUseHits'),
       dontShowStatBlock: (game.settings.get('twodsix', 'animalsUseHits') | game.settings.get("twodsix", "showLifebloodStamina") | game.settings.get('twodsix', 'lifebloodInsteadOfCharacteristics')),
-      animalsUseLocations: game.settings.get('twodsix', 'animalsUseLocations')
+      animalsUseLocations: game.settings.get('twodsix', 'animalsUseLocations'),
+      displayReactionMorale: game.settings.get('twodsix', 'displayReactionMorale')
     };
     //returnData.data.settings = returnData.settings; // DELETE WHEN CONVERSION IS COMPLETE
     returnData.config = TWODSIX;

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -114,6 +114,7 @@ declare global {
       'twodsix.useNationality':boolean;
       'twodsix.animalsUseHits': boolean;
       'twodsix.animalsUseLocations':boolean;
+      'twodsix.displayReactionMorale': boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -912,6 +912,10 @@
       "animalsUseLocations": {
         "hint": "Animals are described by location found instead of type and niche.",
         "name": "Animals use location instead of type"
+      },
+      "displayReactionMorale": {
+        "hint": "Show reaction and morale information on animal sheet.",
+        "name": "Show animal reaction and morale"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/templates/actors/parts/actor/actor-bgi-animal.html
+++ b/static/templates/actors/parts/actor/actor-bgi-animal.html
@@ -32,6 +32,7 @@
 <br>
 {{#unless limited}}
   <!-- Reaction Information -->
+  {{#if settings.displayReactionMorale}}
   <span class="bgi-reaction">
     <span class="roll-reaction orange" style="align-self: center;"><i class="fa-solid fa-person-circle-question" data-tooltip='{{localize "TWODSIX.Animal.Reaction"}}'></i>:</span>
     <span>{{localize "TWODSIX.Animal.Attack"}}:
@@ -44,6 +45,7 @@
     <input name="system.moraleDM" type="text" value="{{system.moraleDM}}" data-tooltip='{{localize "TWODSIX.Animal.MoraleDM"}}'' placeholder='{{localize "TWODSIX.Items.Component.DM"}}'/>
   </span>
   <br>
+  {{/if}}
   <!-- Protection Information-->
   <span class="bgi-armor" data-tooltip='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fa-solid fa-user-shield"></i>:<input
           style="text-align: right;" name="system.primaryArmor.value" type="number" value="{{system.primaryArmor.value}}" placeholder='0'


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)
bug

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix


* **What is the current behavior?** (You can also link to an open issue here)

No option to change the animal sheet reaction and morale information

* **What is the new behavior (if this is a feature change)?**
Advanced setting added to choose whether to display information


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
