### PR TITLE
fix: refactor armor calcs to actor sheet from AbstractActorSheet

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -89,6 +89,29 @@ export default class TwodsixActor extends Actor {
     system.skills = new Proxy(Object.fromEntries(actorSkills), handler);
     system.encumbrance.max = this.getMaxEncumbrance();
     system.encumbrance.value = this.getActorEncumbrance();
+    if (this.type === 'traveller') {
+      const armorValues = this.getArmorValues();
+      system.primaryArmor.value = armorValues.primaryArmor;
+      system.secondaryArmor.value= armorValues.secondaryArmor;
+      system.radiationProtection.value = armorValues.radiationProtection;
+    }
+  }
+
+  getArmorValues():object {
+    const returnValue = {
+      primaryArmor: 0,
+      secondaryArmor: 0,
+      radiationProtection: 0
+    };
+    const armorItems = this.items.filter( a => a.type === "armor");
+    for (const armor of armorItems) {
+      if (armor.system.equipped === "equipped") {
+        returnValue.primaryArmor += armor.system.armor;
+        returnValue.secondaryArmor += armor.system.secondaryArmor.value;
+        returnValue.radiationProtection += armor.system.radiationProtection.value;
+      }
+    }
+    return returnValue;
   }
 
   getMaxEncumbrance():number {

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -4,7 +4,7 @@
 import TwodsixItem, { onRollDamage }  from "../entities/TwodsixItem";
 import {getDataFromDropEvent, getItemDataFromDropData} from "../utils/sheetUtils";
 import TwodsixActor from "../entities/TwodsixActor";
-import {Armor, Skills, UsesConsumables, Component} from "../../types/template";
+import {Skills, UsesConsumables, Component} from "../../types/template";
 import { TwodsixShipSheetData } from "../../types/twodsix";
 import {onPasteStripFormatting} from "../sheets/AbstractTwodsixItemSheet";
 import { getKeyByValue } from "../utils/sheetUtils";
@@ -373,9 +373,6 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
     const spells:Item[] = [];
     const consumable:Item[] = [];
     const component = {};
-    let primaryArmor = 0;
-    let secondaryArmor = 0;
-    let radiationProtection = 0;
     let numberOfSkills = 0;
     let skillRanks = 0;
     const summaryStatus = {};
@@ -388,18 +385,12 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
         item.prepareConsumable();
       }
       if (sheetData.actor.type === "traveller") {
-        const anArmor = <Armor>item.system;
-        if (item.type === "armor" && anArmor.equipped === "equipped") {
-          primaryArmor += anArmor.armor;
-          secondaryArmor += anArmor.secondaryArmor.value;
-          radiationProtection += anArmor.radiationProtection.value;
-        } else if (item.type === "skills") {
+        if (item.type === "skills") {
           if (item.system.value >= 0 && !item.getFlag("twodsix", "untrainedSkill")) {
             numberOfSkills += 1;
             skillRanks += Number(item.system.value);
           }
         }
-
       }
       switch (item.type) {
         case 'storage':
@@ -468,9 +459,6 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       sheetData.container.skills = skills;
       sheetData.container.traits = traits;
       sheetData.container.spells = spells;
-      sheetData.system.primaryArmor.value = primaryArmor;
-      sheetData.system.secondaryArmor.value = secondaryArmor;
-      sheetData.system.radiationProtection.value = radiationProtection;
       sheetData.numberOfSkills = numberOfSkills + (sheetData.jackOfAllTrades > 0 ? 1 : 0);
       sheetData.skillRanks = skillRanks + sheetData.jackOfAllTrades;
     } else if (sheetData.actor.type === "animal" ) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

refactor

* **What is the current behavior?** (You can also link to an open issue here)
armor calc done in AbstractActorSheet


* **What is the new behavior (if this is a feature change)?**
armor calc moved to actor method


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
armor item primary values is system.armor but should really be system.primaryArmor.value