### PR TITLE
Token and actor fixes

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -468,7 +468,7 @@ export default class TwodsixActor extends Actor {
   }
 
   public async createUnarmedSkill(): Promise<Skills | void> {
-    if (this.items?.getName(game.i18n.localize("TWODSIX.Item.Weapon.Unarmed"))) {
+    if (this.items?.getName(game.i18n.localize("TWODSIX.Items.Weapon.Unarmed"))) {
       return;
     }
     const data = {

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -295,11 +295,13 @@ export default class TwodsixActor extends Actor {
             "token.disposition": CONST.TOKEN_DISPOSITIONS.FRIENDLY,
             "token.bar1": {
               attribute: "hits"
-            },
-            "system.movement.walk": game.settings.get("twodsix", "defaultMovement"),
-            "system.movement.units": game.settings.get("twodsix", "defaultMovementUnits")
+            }
           });
         }
+        this.update({
+          "system.movement.walk": game.settings.get("twodsix", "defaultMovement"),
+          "system.movement.units": game.settings.get("twodsix", "defaultMovementUnits")
+        });
         await this.createUntrainedSkill();
         if (this.img === foundry.documents.BaseActor.DEFAULT_ICON) {
           await this.update({

--- a/static/templates/items/parts/common-parts.html
+++ b/static/templates/items/parts/common-parts.html
@@ -53,17 +53,18 @@
           {{/select}}
         </select>
     </div>
-  <div class="item-skillModifier">
-    <label for="system.skillModifier"  class="resource-label">{{localize "TWODSIX.Items.Equipment.SkillModifier"}}</label>
-    <input class="form-input" id="system.skillModifier" type="text" name="system.skillModifier" value="{{system.skillModifier}}"
-           data-dtype="Number"/>
-  </div>
   {{else}}
     <div class="item-skill">
       <label for = "system.associatedSkillName" class="resource-label">{{localize "TWODSIX.Items.Equipment.AssociatedSkillName"}}</label>
       <input class="form-input" id = "system.associatedSkillName" type="text" name="system.associatedSkillName" value="{{system.associatedSkillName}}" />
     </div>
   {{/if}}
+
+<div class="item-skillModifier">
+  <label for="system.skillModifier"  class="resource-label">{{localize "TWODSIX.Items.Equipment.SkillModifier"}}</label>
+  <input class="form-input" id="system.skillModifier" type="text" name="system.skillModifier" value="{{system.skillModifier}}"
+          data-dtype="Number"/>
+</div>
 
 <div class="item-tl">
   <label for="system.techLevel" class="resource-label">{{localize "TWODSIX.Items.Equipment.TL"}}</label>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Movement rate not set to settings if FVTT token defaults used
Unarmed item multiplying when actor duplicated
Skill Roll modifier not visible when item is unattached

* **What is the new behavior (if this is a feature change)?**
Default movement rate always set to advanced settings.
Unarmed item not replicated upon duplication
Skill roll modifier always visible.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
