### PR TITLE
feat: Improve drag-drop of items between actors

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -694,8 +694,3 @@ function getEquipmentWeight(item:TwodsixItem):number {
   }
   return 0;
 }
-
-function isDuplicateItem(itemData: any):boolean {
-  const retValue = this.items.filter(x => x.name === itemData.name);
-  return retValue.length > 0 ? true : false;
-}

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -617,9 +617,9 @@ export default class TwodsixActor extends Actor {
     }
 
     // Item already exists on actor
-    if (this.items.getName(itemData.name)) {
+    const dupItem = <TwodsixItem>this.items.getName(itemData.name);
+    if (dupItem && itemData.type === dupItem.type) {
       console.log(`Twodsix | Item ${itemData.name} already on character ${this.name}.`);
-      const dupItem = <TwodsixItem>this.items.getName(itemData.name);
       if( dupItem.type !== "skills"  && dupItem.type !== "trait" && dupItem.type !== "ship_position") {
         const newQuantity = dupItem.system.quantity + numberToMove;
         dupItem.update({"system.quantity": newQuantity});
@@ -760,7 +760,7 @@ function getEquipmentWeight(item:TwodsixItem):number {
   return 0;
 }
 
-async function getMoveNumber(itemData:number): Promise <number> {
+async function getMoveNumber(itemData:TwodsixItem): Promise <number> {
   const returnNumber:number = await new Promise((resolve) => {
     new Dialog({
       title: game.i18n.localize("TWODSIX.Actor.Items.QuantityToTransfer"),

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -146,9 +146,9 @@ export default class TwodsixItem extends Item {
       const roll = await this.skillRoll(false, settings, showInChat);
       if (game.settings.get("twodsix", "automateDamageRollOnHit") && roll && roll.isSuccess()) {
         const totalBonusDamage = (bonusDamage !== "0" && bonusDamage !== "") ? `${roll.effect} + ${bonusDamage}` : `${roll.effect}`;
-        const damage = await this.rollDamage(settings.rollMode, totalBonusDamage, showInChat, false) || null;
-        if (game.user?.targets.size === 1 && damage) {
-          game.user?.targets.values().next().value.actor.damageActor(damage.total, TwodsixItem.getApValue(weapon, this.actor));
+        const damagePayload = await this.rollDamage(settings.rollMode, totalBonusDamage, showInChat, false) || null;
+        if (game.user?.targets.size === 1 && damagePayload) {
+          game.user?.targets.values().next().value.actor.handleDamageData(damagePayload, <boolean>!game.settings.get('twodsix', 'invertSkillRollShiftClick'));
         } else if (game.user?.targets && game.user?.targets.size > 1) {
           ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.AutoDamageForMultipleTargetsNotImplemented"));
         }
@@ -229,7 +229,7 @@ export default class TwodsixItem extends Item {
     return diceRoll;
   }
 
-  public async rollDamage(rollMode:DICE_ROLL_MODES, bonusDamage = "", showInChat = true, confirmFormula = false):Promise<Roll | void> {
+  public async rollDamage(rollMode:DICE_ROLL_MODES, bonusDamage = "", showInChat = true, confirmFormula = false):Promise<any | void> {
     const weapon = <Weapon | Component>this.system;
 
     if (!weapon.damage) {
@@ -301,7 +301,7 @@ export default class TwodsixItem extends Item {
           }
         }, {rollMode: rollMode});
       }
-      return damage;  //probably should return contentData instead
+      return contentData;
     }
   }
 

--- a/src/module/hooks/dropItemOnToken.ts
+++ b/src/module/hooks/dropItemOnToken.ts
@@ -4,7 +4,6 @@
 //Liberally adapted from "hey-catch" by Mana#4176
 //import { Skills } from "src/types/template";
 import TwodsixActor from "../entities/TwodsixActor";
-import { handleDroppedItem, handleDroppedSkills } from "../sheets/AbstractTwodsixActorSheet";
 import { getItemDataFromDropData } from "../utils/sheetUtils";
 Hooks.on('dropCanvasData', (canvasObject, dropData) => {
   if ((dropData.type === 'damageItem' || dropData.type === "Item") && game.settings.get("twodsix", "allowDropOnIcon")) {
@@ -48,10 +47,10 @@ async function catchDrop(canvasObject: Canvas, dropData) {
         }
 
         if (itemData.type === "skills") {
-          handleDroppedSkills(targetActor, itemData);
+          targetActor.handleDroppedSkills(itemData);
           return;
         } else if (!["component"].includes(itemData.type)) {
-          handleDroppedItem(targetActor, itemData);
+          targetActor.handleDroppedItem(itemData);
           return;
         }
       }

--- a/src/module/hooks/dropItemOnToken.ts
+++ b/src/module/hooks/dropItemOnToken.ts
@@ -2,8 +2,9 @@
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
 
 //Liberally adapted from "hey-catch" by Mana#4176
-import { Skills } from "src/types/template";
+//import { Skills } from "src/types/template";
 import TwodsixActor from "../entities/TwodsixActor";
+import { handleDroppedItem, handleDroppedSkills } from "../sheets/AbstractTwodsixActorSheet";
 import { getItemDataFromDropData } from "../utils/sheetUtils";
 Hooks.on('dropCanvasData', (canvasObject, dropData) => {
   if ((dropData.type === 'damageItem' || dropData.type === "Item") && game.settings.get("twodsix", "allowDropOnIcon")) {
@@ -22,45 +23,35 @@ async function catchDrop(canvasObject: Canvas, dropData) {
   } else if (foundTokens.length === 1) {
     //console.log('Dropped On:', found[0]);
 
-    const actor = foundTokens[0]?.actor;
+    const targetActor = <TwodsixActor>foundTokens[0]?.actor;
     //console.log(actor);
 
-    if (!actor?.isOwner) {
+    if (!targetActor?.isOwner) {
       return ui.notifications?.warn(game.i18n.localize("TWODSIX.Warnings.LackPermissionToDamage"));
     }
 
-    if (actor.type === 'traveller' || actor.type === 'animal') {
+    if (targetActor.type === 'traveller' || targetActor.type === 'animal') {
       if (dropData.type === 'damageItem') {
-        await (<TwodsixActor>actor).damageActor(dropData.payload.damage, dropData.payload.armorPiercingValue, true);
+        await (<TwodsixActor>targetActor).damageActor(dropData.payload.damage, dropData.payload.armorPiercingValue, true);
       } else if (dropData.type === 'Item') {
         const itemData = await getItemDataFromDropData(dropData);  //Note: this might need to change to  itemData = fromUuidSync(dropData.uuid)
 
         //Block unallowed types on animals
-        if (!["weapon", "trait", "skills"].includes(itemData.type) && actor.type === "animal") {
+        if (!["weapon", "trait", "skills"].includes(itemData.type) && targetActor.type === "animal") {
           ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.CantDragOntoActor"));
           return false;
         }
 
-        if (isSameActor(actor, itemData)) {
+        if (isSameActor(targetActor, itemData)) {
           console.log(`Twodsix | Moved Skill ${itemData.name} to another position in the skill list`);
           return;
         }
 
-        if (isDuplicateItem(actor, itemData)) {
-          console.log(`Twodsix | Skill ${itemData.name} already on character ${actor.name}.`);
-          const dupItem:TwodsixItem = actor.items.filter(x => x.name === itemData.name)[0];
-          if( dupItem.type !== "skills"  && dupItem.type !== "trait" && dupItem.type !== "ship_position") {
-            const newQuantity = dupItem.system.quantity + 1;
-            dupItem.update({"system.quantity": newQuantity});
-          }
-          return;
-        }
-
         if (itemData.type === "skills") {
-          handleDroppedSkills(<TwodsixActor>actor, itemData);
+          handleDroppedSkills(targetActor, itemData);
           return;
         } else if (!["component"].includes(itemData.type)) {
-          handleDroppedItem(actor, itemData);
+          handleDroppedItem(targetActor, itemData);
           return;
         }
       }
@@ -77,48 +68,10 @@ async function catchDrop(canvasObject: Canvas, dropData) {
 function getTokensAtLocation(canvasObject: Canvas, x: number, y: number) {
   const controllable = canvasObject.tokens?.placeables.filter(obj => obj.visible && obj.actor && obj.control instanceof Function);
   const foundTokens = controllable?.filter(obj => {
-    const w = obj.width, h = obj.height;
-    return Number.between(x, obj.x, obj.x + w) && Number.between(y, obj.y, obj.y + h);
+    //const w = obj.width, h = obj.height;
+    return Number.between(x, obj.x, obj.x + obj.w) && Number.between(y, obj.y, obj.y + obj.h);
   });
   return foundTokens;
-}
-
-function handleDroppedSkills(actor: TwodsixActor, itemData: TwodsixItem) {
-  // Handle item sorting within the same Actor
-  const droppedSkill = duplicate(itemData);
-  if ((<Skills>droppedSkill.system).value < 0 || !(<Skills>droppedSkill.system).value) {
-    if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
-      const skills: Skills = <Skills>game.system.template.Item?.skills;
-      (<Skills>droppedSkill.system).value = skills?.value;
-    } else {
-      (<Skills>droppedSkill.system).value = 0;
-    }
-  }
-  actor.createEmbeddedDocuments("Item", [droppedSkill]);
-  console.log(`Twodsix | Added Skill ${droppedSkill.name} to character`);
-}
-
-function handleDroppedItem(actor:Actor, itemData:any) {
-  const droppedItem = duplicate(itemData);
-
-  //Remove any attached consumables
-  if (droppedItem.system.consumables !== undefined) {
-    if (droppedItem.system.consumables.length > 0) {
-      droppedItem.system.consumables = [];
-    }
-  }
-
-  //Link an actor skill with name defined by item.associatedSkillName
-  if (droppedItem.system.associatedSkillName !== "") {
-    droppedItem.system.skill = actor.items.getName(droppedItem.system.associatedSkillName)?.id;  // or is it _id????????
-  }
-
-  actor.createEmbeddedDocuments("Item", [droppedItem]);
-}
-
-function isDuplicateItem(actor: Actor, itemData: any):boolean {
-  const retValue = actor.items.filter(x => x.name === itemData.name);
-  return retValue.length > 0 ? true : false;
 }
 
 function isSameActor(actor: Actor, itemData: any): boolean {

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -3,7 +3,7 @@
 
 import { Traveller } from "src/types/template";
 import TwodsixActor from "../entities/TwodsixActor";
-
+import { TWODSIX } from "../config";
 import { getDamageCharacteristics } from "../utils/actorDamage";
 import { _genTranslatedSkillList } from "../utils/TwodsixRollSettings";
 
@@ -150,7 +150,8 @@ async function checkUnconsciousness(selectedActor: TwodsixActor, oldWoundState: 
         await setConditionState(effectType.unconscious, selectedActor, true); // Automatic unconsciousness or out of combat
       } else {
         const displayShortChar = _genTranslatedSkillList(selectedActor)['END'];
-        const returnRoll = await selectedActor.characteristicRoll({ characteristic: 'END', displayLabel: displayShortChar, difficulty: { mod: 0, target: 8 } }, false);
+        const setDifficulty = TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))].Difficult;
+        const returnRoll = await selectedActor.characteristicRoll({ characteristic: 'END', displayLabel: displayShortChar, difficulty: setDifficulty}, false);
         if (returnRoll && returnRoll.effect < 0) {
           await setConditionState(effectType.unconscious, selectedActor, true);
         }

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -31,6 +31,7 @@ export const registerSettings = function ():void {
   booleanSetting('automateDamageRollOnHit', false, true, 'client');
   booleanSetting('hideUntrainedSkills', false, true, "world", _onHideUntrainedSkillsChange);
   booleanSetting('invertSkillRollShiftClick', false, true);
+  booleanSetting('transferDroppedItems', false, true);
   booleanSetting('autoAddUnarmed', false, true);
   numberSetting('weightModifierForWornArmor', 1.0, true);
 

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -684,7 +684,7 @@ export async function handleDroppedItem(actor, itemData): Promise<boolean>{
       const newQuantity = dupItem.system.quantity + itemData.system.quantity;
       dupItem.update({"system.quantity": newQuantity});
     }
-    return;
+    return false;
   }
 
   //Remove any attached consumables
@@ -704,7 +704,7 @@ export async function handleDroppedItem(actor, itemData): Promise<boolean>{
     skillId = await actor.items.getName(addedItem.system.associatedSkillName)?.id;
     //Try to link Untrained if no match
     if (!skillId) {
-      skillId = (<TwodsixActor>actor).getUntrainedSkill()?.id;
+      skillId = (<TwodsixActor>actor).getUntrainedSkill()?.id ?? "";
     }
     await addedItem.update({"system.skill": skillId});
   }

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -635,36 +635,35 @@ function sortObj(obj) {
   }, {});
 }
 
-export async function handleDroppedSkills(actor, itemData): Promise<boolean>{
-  const matching = actor.items.filter(x => {
-    return x.name === itemData.name;
-  });
-
+export async function handleDroppedSkills(actor, skillData): Promise<boolean>{
   // Handle item sorting within the same Actor
-  const sameActor = actor.items.get(itemData._id);;
+  const sameActor = actor.items.get(skillData._id);;
   if (sameActor) {
-    console.log(`Twodsix | Moved Skill ${itemData.name} to another position in the skill list`);
+    console.log(`Twodsix | Moved Skill ${skillData.name} to another position in the skill list`);
     //return this._onSortItem(event, sameActor);
     return false;
   }
 
-  if (matching.length > 0) {
-    console.log(`Twodsix | Skill ${itemData.name} already on character ${actor.name}.`);
+  //Check for pre-existing skill by same name
+  const matching = actor.items.getName(skillData.name);
+
+  if (matching) {
+    console.log(`Twodsix | Skill ${skillData.name} already on character ${actor.name}.`);
     //TODO Maybe this should mean increase skill value?
     return false;
   }
 
-  if (itemData.system.value < 0 || !itemData.system.value) {
+  if (skillData.system.value < 0 || !skillData.system.value) {
     if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
       const skills: Skills = <Skills>game.system.template.Item?.skills;
-      itemData.system.value = skills?.value;
+      skillData.system.value = skills?.value;
     } else {
-      itemData.system.value = 0;
+      skillData.system.value = 0;
     }
   }
 
-  const addedSkill = await actor.createEmbeddedDocuments("Item", [itemData]);
-  console.log(`Twodsix | Added Skill ${itemData.name} to character`);
+  const addedSkill = await actor.createEmbeddedDocuments("Item", [skillData]);
+  console.log(`Twodsix | Added Skill ${skillData.name} to character`);
   return(!!addedSkill);
 }
 
@@ -678,7 +677,7 @@ export async function handleDroppedItem(actor, itemData): Promise<boolean>{
 
   // Item already exists on actor
   if (isDuplicateItem(actor, itemData)) {
-    console.log(`Twodsix | Skill ${itemData.name} already on character ${actor.name}.`);
+    console.log(`Twodsix | Item ${itemData.name} already on character ${actor.name}.`);
     const dupItem:TwodsixItem = actor.items.getName(itemData.name);
     if( dupItem.type !== "skills"  && dupItem.type !== "trait" && dupItem.type !== "ship_position") {
       const newQuantity = dupItem.system.quantity + itemData.system.quantity;

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -215,7 +215,7 @@ export async function getItemDataFromDropData(dropData:Record<string, any>) {
   if (!item) {
     throw new Error(game.i18n.localize("TWODSIX.Errors.CouldNotFindItem").replace("_ITEM_ID_", dropData.uuid));
   }
-  return duplicate(item);
+  return deepClone(item);
 }
 
 export function getHTMLLink(dropString:string): Record<string,unknown> {

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -120,6 +120,7 @@ declare global {
       'twodsix.displayReactionMorale': boolean;
       'twodsix.showComponentRating': boolean;
       'twodsix.showComponentDM': boolean;
+      'twodsix.transferDroppedItems': boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -84,6 +84,7 @@
         "ENEMIES": "ENEMIES"
       },
       "Items": {
+        "Amount": "Amount",
         "ARMOR": "ARMOR",
         "AUGMENTS": "AUGMENTS",
         "Ammo": "Ammo",
@@ -99,6 +100,7 @@
         "Effect": "Effect",
         "Location": "Location",
         "Name": "Name",
+        "QuantityToTransfer": "Quantity to Transfer",
         "Qty": "Qty",
         "Range": "Range",
         "Refill": "Refill",
@@ -109,6 +111,7 @@
         "Subtype": "Type",
         "TRAITS": "TRAITS",
         "Traits": "Traits",
+        "Transfer": "Transfer Items",
         "TL": "TL",
         "TechLevel": "Tech Level",
         "Value": "Value",
@@ -946,6 +949,10 @@
       "encumbranceModifier": {
         "hint": "The number to add to the physical (STR, END, DEX) characteristic modifier when encumbered. For example, -1 indicates one should be subtracted for all rolls involving physical characterisitcs.",
         "name": "Modifier to physical characteristics when actor becomes encumbered"
+      },
+      "transferDroppedItems": {
+        "hint": "Overrides the default Foundry behavior of copying on drag-drop to transfering items (items removed from source actor) when drag-dropping equipment between actors.",
+        "name": "Transfer rather than copy dropped equipment on actors"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1002,7 +1002,7 @@
       "CantDragOntoActor": "This item can't be dragged onto this actor",
       "PDFPagerNotInstalled": "PDF Pager must be installed to use source links.",
       "NoSpecfiedLink": "No document and page specified for document link.",
-      "NoTargetFound": "No target for damage found.",
+      "NoTargetFound": "No target for dropping found.",
       "LackPermissionToDamage": "You lack sufficient permissions on target actor.",
       "MultipleActorsFound": "Multiple actors found. Cannot apply damage.",
       "EncumbranceFormulaInvalid": "Encumbrance Formula is not valid.  Value is set to zero.",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
duplicate items created when dropping on actor sheet
redundant code for drop on token and sheet
unconsciousness rolls don't display a difficulty


* **What is the new behavior (if this is a feature change)?**
increase quantity if name is the same
refactor handling of dropped items to an actor method
show difficulty level for unconsciousness rolls
add option setting to transfer rather than copy when drag-dropping between actors
add transfer dialog

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
