### PR TITLE
fix: Quick fix to prevent JOAT from drag and drop

### DIFF
--- a/static/templates/actors/npc-sheet.html
+++ b/static/templates/actors/npc-sheet.html
@@ -43,7 +43,7 @@
       <span class="item-title-npc">{{localize "TWODSIX.Actor.Tabs.Skills"}}</span>
       {{#unless limited}}
       <div style="margin-left: 1ch;">
-        <span class="item" data-item-id="{{joat-skill-input}}" >
+        <span class="fixed-item" data-item-id="{{joat-skill-input}}" >
             <span class="item-name" >{{localize "TWODSIX.Actor.Skills.JOAT"}}</span>
             <input type="number" value="{{jackOfAllTrades}}" id="joat-skill-input" style="text-align: center; width: 3ch;"/>,
         </span>

--- a/static/templates/actors/npc-sheet.html
+++ b/static/templates/actors/npc-sheet.html
@@ -55,7 +55,7 @@
               {{#if ../settings.hideUntrainedSkills}},{{else}}{{#unless @last}},{{/unless}}{{/if}}
       {{/each_sort_item}}
       {{#if settings.hideUntrainedSkills}}
-      <span class="item" data-item-id="{{untrainedSkill.id}}">
+      <span class="item" data-item-id="{{untrainedSkill.id}}" draggable="false">
           <text class="item-name rollable" data-tooltip="{{twodsix_invertSkillRollShiftClick}}"> {{untrainedSkill.name}}</text>
           <input style="width: 3ch;" class="item-value-edit" type="number" value= "{{untrainedSkill.system.value}}" readonly/>
       </span>

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -23,7 +23,7 @@
 </div>
 
 <div class="skill">
-  <span class="item skill-container">
+  <span class="fixed-item skill-container" draggable="false">
     <ol class="ol-no-indent">
       <li class="fixed-item flexrow" data-item-id="{{joat-skill-input}}" style="margin-bottom: 0.01px;">
         <span class="skill-container">

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -67,9 +67,9 @@
 </section>
 {{#if settings.hideUntrainedSkills}}
 <div class="skill">
-  <span class="item skill-container" draggable="false">
+  <span class="item skill-container" data-item-id="{{untrainedSkill.id}}" draggable="false">
     <ol class="ol-no-indent">
-      <li class="item flexrow" data-item-id="{{untrainedSkill.id}}" draggable="false">
+      <li class="flexrow" >
         <span class="skill-container">
           <span class="mini-dice centre rollable" data-tooltip="{{twodsix_invertSkillRollShiftClick}}"><i class="fa-solid fa-dice" alt="d6"></i></span>
           <span class="item-name rollable">{{untrainedSkill.name}}</span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)

JOAT skill can be dragged and dropped

* **What is the new behavior (if this is a feature change)?**

Prevent drag and dropping of the skill

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
