### PR TITLE
fix: adding untrained skills

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -572,17 +572,16 @@ export default class TwodsixActor extends Actor {
       return false;
     }
 
-    if (skillData.system.value < 0 || !skillData.system.value) {
+    const addedSkill = (await this.createEmbeddedDocuments("Item", [duplicate(skillData)]))[0];
+    if (addedSkill.system.value < 0 || !addedSkill.system.value) {
       if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
         const skills: Skills = <Skills>game.system.template.Item?.skills;
-        skillData.system.value = skills?.value;
+        addedSkill.update({"system.value": skills?.value});
       } else {
-        skillData.system.value = 0;
+        addedSkill.update({"system.value": 0});
       }
     }
-
-    const addedSkill = await this.createEmbeddedDocuments("Item", [skillData]);
-    console.log(`Twodsix | Added Skill ${skillData.name} to character`);
+    console.log(`Twodsix | Added Skill ${addedSkill.name} to character`);
     return(!!addedSkill);
   }
 

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -24,13 +24,8 @@ export default class TwodsixItem extends Item {
         await item.update({'img': 'systems/twodsix/assets/icons/components/other.svg'});
       }
     }
-    if (item?.type === "skills") {
-      if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
-        const skills: Skills = <Skills>game.system.template.Item?.skills;
-        item.update({"system.value": skills?.value});
-      } else {
-        item.update({"system.value": 0});
-      }
+    if (item?.type === "skills" && game.settings.get('twodsix', 'hideUntrainedSkills')) {
+      item.update({"system.value": 0});
     }
     return item;
   }

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -24,6 +24,14 @@ export default class TwodsixItem extends Item {
         await item.update({'img': 'systems/twodsix/assets/icons/components/other.svg'});
       }
     }
+    if (item?.type === "skills") {
+      if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
+        const skills: Skills = <Skills>game.system.template.Item?.skills;
+        item.update({"system.value": skills?.value});
+      } else {
+        item.update({"system.value": 0});
+      }
+    }
     return item;
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Untrained skills (level <0) disappear when dragging and dropping onto actor when hide untrained is set to true
New skills are created at the untrained level


* **What is the new behavior (if this is a feature change)?**
Dropped skills set to a min level of zero if hide untrained setting is true
New skills have default zero value when created with hide untrained true


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
