### PR TITLE
feat: add item html and pdf links

### DIFF
--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -28,7 +28,6 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.push(booleanSetting('useFoundryStandardStyle', false, false, 'world', refreshWindow));
     settings.push(booleanSetting('useWoundedStatusIndicators', false));
     settings.push(booleanSetting('showWeightUsage', false));
-    settings.push(booleanSetting('showItemReferences', true));
     settings.push(booleanSetting('showIcons', false));
     settings.push(booleanSetting('useEncumbrance', false));
     settings.push(booleanSetting('showStatusIcons', true));

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -28,6 +28,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.push(booleanSetting('useFoundryStandardStyle', false, false, 'world', refreshWindow));
     settings.push(booleanSetting('useWoundedStatusIndicators', false));
     settings.push(booleanSetting('showWeightUsage', false));
+    settings.push(booleanSetting('usePDFPagerForRefs', false));
     settings.push(booleanSetting('showIcons', false));
     settings.push(booleanSetting('useEncumbrance', false));
     settings.push(booleanSetting('showStatusIcons', true));

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -258,9 +258,9 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
     }
 
     //Handle droped pdf reference for vehicle sheet
-    if (dropData.type === 'html'){
+    if (dropData.type === 'html' || dropData.type === 'pdf'){
       if (dropData.href && this.actor.type === 'vehicle') {
-        await this.actor.update({"system.pdfReference.href": dropData.href, "system.pdfReference.label": dropData.label});
+        await this.actor.update({"system.pdfReference.type": dropData.type, "system.pdfReference.href": dropData.href, "system.pdfReference.label": dropData.label});
       }
       return false;
     }
@@ -688,9 +688,11 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
    */
   protected async _onEditEffect(event): Promise<void> {
     const effectUuid = event.currentTarget["dataset"].uuid;
-    const selectedEffect = await fromUuid(effectUuid);
-    console.log(selectedEffect);
-    new ActiveEffectConfig(selectedEffect).render(true);
+    const selectedEffect = <ActiveEffect> await fromUuid(effectUuid);
+    //console.log(selectedEffect);
+    if (selectedEffect) {
+      new ActiveEffectConfig(selectedEffect).render(true);
+    };
   }
   /**
    * Handle when the right clicking on status icon.

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -257,6 +257,14 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       return false;
     }
 
+    //Handle droped pdf reference for vehicle sheet
+    if (dropData.type === 'html'){
+      if (dropData.href && this.actor.type === 'vehicle') {
+        await this.actor.update({"system.pdfReference.href": dropData.href, "system.pdfReference.label": dropData.label});
+      }
+      return false;
+    }
+
     const itemData = await getItemDataFromDropData(dropData);
 
     switch (actor.type) {

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -60,7 +60,6 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
       useProseMirror: game.settings.get('twodsix', 'useProseMirror'),
       useFoundryStandardStyle: game.settings.get('twodsix', 'useFoundryStandardStyle'),
       showSkillCountsRanks: game.settings.get('twodsix', 'showSkillCountsRanks'),
-      showReferences: game.settings.get('twodsix', 'showItemReferences'),
       showSpells: game.settings.get('twodsix', 'showSpells'),
       useNationality: game.settings.get('twodsix', 'useNationality')
     };

--- a/src/module/sheets/TwodsixAnimalSheet.ts
+++ b/src/module/sheets/TwodsixAnimalSheet.ts
@@ -55,6 +55,7 @@ export class TwodsixAnimalSheet extends AbstractTwodsixActorSheet {
       showInitiativeButton: game.settings.get("twodsix", "showInitiativeButton"),
       useProseMirror: game.settings.get('twodsix', 'useProseMirror'),
       useFoundryStandardStyle: game.settings.get('twodsix', 'useFoundryStandardStyle'),
+      showReferences: game.settings.get('twodsix', 'usePDFPagerForRefs'),
       showSpells: game.settings.get('twodsix', 'showSpells'),
       animalsUseHits: game.settings.get('twodsix', 'animalsUseHits'),
       dontShowStatBlock: (game.settings.get('twodsix', 'animalsUseHits') | game.settings.get("twodsix", "showLifebloodStamina") | game.settings.get('twodsix', 'lifebloodInsteadOfCharacteristics')),

--- a/src/module/sheets/TwodsixAnimalSheet.ts
+++ b/src/module/sheets/TwodsixAnimalSheet.ts
@@ -55,7 +55,6 @@ export class TwodsixAnimalSheet extends AbstractTwodsixActorSheet {
       showInitiativeButton: game.settings.get("twodsix", "showInitiativeButton"),
       useProseMirror: game.settings.get('twodsix', 'useProseMirror'),
       useFoundryStandardStyle: game.settings.get('twodsix', 'useFoundryStandardStyle'),
-      showReferences: game.settings.get('twodsix', 'showItemReferences'),
       showSpells: game.settings.get('twodsix', 'showSpells'),
       animalsUseHits: game.settings.get('twodsix', 'animalsUseHits'),
       dontShowStatBlock: (game.settings.get('twodsix', 'animalsUseHits') | game.settings.get("twodsix", "showLifebloodStamina") | game.settings.get('twodsix', 'lifebloodInsteadOfCharacteristics')),

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -47,7 +47,6 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       ShowDamageType: game.settings.get('twodsix', 'ShowDamageType'),
       ShowRateOfFire: game.settings.get('twodsix', 'ShowRateOfFire'),
       ShowRecoil: game.settings.get('twodsix', 'ShowRecoil'),
-      showReferences: game.settings.get('twodsix', 'showItemReferences'),
       DIFFICULTIES: TWODSIX.DIFFICULTIES[(<number>game.settings.get('twodsix', 'difficultyListUsed'))]
     };
     returnData.config = TWODSIX;
@@ -221,9 +220,13 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
     try {
       const dropData = getDataFromDropEvent(event);
       TwodsixItemSheet.check(!dropData, "DraggingSomething");
-      if (dropData.type === 'html'){
+      if (dropData.type === 'html' || dropData.type === 'pdf'){
         if (dropData.href) {
-          await this.item.update({"system.pdfReference.href": dropData.href, "system.pdfReference.label": dropData.label});
+          await this.item.update({
+            "system.pdfReference.type": dropData.type,
+            "system.pdfReference.href": dropData.href,
+            "system.pdfReference.label": dropData.label
+          });
         }
       } else {
         //This part handles just comsumables

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -4,7 +4,7 @@
 import { AbstractTwodsixItemSheet } from "./AbstractTwodsixItemSheet";
 import { TWODSIX } from "../config";
 import TwodsixItem from "../entities/TwodsixItem";
-import { getDataFromDropEvent, getItemDataFromDropData } from "../utils/sheetUtils";
+import { getDataFromDropEvent, getItemDataFromDropData, openPDFReference, deletePDFReference } from "../utils/sheetUtils";
 import { Component } from "src/types/template";
 
 /**
@@ -47,6 +47,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       ShowDamageType: game.settings.get('twodsix', 'ShowDamageType'),
       ShowRateOfFire: game.settings.get('twodsix', 'ShowRateOfFire'),
       ShowRecoil: game.settings.get('twodsix', 'ShowRecoil'),
+      usePDFPager: game.settings.get('twodsix', 'usePDFPagerForRefs'),
       DIFFICULTIES: TWODSIX.DIFFICULTIES[(<number>game.settings.get('twodsix', 'difficultyListUsed'))]
     };
     returnData.config = TWODSIX;
@@ -84,7 +85,8 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
     html.find('.consumable-delete').on('click', this._onDeleteConsumable.bind(this));
     html.find('.consumable-use-consumable-for-attack').on('change', this._onChangeUseConsumableForAttack.bind(this));
     this.handleContentEditable(html);
-    html.find('.delete-link').on('click', this._deletePDFReference.bind(this));
+    html.find('.open-link').on('click', openPDFReference.bind(this, [this.item.system.docReference]));
+    html.find('.delete-link').on('click', deletePDFReference.bind(this));
     html.find(`[name="system.subtype"]`).on('change', this._changeSubtype.bind(this));
     html.find(`[name="system.isBaseHull"]`).on('change', this._changeIsBaseHull.bind(this));
   }
@@ -258,27 +260,4 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       ui.notifications.error(err);
     }
   }
-  private async _deletePDFReference(event): void {
-    event.preventDefault();
-    if (this.item.system.pdfReference.href != "") {
-      await this.item.update({"system.pdfReference.type": "", "system.pdfReference.href": "", "system.pdfReference.label": ""});
-    } else {
-      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
-    }
-  }
-  /*private _openPDFReference(event): void {
-    event.preventDefault();
-    const sourceString = (<GearTemplate>this.item.system).docReference;
-    if (sourceString) {
-      const [code, page] = sourceString.split(' ');
-      const selectedPage = parseInt(page);
-      if (ui["PDFoundry"]) {
-        ui["PDFoundry"].openPDFByCode(code, {page: selectedPage});
-      } else {
-        ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.PDFFoundryNotInstalled"));
-      }
-    } else {
-      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
-    }
-  }*/
 }

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -261,7 +261,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
   private async _deletePDFReference(event): void {
     event.preventDefault();
     if (this.item.system.pdfReference.href != "") {
-      await this.item.update({"system.pdfReference.href": "", "system.pdfReference.label": ""});
+      await this.item.update({"system.pdfReference.type": "", "system.pdfReference.href": "", "system.pdfReference.label": ""});
     } else {
       ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
     }

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -247,6 +247,9 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
 
     try {
       const dropData:any = getDataFromDropEvent(event);
+      if (dropData.type === 'html') {
+        return false;
+      }
       const droppedObject:any = await getItemDataFromDropData(dropData);
 
       if (droppedObject.type === "traveller") {

--- a/src/module/sheets/TwodsixVehicleSheet.ts
+++ b/src/module/sheets/TwodsixVehicleSheet.ts
@@ -6,6 +6,7 @@ import {TwodsixVehicleSheetData, TwodsixVehicleSheetSettings } from "src/types/t
 import TwodsixItem, { onRollDamage} from "../entities/TwodsixItem";
 import { TwodsixRollSettings } from "../utils/TwodsixRollSettings";
 import { AbstractTwodsixActorSheet } from "./AbstractTwodsixActorSheet";
+import { openPDFReference, deletePDFReference } from "../utils/sheetUtils";
 
 export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
 
@@ -16,6 +17,7 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
     AbstractTwodsixActorSheet._prepareItemContainers(this.actor.items, context);
     context.settings = <TwodsixVehicleSheetSettings>{
       showHullAndArmor: game.settings.get('twodsix', 'showHullAndArmor'),
+      usePDFPager: game.settings.get('twodsix', 'usePDFPagerForRefs'),
       showRangeSpeedNoUnits: game.settings.get('twodsix', 'showRangeSpeedNoUnits')
     };
 
@@ -37,7 +39,8 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
     html.find(".component-toggle").on("click", this._onToggleComponent.bind(this));
     html.find('.roll-damage').on('click', onRollDamage.bind(this));
     html.find('.rollable').on('click', this._onRollWrapper(this._onSkillRoll));
-    html.find('.delete-link').on('click', this._deletePDFReference.bind(this));
+    html.find('.open-link').on('click', openPDFReference.bind(this, [this.actor.system.docReference]));
+    html.find('.delete-link').on('click', deletePDFReference.bind(this));
   }
 
   private _onToggleComponent(event:Event):void {
@@ -89,30 +92,6 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
         return;
       }
       await skill?.skillRoll(showThrowDiag, settings);
-    }
-  }
-
-  /*private _openPDFReference(event): void {
-    event.preventDefault();
-    const sourceString = (<Vehicle>this.actor.system).docReference;
-    if (sourceString) {
-      const [code, page] = sourceString.split(' ');
-      const selectedPage = parseInt(page);
-      if (ui["PDFoundry"]) {
-        ui["PDFoundry"].openPDFByCode(code, {page: selectedPage});
-      } else {
-        ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.PDFFoundryNotInstalled"));
-      }
-    } else {
-      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
-    }
-  }*/
-  private async _deletePDFReference(event): void {
-    event.preventDefault();
-    if (this.actor.system.pdfReference.href != "") {
-      await this.actor.update({"system.pdfReference.type": "", "system.pdfReference.href": "", "system.pdfReference.label": ""});
-    } else {
-      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
     }
   }
 }

--- a/src/module/sheets/TwodsixVehicleSheet.ts
+++ b/src/module/sheets/TwodsixVehicleSheet.ts
@@ -38,7 +38,7 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
     html.find(".component-toggle").on("click", this._onToggleComponent.bind(this));
     html.find('.roll-damage').on('click', onRollDamage.bind(this));
     html.find('.rollable').on('click', this._onRollWrapper(this._onSkillRoll));
-    html.find('.open-link').on('click', this._openPDFReference.bind(this));
+    html.find('.delete-link').on('click', this._deletePDFReference.bind(this));
   }
 
   private _onToggleComponent(event:Event):void {
@@ -93,7 +93,7 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
     }
   }
 
-  private _openPDFReference(event): void {
+  /*private _openPDFReference(event): void {
     event.preventDefault();
     const sourceString = (<Vehicle>this.actor.system).docReference;
     if (sourceString) {
@@ -104,6 +104,14 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
       } else {
         ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.PDFFoundryNotInstalled"));
       }
+    } else {
+      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
+    }
+  }*/
+  private async _deletePDFReference(event): void {
+    event.preventDefault();
+    if (this.actor.system.pdfReference.href != "") {
+      await this.actor.update({"system.pdfReference.href": "", "system.pdfReference.label": ""});
     } else {
       ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
     }

--- a/src/module/sheets/TwodsixVehicleSheet.ts
+++ b/src/module/sheets/TwodsixVehicleSheet.ts
@@ -16,8 +16,7 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
     AbstractTwodsixActorSheet._prepareItemContainers(this.actor.items, context);
     context.settings = <TwodsixVehicleSheetSettings>{
       showHullAndArmor: game.settings.get('twodsix', 'showHullAndArmor'),
-      showRangeSpeedNoUnits: game.settings.get('twodsix', 'showRangeSpeedNoUnits'),
-      showReferences: game.settings.get('twodsix', 'showItemReferences')
+      showRangeSpeedNoUnits: game.settings.get('twodsix', 'showRangeSpeedNoUnits')
     };
 
     return context;

--- a/src/module/sheets/TwodsixVehicleSheet.ts
+++ b/src/module/sheets/TwodsixVehicleSheet.ts
@@ -110,7 +110,7 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
   private async _deletePDFReference(event): void {
     event.preventDefault();
     if (this.actor.system.pdfReference.href != "") {
-      await this.actor.update({"system.pdfReference.href": "", "system.pdfReference.label": ""});
+      await this.actor.update({"system.pdfReference.type": "", "system.pdfReference.href": "", "system.pdfReference.label": ""});
     } else {
       ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
     }

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -190,7 +190,12 @@ export function getDataFromDropEvent(event:DragEvent):Record<string, any> {
   try {
     return JSON.parse(<string>event.dataTransfer?.getData('text/plain'));
   } catch (err) {
-    throw new Error(game.i18n.localize("TWODSIX.Errors.DropFailedWith").replace("_ERROR_MSG_", err));
+    const htmlRef = event.dataTransfer?.getData('text/html');
+    if (htmlRef) {
+      return getHTMLLink(htmlRef);
+    } else {
+      throw new Error(game.i18n.localize("TWODSIX.Errors.DropFailedWith").replace("_ERROR_MSG_", err));
+    }
   }
 }
 
@@ -200,4 +205,22 @@ export async function getItemDataFromDropData(dropData:Record<string, any>) {
     throw new Error(game.i18n.localize("TWODSIX.Errors.CouldNotFindItem").replace("_ITEM_ID_", dropData.uuid));
   }
   return duplicate(item);
+}
+
+export function getHTMLLink(dropString:string): Record<string,unknown> {
+  const re = new RegExp(/<a href="(.+?)">(.*?)<\/a>/gm);
+  const parsedResult: RegExpMatchArray | null = re.exec(dropString);
+  if (parsedResult){
+    return ({
+      type: "html",
+      href: parsedResult[1] ?? "",
+      label: parsedResult[2] ?? ""
+    });
+  } else {
+    return ({
+      type: "html",
+      href: "",
+      label: ""
+    });
+  }
 }

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+
 //Assorted utility functions likely to be helpful when displaying characters
 
 
@@ -233,3 +236,62 @@ export function getHTMLLink(dropString:string): Record<string,unknown> {
     });
   }
 }
+
+export function openPDFReference(sourceString:string[]): void {
+  if (sourceString) {
+    const [code, page] = sourceString[0].split(' ');
+    const selectedPage = parseInt(page);
+    if (ui["pdfpager"]) {
+      ui["pdfpager"].openPDFByCode(code, {page: selectedPage});
+      //byJournalName(code, selectedPage);
+    } else {
+      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.PDFPagerNotInstalled"));
+    }
+  } else {
+    ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
+  }
+}
+
+export async function deletePDFReference(event): Promise<void> {
+  event.preventDefault();
+  if (this.actor.system.pdfReference.href != "") {
+    await this.actor.update({"system.pdfReference.type": "", "system.pdfReference.href": "", "system.pdfReference.label": ""});
+  } else {
+    ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoSpecfiedLink"));
+  }
+}
+/*
+async function byJournalName(journalName, pageNumber) {
+  //This function bypasses pdf pager codes and calls by journal name
+  // Find page uuid
+  const journalEntry = game.journal?.getName(journalName);
+  let uuid = "";
+  if (journalEntry?.pages){
+    for (const page of journalEntry.pages) {
+      if (page.type === 'pdf') {
+        uuid = page.uuid;
+        break;
+      }
+    }
+  }
+
+  // Now request that the corresponding page be loaded.
+  if (!uuid) {
+    console.error(`byJournalName: unable to find PDF with name '${journalName}'`);
+    //ui.notifications.error(game.i18n.localize(`${PDFCONFIG.MODULE_NAME}.Error.NoPDFWithCode`));
+    return;
+  }
+  const pagedoc = await fromUuid(uuid);
+  if (!pagedoc) {
+    console.error(`byJournalName failed to retrieve document uuid '${uuid}`);
+    //ui.notifications.error(game.i18n.localize(`${PDFCONFIG.MODULE_NAME}.Error.FailedLoadPage`))
+    return;
+  }
+  const pageoptions = { pageId: pagedoc.id };
+  if (pageNumber) {
+    pageoptions.anchor = `page=${pageNumber}`;
+  }
+
+  // Render journal entry showing the appropriate page (JOurnalEntryPage#_onClickDocumentLink)
+  pagedoc.parent.sheet.render(true, pageoptions);
+} */

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -190,10 +190,18 @@ export function getDataFromDropEvent(event:DragEvent):Record<string, any> {
   try {
     return JSON.parse(<string>event.dataTransfer?.getData('text/plain'));
   } catch (err) {
-    const htmlRef = event.dataTransfer?.getData('text/html');
-    if (htmlRef) {
-      return getHTMLLink(htmlRef);
+    const pdfRef = event.dataTransfer?.getData('text/html');
+    if (pdfRef) {
+      return getHTMLLink(pdfRef);
     } else {
+      const uriRef = event.dataTransfer?.getData('text/uri-list');
+      if (uriRef) {
+        return ({
+          type: "html",
+          href: uriRef,
+          label: "Weblink"
+        });
+      }
       throw new Error(game.i18n.localize("TWODSIX.Errors.DropFailedWith").replace("_ERROR_MSG_", err));
     }
   }
@@ -210,15 +218,16 @@ export async function getItemDataFromDropData(dropData:Record<string, any>) {
 export function getHTMLLink(dropString:string): Record<string,unknown> {
   const re = new RegExp(/<a href="(.+?)">(.*?)<\/a>/gm);
   const parsedResult: RegExpMatchArray | null = re.exec(dropString);
+  const isPDF = dropString.includes("/pdfjs/");
   if (parsedResult){
     return ({
-      type: "html",
+      type: isPDF ? "pdf" : "html",
       href: parsedResult[1] ?? "",
       label: parsedResult[2] ?? ""
     });
   } else {
     return ({
-      type: "html",
+      type: isPDF ? "pdf" : "html",
       href: "",
       label: ""
     });

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -436,7 +436,7 @@ export interface Item {
   component:Component;
 }
 
-export interface Armor extends GearTemplate {
+export interface Armor extends GearTemplate, LinkTemplate {
   templates:string[];
   armor:number;
   secondaryArmor:PrimaryArmor;
@@ -447,7 +447,7 @@ export interface Armor extends GearTemplate {
   isPowered:boolean;
 }
 
-export interface Augment extends GearTemplate {
+export interface Augment extends GearTemplate, LinkTemplate {
   templates:string[];
   auglocation:string;
   type:string;
@@ -455,7 +455,7 @@ export interface Augment extends GearTemplate {
   location:string[];
 }
 
-export interface Component extends GearTemplate {
+export interface Component extends GearTemplate, LinkTemplate {
   templates:string[];
   subtype:string;
   powerDraw:number;
@@ -481,7 +481,7 @@ export interface Component extends GearTemplate {
   actorLink: string;
 }
 
-export interface Consumable extends GearTemplate {
+export interface Consumable extends GearTemplate, LinkTemplate {
   templates:string[];
   currentCount:number;
   max:number;
@@ -491,7 +491,7 @@ export interface Consumable extends GearTemplate {
   armorPiercing:number;
 }
 
-export interface Equipment extends GearTemplate {
+export interface Equipment extends GearTemplate, LinkTemplate {
   templates:string[];
   type:string;
   useConsumableForAttack:string;
@@ -512,10 +512,16 @@ export interface Skills {
   difficulty:string;
   rolltype:string;
   trainingNotes:string;
+  pdfReference:PDFLink;
 }
 
 export interface Templates {
   gearTemplate:GearTemplate;
+  referenceTemplate:LinkTemplate;
+}
+
+export interface LinkTemplate {
+  pdfReference:PDFLink;
 }
 
 export interface GearTemplate {
@@ -534,10 +540,9 @@ export interface GearTemplate {
   associatedSkillName:string;
   equipped:string;
   docReference:string;
-  pdfReference:PDFLink;
 }
 
-export interface Trait {
+export interface Trait extends LinkTemplate {
   templates:string[];
   value:number;
   type:string;
@@ -546,11 +551,10 @@ export interface Trait {
   shortdescr:string;
   subtype:string;
   docReference:string;
-  pdfReference:PDFLink;
   key:string;
 }
 
-export interface Spell {
+export interface Spell extends LinkTemplate {
   templates:string[];
   value:number;
   type:string;
@@ -560,10 +564,9 @@ export interface Spell {
   shortdescr:string;
   subtype:string;
   docReference:string;
-  pdfReference:PDFLink;
 }
 
-export interface Weapon extends GearTemplate {
+export interface Weapon extends GearTemplate, LinkTemplate {
   templates:string[];
   range:number;
   damage:string;
@@ -585,6 +588,7 @@ export interface Weapon extends GearTemplate {
 }
 
 export interface PDFLink {
+  type:string;
   href:string;
   label:string;
 }

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -365,7 +365,7 @@ export interface ShipPosition {
   actors?: TwodsixActor[];
 }
 
-export interface Vehicle {
+export interface Vehicle extends LinkTemplate {
   name:string;
   cargoList:string;
   cargoCapacity:string;
@@ -380,8 +380,6 @@ export interface Vehicle {
   openVehicle:boolean;
   techLevel:string;
   traits:string;
-  docReference:string;
-  pdfReference:PDFLink;
   weight:string;
 }
 
@@ -498,7 +496,7 @@ export interface Equipment extends GearTemplate, LinkTemplate {
   location:string[];
 }
 
-export interface Skills {
+export interface Skills extends LinkTemplate {
   templates:string[];
   value:number;
   characteristic:string;
@@ -506,13 +504,10 @@ export interface Skills {
   description:string;
   shortdescr:string;
   subtype:string;
-  docReference:string;
-  pdfReference:PDFLink;
   key:string;
   difficulty:string;
   rolltype:string;
   trainingNotes:string;
-  pdfReference:PDFLink;
 }
 
 export interface Templates {
@@ -521,7 +516,14 @@ export interface Templates {
 }
 
 export interface LinkTemplate {
+  docReference:string;
   pdfReference:PDFLink;
+}
+
+export interface PDFLink {
+  type:string;
+  href:string;
+  label:string;
 }
 
 export interface GearTemplate {
@@ -539,7 +541,6 @@ export interface GearTemplate {
   skill:string;
   associatedSkillName:string;
   equipped:string;
-  docReference:string;
 }
 
 export interface Trait extends LinkTemplate {
@@ -550,7 +551,6 @@ export interface Trait extends LinkTemplate {
   prereq:string;
   shortdescr:string;
   subtype:string;
-  docReference:string;
   key:string;
 }
 
@@ -563,7 +563,6 @@ export interface Spell extends LinkTemplate {
   duration:string;
   shortdescr:string;
   subtype:string;
-  docReference:string;
 }
 
 export interface Weapon extends GearTemplate, LinkTemplate {
@@ -587,8 +586,3 @@ export interface Weapon extends GearTemplate, LinkTemplate {
   armorPiercing:number;
 }
 
-export interface PDFLink {
-  type:string;
-  href:string;
-  label:string;
-}

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -381,6 +381,7 @@ export interface Vehicle {
   techLevel:string;
   traits:string;
   docReference:string;
+  pdfReference:PDFLink;
   weight:string;
 }
 
@@ -505,7 +506,8 @@ export interface Skills {
   description:string;
   shortdescr:string;
   subtype:string;
-  reference:string;
+  docReference:string;
+  pdfReference:PDFLink;
   key:string;
   difficulty:string;
   rolltype:string;
@@ -532,6 +534,7 @@ export interface GearTemplate {
   associatedSkillName:string;
   equipped:string;
   docReference:string;
+  pdfReference:PDFLink;
 }
 
 export interface Trait {
@@ -542,7 +545,8 @@ export interface Trait {
   prereq:string;
   shortdescr:string;
   subtype:string;
-  reference:string;
+  docReference:string;
+  pdfReference:PDFLink;
   key:string;
 }
 
@@ -555,7 +559,8 @@ export interface Spell {
   duration:string;
   shortdescr:string;
   subtype:string;
-  reference:string;
+  docReference:string;
+  pdfReference:PDFLink;
 }
 
 export interface Weapon extends GearTemplate {
@@ -577,4 +582,9 @@ export interface Weapon extends GearTemplate {
   recoil:boolean;
   features:string;
   armorPiercing:number;
+}
+
+export interface PDFLink {
+  href:string;
+  label:string;
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -723,6 +723,10 @@
         "hint": "Show Hero Points counter on actor sheet.",
         "name": "Show Hero Points"
       },
+      "usePDFPagerForRefs": {
+        "hint": "Use with PDF Pager to show references.  The format must be '[code name] [page number]'. If setting is false, uri links to references are used instead.",
+        "name": "Use PDF-Pager module to show references"
+      },
       "ShowLawLevel": {
         "hint": "checked=Show the 'Law Level' field, unchecked=Hide it",
         "name": "Show the 'Law Level' field on weapon sheets"
@@ -970,7 +974,7 @@
       "CantAutoDamage": "Automatic damage of ship or vehicle is not supported",
       "CantDropOnToken": "Dropping items on ship or vehicle tokens is not supported",
       "CantDragOntoActor": "This item can't be dragged onto this actor",
-      "PDFFoundryNotInstalled": "PDFoundry must be installed to use source links.",
+      "PDFPagerNotInstalled": "PDF Pager must be installed to use source links.",
       "NoSpecfiedLink": "No document and page specified for document link.",
       "NoTargetFound": "No target for damage found.",
       "LackPermissionToDamage": "You lack sufficient permissions on target actor.",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -250,6 +250,7 @@
       "Encumbrance": "Encumbrance",
       "Enc": "Enc",
       "DocumentReference": "Document Reference",
+      "Link": "Link",
       "DeleteReference": "Delete Reference",
       "Armor": {
         "Armor": "Armor",
@@ -719,10 +720,6 @@
       "showHeroPoints": {
         "hint": "Show Hero Points counter on actor sheet.",
         "name": "Show Hero Points"
-      },
-      "showItemReferences": {
-        "hint": "Shows a text field on item and vehicle sheets to use with PDFoundry or as a freeform reference.  For PDFoundry, format must be '[abbreviated name] [page number]'.",
-        "name": "Show reference field on vehicle and item sheets."
       },
       "ShowLawLevel": {
         "hint": "checked=Show the 'Law Level' field, unchecked=Hide it",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -250,6 +250,7 @@
       "Encumbrance": "Encumbrance",
       "Enc": "Enc",
       "DocumentReference": "Document Reference",
+      "DeleteReference": "Delete Reference",
       "Armor": {
         "Armor": "Armor",
         "SecondaryArmor": "Secondary Armor",

--- a/static/lang/es.json
+++ b/static/lang/es.json
@@ -720,7 +720,7 @@
         "hint": "Mostrar un contador de Puntos de Heroe en la hoja de personaje.",
         "name": "Mostrar Puntos Heroe"
       },
-      "showItemReferences": {
+      "usePDFPagerForRefs": {
         "hint": "Mostrar un campo de texto en la hoja de objetos para utilizar por PDFoundry o como referencia. Para PDFoundry, el formato debe ser '[nombre abreviado] [número página]'.",
         "name": "Mostrar campo de referencia en los objetos."
       },

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1762,10 +1762,10 @@ span.total-output {
   font-size: 15px;
   padding: 0.2em 0.2em 0.2em 0.5em;
 }
-.manifest {
-  /* margin-left: 10px; */
-  /* width: 215px; */
-}
+/*.manifest {
+  margin-left: 10px;
+  width: 215px;
+}*/
 .simplified-skill-description {
   font-weight: normal;
   font-size: 10px;
@@ -2644,7 +2644,7 @@ a:hover {
 }
 
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
-.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-features, .item-subtype, .item-type,
+.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-features, .item-subtype, .item-type, .item-reference,
 .item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
 .item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .item-data, .item-powered, .item-circle, .item-duration {
   margin-top: 0.3em;
@@ -2653,7 +2653,7 @@ a:hover {
   gap: 1ch;
 }
 
-.item-reference {
+.item-link {
   display: inline-flex;
   margin-top: 0.3em;
   gap: 1ch;

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -532,7 +532,7 @@ h2 {
   grid-area: vehicle-name-photo;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: space-evenly;
 }
 
 .vehicle-notes {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2545,12 +2545,18 @@ a:hover {
 }
 
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
-.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-reference, .item-features, .item-subtype, .item-type,
+.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-features, .item-subtype, .item-type,
 .item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
 .item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .item-data, .item-powered, .item-circle, .item-duration {
   margin-top: 0.3em;
   display: grid;
   grid-template-columns: 1fr 2fr;
+  gap: 1ch;
+}
+
+.item-reference {
+  display: inline-flex;
+  margin-top: 0.3em;
   gap: 1ch;
 }
 

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2076,11 +2076,6 @@ button.flexrow.flex-group-center.toggle-skills {
   margin: 0 0.4em -0.5em 0.3em;
 }
 
-/*a:hover {
-  color: var(--light-color);
-  text-shadow: 0 0 5px /*var(--default-color);
-}*/
-
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
 .item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-features, .item-subtype, .item-type,
 .item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2123,7 +2123,7 @@ button.flexrow.flex-group-center.toggle-skills {
 }
 
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
-.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-features, .item-subtype, .item-type,
+.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-features, .item-subtype, .item-type, .item-reference,
 .item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
 .item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .item-data, .item-powered, .item-circle, .item-duration {
   margin-top: 0.3em;
@@ -2132,7 +2132,8 @@ button.flexrow.flex-group-center.toggle-skills {
   gap: 1ch;
 }
 
-.item-reference {
+.item-link {
+  display: inline-flex;
   text-align: center;
   margin-top: 0.3em;
   gap: 1ch;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2092,7 +2092,7 @@ button.flexrow.flex-group-center.toggle-skills {
 }
 
 .item-reference {
-  display: inline-flex;
+  text-align: center;
   margin-top: 0.3em;
   gap: 1ch;
 }

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -219,7 +219,7 @@ label.checkbox > input[type="checkbox"] {
   grid-area: vehicle-name-photo;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: space-evenly;
 }
 
 .vehicle-stats {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2082,12 +2082,18 @@ button.flexrow.flex-group-center.toggle-skills {
 }*/
 
 .item-tl, .item-price, .item-skill, .item-skillModifier, .item-ammo, .item-qty, .item-weight, .item-power, .item-damage, .item-hits, .item-lvl, .item-armor, .item-range, .item-short,
-.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-reference, .item-features, .item-subtype, .item-type,
+.item-secondaryArmor, .item-radiationProtection, .item-prereq, .item-features, .item-subtype, .item-type,
 .item-lawLevel, .item-rangeBand, .item-weaponType,  .item-damageType, .item-rateOfFire, .item-recoil, .item-augmentLoc, .item-bonus,
 .item-rollDifficulty, .item-rollType, .item-simplifiedName, .simplified-skill-description, .item-data, .item-powered, .item-circle, .item-duration {
   margin-top: 0.3em;
   display: grid;
   grid-template-columns: 1fr 2fr;
+  gap: 1ch;
+}
+
+.item-reference {
+  display: inline-flex;
+  margin-top: 0.3em;
   gap: 1ch;
 }
 

--- a/static/template.json
+++ b/static/template.json
@@ -473,10 +473,10 @@
         "skillModifier": 0,
         "skill": "",
         "associatedSkillName": "",
-        "equipped": "backpack",
-        "docReference": ""
+        "equipped": "backpack"
       },
       "referenceTemplate": {
+        "docReference": "",
         "pdfReference": {
           "type": "",
           "href": "",
@@ -538,14 +538,13 @@
       "location": ["inventory", "storage"]
     },
     "skills": {
-      "templates": ["referenceTemplate"],
+      "templates": ["referenceTemplate", "referenceTemplate"],
       "value": -3,
       "characteristic": "STR",
       "type": "skills",
       "description": "",
       "shortdescr": "",
       "subtype": "",
-      "docReference": "",
       "key": "key",
       "difficulty": "Average",
       "rolltype": "Normal",
@@ -559,7 +558,6 @@
       "prereq": "",
       "shortdescr": "",
       "subtype": "",
-      "docReference": "",
       "key": "key"
     },
     "spell": {
@@ -571,7 +569,6 @@
       "duration": "",
       "shortdescr": "",
       "subtype": "",
-      "docReference": "",
       "key": "key"
     },
     "consumable": {

--- a/static/template.json
+++ b/static/template.json
@@ -283,6 +283,10 @@
         }
       },
       "docReference": "",
+      "pdfReference": {
+        "href": "",
+        "label": ""
+      },
       "features": "",
       "maneuver": {
         "speed": "0",
@@ -469,7 +473,11 @@
         "skill": "",
         "associatedSkillName": "",
         "equipped": "backpack",
-        "docReference": ""
+        "docReference": "",
+        "pdfReference": {
+          "href": "",
+          "label": ""
+        }
       }
     },
     "equipment": {
@@ -533,7 +541,11 @@
       "description": "",
       "shortdescr": "",
       "subtype": "",
-      "reference": "",
+      "docReference": "",
+      "pdfReference": {
+        "href": "",
+        "label": ""
+      },
       "key": "key",
       "difficulty": "Average",
       "rolltype": "Normal",
@@ -547,7 +559,11 @@
       "prereq": "",
       "shortdescr": "",
       "subtype": "",
-      "reference": "",
+      "docReference": "",
+      "pdfReference": {
+        "href": "",
+        "label": ""
+      },
       "key": "key"
     },
     "spell": {
@@ -559,7 +575,11 @@
       "duration": "",
       "shortdescr": "",
       "subtype": "",
-      "reference": "",
+      "docReference": "",
+      "pdfReference": {
+        "href": "",
+        "label": ""
+      },
       "key": "key"
     },
     "consumable": {

--- a/static/template.json
+++ b/static/template.json
@@ -284,6 +284,7 @@
       },
       "docReference": "",
       "pdfReference": {
+        "type": "",
         "href": "",
         "label": ""
       },
@@ -473,27 +474,30 @@
         "skill": "",
         "associatedSkillName": "",
         "equipped": "backpack",
-        "docReference": "",
+        "docReference": ""
+      },
+      "referenceTemplate": {
         "pdfReference": {
+          "type": "",
           "href": "",
           "label": ""
         }
       }
     },
     "equipment": {
-      "templates": ["gearTemplate"],
+      "templates": ["gearTemplate", "referenceTemplate"],
       "type": "equipment",
       "useConsumableForAttack": "",
       "location": ["inventory", "storage"]
     },
     "tool": {
-      "templates": ["gearTemplate"],
+      "templates": ["gearTemplate", "referenceTemplate"],
       "type": "equipment",
       "useConsumableForAttack": "",
       "location": ["inventory", "storage"]
     },
     "weapon": {
-      "templates": ["gearTemplate"],
+      "templates": ["gearTemplate", "referenceTemplate"],
       "range": 0,
       "damage": "3d6",
       "damageBonus": 0,
@@ -513,7 +517,7 @@
       "armorPiercing": 0
     },
     "armor": {
-      "templates": ["gearTemplate"],
+      "templates": ["gearTemplate", "referenceTemplate"],
       "armor": 0,
       "secondaryArmor": {
         "value": 0
@@ -527,14 +531,14 @@
       "isPowered": false
     },
     "augment": {
-      "templates": ["gearTemplate"],
+      "templates": ["gearTemplate", "referenceTemplate"],
       "auglocation": "None",
       "type": "augment",
       "bonus": "stat increase",
       "location": ["inventory", "storage"]
     },
     "skills": {
-      "templates": ["skillsTemplate"],
+      "templates": ["referenceTemplate"],
       "value": -3,
       "characteristic": "STR",
       "type": "skills",
@@ -542,17 +546,13 @@
       "shortdescr": "",
       "subtype": "",
       "docReference": "",
-      "pdfReference": {
-        "href": "",
-        "label": ""
-      },
       "key": "key",
       "difficulty": "Average",
       "rolltype": "Normal",
       "trainingNotes": ""
     },
     "trait": {
-      "templates": ["skillsTemplate"],
+      "templates": ["referenceTemplate"],
       "value": 0,
       "type": "trait",
       "description": "",
@@ -560,14 +560,10 @@
       "shortdescr": "",
       "subtype": "",
       "docReference": "",
-      "pdfReference": {
-        "href": "",
-        "label": ""
-      },
       "key": "key"
     },
     "spell": {
-      "templates": ["skillsTemplate"],
+      "templates": ["referenceTemplate"],
       "value": 0,
       "type": "spell",
       "description": "",
@@ -576,14 +572,10 @@
       "shortdescr": "",
       "subtype": "",
       "docReference": "",
-      "pdfReference": {
-        "href": "",
-        "label": ""
-      },
       "key": "key"
     },
     "consumable": {
-      "templates": ["gearTemplate"],
+      "templates": ["gearTemplate", "referenceTemplate"],
       "currentCount": 1,
       "max": 0,
       "type": "consumable",
@@ -592,7 +584,7 @@
       "armorPiercing": 0
     },
     "component": {
-      "templates": ["gearTemplate"],
+      "templates": ["gearTemplate", "referenceTemplate"],
       "subtype": "otherInternal",
       "powerDraw": 0,
       "rating": "",

--- a/static/templates/actors/vehicle-sheet.html
+++ b/static/templates/actors/vehicle-sheet.html
@@ -4,20 +4,27 @@
       <div class="vehicle-photo">
         <img class="profile-img" src="{{actor.img}}" data-edit="img" data-tooltip="{{actor.name}}" alt='{{localize "TWODSIX.Actor.CharacterImage"}}'/>
       </div>
-      <div class="vehicle-name"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}'
-                                         onClick="this.select();"/></div>
-      {{#if actor.system.pdfReference.href}}
-        <div class="item-reference centre">
-          {{localize "TWODSIX.Items.Link"}}:
-          <a class="open-link" href="{{actor.system.pdfReference.href}}">
-            {{#iff actor.system.pdfReference.type "===" 'pdf'}}
-              <i class="fa-solid fa-file-pdf" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
-            {{else}}
-              <i class="fa-solid fa-link" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
-            {{/iff}}
-            {{actor.system.pdfReference.label}}</a>
-          <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>
+      <div class="vehicle-name"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}' onClick="this.select();"/>
+      </div>
+      {{#if settings.usePDFPager}}
+        <div class="item-reference">
+          <a class="open-link">{{localize "TWODSIX.Items.DocumentReference"}}</a>
+          <input class="form-input" id="source" type="text" name="system.docReference" value="{{actor.system.docReference}}"/>
         </div>
+      {{else}}
+        {{#if actor.system.pdfReference.href}}
+          <div class="item-link centre">
+            {{localize "TWODSIX.Items.Link"}}:
+            <a href="{{actor.system.pdfReference.href}}">
+              {{#iff actor.system.pdfReference.type "===" 'pdf'}}
+                <i class="fa-solid fa-file-pdf" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
+              {{else}}
+                <i class="fa-solid fa-link" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
+              {{/iff}}
+              {{actor.system.pdfReference.label}}</a>
+            <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>
+          </div>
+        {{/if}}
       {{/if}}
     </div>
     <div class="vehicle-stats">

--- a/static/templates/actors/vehicle-sheet.html
+++ b/static/templates/actors/vehicle-sheet.html
@@ -7,10 +7,11 @@
       <div class="vehicle-name"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}'
                                          onClick="this.select();"/></div>
       {{#if settings.showReferences}}
-      <div class="item-reference">
-        <a class="open-link">{{localize "TWODSIX.Items.DocumentReference"}}</a>
-        <input class="form-input" id="source" type="text" name="system.docReference" value="{{actor.system.docReference}}"/>
-      </div>
+        <div class="item-reference">
+          {{localize "TWODSIX.Items.DocumentReference"}}:
+          <a class="open-link" href="{{actor.system.pdfReference.href}}">{{actor.system.pdfReference.label}}</a>
+          {{#if actor.system.pdfReference.href}} <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>{{/if}}
+        </div>
       {{/if}}
     </div>
     <div class="vehicle-stats">

--- a/static/templates/actors/vehicle-sheet.html
+++ b/static/templates/actors/vehicle-sheet.html
@@ -6,11 +6,17 @@
       </div>
       <div class="vehicle-name"><input name="name" type="text" value="{{actor.name}}" placeholder='{{localize "TWODSIX.Actor.CharacterName"}}'
                                          onClick="this.select();"/></div>
-      {{#if settings.showReferences}}
-        <div class="item-reference">
-          {{localize "TWODSIX.Items.DocumentReference"}}:
-          <a class="open-link" href="{{actor.system.pdfReference.href}}">{{actor.system.pdfReference.label}}</a>
-          {{#if actor.system.pdfReference.href}} <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>{{/if}}
+      {{#if actor.system.pdfReference.href}}
+        <div class="item-reference centre">
+          {{localize "TWODSIX.Items.Link"}}:
+          <a class="open-link" href="{{actor.system.pdfReference.href}}">
+            {{#iff actor.system.pdfReference.type "===" 'pdf'}}
+              <i class="fa-solid fa-file-pdf" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
+            {{else}}
+              <i class="fa-solid fa-link" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
+            {{/iff}}
+            {{actor.system.pdfReference.label}}</a>
+          <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>
         </div>
       {{/if}}
     </div>

--- a/static/templates/items/parts/reference-footer.html
+++ b/static/templates/items/parts/reference-footer.html
@@ -1,6 +1,7 @@
 {{#if settings.showReferences}}
 <div class="item-reference">
-  <a class="open-link">{{localize "TWODSIX.Items.DocumentReference"}}</a>
-  <input class="form-input" id="source" type="text" name="system.docReference" value="{{system.docReference}}"/>
+  {{localize "TWODSIX.Items.DocumentReference"}}:
+  <a class="open-link" href="{{system.pdfReference.href}}">{{system.pdfReference.label}}</a>
+  {{#if system.pdfReference.href}} <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>{{/if}}
 </div>
 {{/if}}

--- a/static/templates/items/parts/reference-footer.html
+++ b/static/templates/items/parts/reference-footer.html
@@ -1,14 +1,21 @@
-{{#if system.pdfReference.href}}
-<div class="item-reference">
-  {{localize "TWODSIX.Items.Link"}}:
-  <a class="open-link" href="{{system.pdfReference.href}}">
-    {{#iff system.pdfReference.type "===" 'pdf'}}
-      <i class="fa-solid fa-file-pdf" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
-    {{else}}
-      <i class="fa-solid fa-link" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
-    {{/iff}}
-     {{system.pdfReference.label}}
-  </a>
-  <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>
-</div>
+{{#if settings.usePDFPager}}
+  <div class="item-reference">
+    <a class="open-link">{{localize "TWODSIX.Items.DocumentReference"}}</a>
+    <input class="form-input" id="source" type="text" name="system.docReference" value="{{system.docReference}}"/>
+  </div>
+{{else}}
+  {{#if system.pdfReference.href}}
+      <div class="item-link">
+        {{localize "TWODSIX.Items.Link"}}:
+        <a href="{{system.pdfReference.href}}">
+          {{#iff system.pdfReference.type "===" 'pdf'}}
+            <i class="fa-solid fa-file-pdf" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
+          {{else}}
+            <i class="fa-solid fa-link" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
+          {{/iff}}
+          {{system.pdfReference.label}}
+        </a>
+        <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>
+      </div>
+  {{/if}}
 {{/if}}

--- a/static/templates/items/parts/reference-footer.html
+++ b/static/templates/items/parts/reference-footer.html
@@ -1,7 +1,14 @@
-{{#if settings.showReferences}}
+{{#if system.pdfReference.href}}
 <div class="item-reference">
-  {{localize "TWODSIX.Items.DocumentReference"}}:
-  <a class="open-link" href="{{system.pdfReference.href}}">{{system.pdfReference.label}}</a>
-  {{#if system.pdfReference.href}} <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>{{/if}}
+  {{localize "TWODSIX.Items.Link"}}:
+  <a class="open-link" href="{{system.pdfReference.href}}">
+    {{#iff system.pdfReference.type "===" 'pdf'}}
+      <i class="fa-solid fa-file-pdf" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
+    {{else}}
+      <i class="fa-solid fa-link" data-tooltip='{{localize "TWODSIX.Items.Link"}}'></i>
+    {{/iff}}
+     {{system.pdfReference.label}}
+  </a>
+  <a class="delete-link" data-tooltip='{{localize "TWODSIX.Items.DeleteReference"}}'><i class="fa-solid fa-trash"></i></a>
 </div>
 {{/if}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Replace PDFoundry pdf links with native heading drag and drop

* **What is the current behavior?** (You can also link to an open issue here)
Old method of adding pdf links through PDFoundry does not work with v10 (module not updated)


* **What is the new behavior (if this is a feature change)?**
Links to pdf header (rather than a page) or a uri


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Old links using pdFoundry are not supported or migrated.

* **Other information**:
