### PR TITLE
features: QOL Issues for Consumables

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -135,9 +135,12 @@ Can probably be done, but, I haven't tried it. If you have, tell us on the Disco
 * Can drag a scene to ship actor to act as an attached deck plan.
 * Option to use ProseMirror editor for larger text input fields.
 * Dragging a vehicle actor to a ship component list creats a component copy of the vehicle.  Name links to actor.
-* Automatic wounded status indicators (along with roll modifiers) can be optional added through a setting
-* There is an NPC sheet that can be used for any traveller.  Select under sheet settings
+* Automatic wounded status indicators (along with roll modifiers) can be optional added through a setting.
+* There is an NPC sheet that can be used for any traveller.  Select under sheet settings.
 * If using the show untrained skill, any roll that depends on a skill will default to untrained if no specific skill is selected.
+* If the training notes contain aa fraction, the pie shown represents that fraction rather than the default 50 percent.
+* Can now hide items on actor sheet that are stored on the ship by toggling the eyeball icon.
+* Unconsciousness rolls (if made) now fixed at 8+ per all rules settings (not a specific difficulty)
 
 Note that skills can be set to not use any characteristic for modifiers which is useful in some cases beyond Cepheus Light (like classic Traveller).
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -141,6 +141,7 @@ Can probably be done, but, I haven't tried it. If you have, tell us on the Disco
 * If the training notes contain aa fraction, the pie shown represents that fraction rather than the default 50 percent.
 * Can now hide items on actor sheet that are stored on the ship by toggling the eyeball icon.
 * Unconsciousness rolls (if made) now fixed at 8+ per all rules settings (not a specific difficulty)
+* Unconscious and Dead condition icons only get applied if the actor has an active token.
 
 Note that skills can be set to not use any characteristic for modifiers which is useful in some cases beyond Cepheus Light (like classic Traveller).
 

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -10,6 +10,7 @@ import {TwodsixRollSettings} from "../utils/TwodsixRollSettings";
 import TwodsixActor from "./TwodsixActor";
 import {DICE_ROLL_MODES} from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs";
 import {Component, Consumable, Gear, Skills, UsesConsumables, Weapon} from "../../types/template";
+import { simplifyRollFormula } from "../utils/dice";
 
 export default class TwodsixItem extends Item {
   public static async create(data, options?):Promise<TwodsixItem> {
@@ -44,10 +45,15 @@ export default class TwodsixItem extends Item {
     if (gear.consumables !== undefined && gear.consumables.length > 0 && this.actor != null) {
 
       //TODO What is consumableData? Where does it come from? Not in template.json
-      gear.consumableData = gear.consumables.map((consumableId:string) => {
+      const allConsumables = gear.consumables.map((consumableId:string) => {
         return this.actor?.items.find((item) => item.id === consumableId);
       });
+      gear.consumableData = allConsumables.filter((item) => !item.system.isAttachment);
       gear.consumableData.sort((a, b) => {
+        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+      });
+      gear.attachmentData = allConsumables.filter((item) => item.system.isAttachment);
+      gear.attachmentData.sort((a, b) => {
         return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
       });
     }
@@ -246,15 +252,17 @@ export default class TwodsixItem extends Item {
       return;
     } else {
       //Calc regular damage
-      let rollFormula = weapon.damage + ((bonusDamage !== "0" && bonusDamage !== "") ? "+" + bonusDamage : "");
+      const consumableDamage = TwodsixItem.getConsumableBonusDamage(<Weapon>weapon, this.actor);
+      let rollFormula = weapon.damage + ((bonusDamage !== "0" && bonusDamage !== "") ? "+" + bonusDamage : "") + (consumableDamage != "" ? "+" + consumableDamage : "");
       //console.log(rollFormula);
       if (confirmFormula) {
         rollFormula = await TwodsixItem.confirmRollFormula(rollFormula, game.i18n.localize("TWODSIX.Damage.DamageFormula"));
       }
-
+      rollFormula = rollFormula.replace(/dd/ig, "d6*10"); //Parse for a destructive damage roll DD = d6*10
+      rollFormula = simplifyRollFormula(rollFormula);
       let damage = <Roll>{};
       let apValue = 0;
-      rollFormula = rollFormula.replace(/dd/ig, "d6*10"); //Parse for a destructive damage roll DD = d6*10
+
       if (Roll.validate(rollFormula)) {
         damage = new Roll(rollFormula, this.actor?.system);
         await damage.evaluate({async: true}); // async: true will be default in foundry 0.10
@@ -268,7 +276,9 @@ export default class TwodsixItem extends Item {
       let radDamage = <Roll>{};
       if (this.type === "component") {
         if (Roll.validate(this.system.radDamage)) {
-          radDamage = new Roll(this.system.radDamage, this.actor?.system);
+          let radFormula = this.system.radDamage.replace(/dd/ig, "d6*10"); //Parse for a destructive damage roll DD = d6*10
+          radFormula = simplifyRollFormula(radFormula);
+          radDamage = new Roll(radFormula, this.actor?.system);
           await radDamage.evaluate({async: true});
         }
       }
@@ -281,7 +291,7 @@ export default class TwodsixItem extends Item {
       Object.assign(contentData, {
         flavor: flavor,
         roll: damage,
-        dice: damage.terms[0]["results"],
+        dice: getDiceResults(damage), //damage.terms[0]["results"]
         armorPiercingValue: apValue ?? 0,
         damage: (damage.total && damage.total > 0) ? damage.total : 0
       });
@@ -290,7 +300,7 @@ export default class TwodsixItem extends Item {
         Object.assign(contentData, {
           radDamage: radDamage.total,
           radRoll: radDamage,
-          radDice: radDamage.terms[0]["results"]
+          radDice: getDiceResults(radDamage)
         });
       }
       if (showInChat) {
@@ -318,8 +328,19 @@ export default class TwodsixItem extends Item {
     let returnValue = weapon.armorPiercing;
     if (weapon.useConsumableForAttack && actor) {
       const magazine = actor.items.get(weapon.useConsumableForAttack);
-      if (magazine?.type === "consumable") {
+      if (magazine?.type === "consumable" && !magazine?.isAttachment) {
         returnValue += (<Consumable>magazine.system)?.armorPiercing || 0;
+      }
+    }
+    return returnValue;
+  }
+
+  public static getConsumableBonusDamage(weapon:Weapon, actor?):string {
+    let returnValue = "";
+    if (weapon.useConsumableForAttack && actor) {
+      const magazine = actor.items.get(weapon.useConsumableForAttack);
+      if (magazine?.type === "consumable") {
+        returnValue = (<Consumable>magazine.system)?.bonusDamage;
       }
     }
     return returnValue;
@@ -443,4 +464,17 @@ export async function onRollDamage(event):Promise<void> {
 
   await item.rollDamage((<DICE_ROLL_MODES>game.settings.get('core', 'rollMode')), bonusDamageFormula, true, showFormulaDialog);
 
+}
+/**
+ * A function for simplifying the dice results of a multipart roll formula.
+ *
+ * @param {Roll} inputRoll    The original roll.
+ * @returns {object[]}        The resulting simplified dice terms.
+ */
+function getDiceResults(inputRoll:Roll) {
+  const returnValue = [];
+  for (const die of inputRoll.dice) {
+    returnValue.push(die.results);
+  }
+  return returnValue.flat(2);
 }

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -48,14 +48,18 @@ export default class TwodsixItem extends Item {
       const allConsumables = gear.consumables.map((consumableId:string) => {
         return this.actor?.items.find((item) => item.id === consumableId);
       });
-      gear.consumableData = allConsumables.filter((item) => !item.system.isAttachment);
-      gear.consumableData.sort((a, b) => {
-        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
-      });
-      gear.attachmentData = allConsumables.filter((item) => item.system.isAttachment);
-      gear.attachmentData.sort((a, b) => {
-        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
-      });
+      gear.consumableData = allConsumables.filter((item) => !item?.system.isAttachment);
+      if (gear.consumableData.length > 0) {
+        gear.consumableData.sort((a, b) => {
+          return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+        });
+      }
+      gear.attachmentData = allConsumables.filter((item) => item?.system.isAttachment);
+      if (gear.attachmentData > 0) {
+        gear.attachmentData.sort((a, b) => {
+          return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+        });
+      }
     }
   }
 

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -48,14 +48,14 @@ export default class TwodsixItem extends Item {
       const allConsumables = gear.consumables.map((consumableId:string) => {
         return this.actor?.items.find((item) => item.id === consumableId);
       });
-      gear.consumableData = allConsumables.filter((item) => !item?.system.isAttachment);
+      gear.consumableData = allConsumables.filter((item) => !item?.system.isAttachment) ?? [];
       if (gear.consumableData.length > 0) {
         gear.consumableData.sort((a, b) => {
           return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
         });
       }
-      gear.attachmentData = allConsumables.filter((item) => item?.system.isAttachment);
-      if (gear.attachmentData > 0) {
+      gear.attachmentData = allConsumables.filter((item) => item?.system.isAttachment) ?? [];
+      if (gear.attachmentData.length > 0) {
         gear.attachmentData.sort((a, b) => {
           return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
         });

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -220,6 +220,10 @@ export default function registerHandlebarsHelpers(): void {
     return game.settings.get('twodsix', 'showTimeframe');
   });
 
+  Handlebars.registerHelper('twodsix_hideItem', (display:boolean, itemLocation:string) => {
+    return (display && (itemLocation === "ship"));
+  });
+
   Handlebars.registerHelper("concat", (...args) => args.slice(0, args.length - 1).join(''));  //Needed? In FVTT baseline
 
   Handlebars.registerHelper('each_sort_item', (array, options) => {

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -153,7 +153,6 @@ async function checkUnconsciousness(selectedActor: TwodsixActor, oldWoundState: 
       if (['CEQ', 'CEATOM', 'BARBARIC'].includes(rulesSet)) {
         await setConditionState(effectType.unconscious, selectedActor, true); // Automatic unconsciousness or out of combat
       } else {
-        const displayShortChar = _genTranslatedSkillList(selectedActor)['END'];
         const setDifficulty = TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))].Difficult;
         const returnRoll = await selectedActor.characteristicRoll({ rollModifiers: {characteristic: 'END'}, difficulty: setDifficulty}, false);
         if (returnRoll && returnRoll.effect < 0) {

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -8,14 +8,14 @@ import { getDamageCharacteristics } from "../utils/actorDamage";
 import { _genTranslatedSkillList } from "../utils/TwodsixRollSettings";
 
 Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>) => {
+  const firstGM = game.users.find(u => u.isGM);
   if (game.settings.get('twodsix', 'useWoundedStatusIndicators')) {
-    const firstGM = game.users.find(u => u.isGM);
     if (checkForWounds(update.system, actor.type) && (actor.type === 'traveller' || actor.type === 'animal') && game.user?.id === firstGM?.id) {
       await applyWoundedEffect(actor).then();
     }
   }
   if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators')) {
-    if (update.system?.characteristics && (actor.type === 'traveller') && game.user?.isGM) {
+    if (update.system?.characteristics && (actor.type === 'traveller') && game.user?.id === firstGM?.id) {
       await applyEncumberedEffect(actor).then();
     }
   }

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -152,7 +152,7 @@ async function checkUnconsciousness(selectedActor: TwodsixActor, oldWoundState: 
       if (['CEQ', 'CEATOM', 'BARBARIC'].includes(rulesSet)) {
         await setConditionState(effectType.unconscious, selectedActor, true); // Automatic unconsciousness or out of combat
       } else {
-        const setDifficulty = TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))].Average;
+        const setDifficulty = Object.values(TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))]).find(e => e.target=== 8); //always 8+
         const returnRoll = await selectedActor.characteristicRoll({ rollModifiers: {characteristic: 'END'}, difficulty: setDifficulty}, false);
         if (returnRoll && returnRoll.effect < 0) {
           await setConditionState(effectType.unconscious, selectedActor, true);

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -5,7 +5,6 @@ import { Traveller } from "src/types/template";
 import TwodsixActor from "../entities/TwodsixActor";
 import { TWODSIX } from "../config";
 import { getDamageCharacteristics } from "../utils/actorDamage";
-import { _genTranslatedSkillList } from "../utils/TwodsixRollSettings";
 
 Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>) => {
   const firstGM = game.users.find(u => u.isGM);

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -9,7 +9,8 @@ import { _genTranslatedSkillList } from "../utils/TwodsixRollSettings";
 
 Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>) => {
   if (game.settings.get('twodsix', 'useWoundedStatusIndicators')) {
-    if (checkForWounds(update.system, actor.type) && (actor.type === 'traveller' || actor.type === 'animal') && game.user?.isGM) {
+    const firstGM = game.users.find(u => u.isGM);
+    if (checkForWounds(update.system, actor.type) && (actor.type === 'traveller' || actor.type === 'animal') && game.user?.id === firstGM?.id) {
       await applyWoundedEffect(actor).then();
     }
   }
@@ -22,14 +23,16 @@ Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>)
 
 Hooks.on("updateItem", async (item: TwodsixItem) => {
   if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators')) {
-    if ((item.actor?.type === 'traveller') && ["weapon", "armor", "equipment", "tool", "junk", "consumable"].includes(item.type) && game.user?.isGM) {
+    const firstGM = game.users.find(u => u.isGM);
+    if ((item.actor?.type === 'traveller') && ["weapon", "armor", "equipment", "tool", "junk", "consumable"].includes(item.type) && game.user?.id === firstGM?.id) {
       await applyEncumberedEffect(<TwodsixActor>item.actor).then();
     }
   }
 });
 Hooks.on("deleteItem", async (item: TwodsixItem) => {
   if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators')) {
-    if ((item?.actor?.type === 'traveller') && game.user?.isGM) {
+    const firstGM = game.users.find(u => u.isGM);
+    if ((item?.actor?.type === 'traveller') && game.user?.id === firstGM?.id) {
       applyEncumberedEffect(<TwodsixActor>item.actor).then();
     }
   }
@@ -37,7 +40,8 @@ Hooks.on("deleteItem", async (item: TwodsixItem) => {
 
 Hooks.on("createItem", async (item: TwodsixItem) => {
   if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators')) {
-    if ((item?.actor?.type === 'traveller') && game.user?.isGM) {
+    const firstGM = game.users.find(u => u.isGM);
+    if ((item?.actor?.type === 'traveller') && game.user?.id === firstGM?.id) {
       applyEncumberedEffect(<TwodsixActor>item.actor).then();
     }
   }
@@ -212,7 +216,7 @@ async function setWoundedState(effectLabel: string, targetActor: TwodsixActor, s
         woundModifier = game.settings.get('twodsix', 'seriousWoundsRollModifier');
         break;
     }
-    const changeData = { key: "system.woundedEffect", mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE, value: woundModifier.toString() };//
+    const changeData = { key: "system.woundedEffect", mode: CONST.ACTIVE_EFFECT_MODES.ADD, value: woundModifier.toString() };//
     if (isAlreadySet.length === 0 && state === true) {
       await targetActor.createEmbeddedDocuments("ActiveEffect", [{
         label: effectLabel,

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -152,7 +152,7 @@ async function checkUnconsciousness(selectedActor: TwodsixActor, oldWoundState: 
       if (['CEQ', 'CEATOM', 'BARBARIC'].includes(rulesSet)) {
         await setConditionState(effectType.unconscious, selectedActor, true); // Automatic unconsciousness or out of combat
       } else {
-        const setDifficulty = TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))].Difficult;
+        const setDifficulty = TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))].Average;
         const returnRoll = await selectedActor.characteristicRoll({ rollModifiers: {characteristic: 'END'}, difficulty: setDifficulty}, false);
         if (returnRoll && returnRoll.effect < 0) {
           await setConditionState(effectType.unconscious, selectedActor, true);

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -155,7 +155,7 @@ async function checkUnconsciousness(selectedActor: TwodsixActor, oldWoundState: 
       } else {
         const displayShortChar = _genTranslatedSkillList(selectedActor)['END'];
         const setDifficulty = TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))].Difficult;
-        const returnRoll = await selectedActor.characteristicRoll({ rollModifiers: {characteristic: 'END'}, displayLabel: displayShortChar, difficulty: setDifficulty}, false);
+        const returnRoll = await selectedActor.characteristicRoll({ rollModifiers: {characteristic: 'END'}, difficulty: setDifficulty}, false);
         if (returnRoll && returnRoll.effect < 0) {
           await setConditionState(effectType.unconscious, selectedActor, true);
         }

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -208,7 +208,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
     const {type} = header.dataset;
 
     // Grab any data associated with this control.
-    const data = duplicate(header.dataset) as Record<string, any>;
+    //const data = duplicate(header.dataset) as Record<string, any>;
 
     // Initialize a default name, handle bad naming of 'skills' item type, which should be singular.
     const itemType = (type === "skills" ? "skill" : type);
@@ -223,7 +223,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
     const itemData = {
       name: itemName,
       type,
-      system: data
+      system: {}
     };
 
     // Remove the type from the dataset since it's in the itemData.type prop.
@@ -323,7 +323,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
           };
         }
         component[(<Component>item.system).subtype].push(item);
-        if (statusOrder[summaryStatus[(<Component>item.system).subtype]] < statusOrder[item.system.status]) {
+        if (statusOrder[summaryStatus[(<Component>item.system).subtype].status] < statusOrder[item.system.status]) {
           summaryStatus[(<Component>item.system).subtype] = {
             status: item.system.status,
             uuid: item.uuid

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -184,6 +184,15 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
           itemData.img = 'systems/twodsix/assets/icons/spell-book.svg';
         }
         break;
+      case "consumable":
+        itemData.system.subtype = "other";
+        if (subtype === "attachment") {
+          itemData.system.isAttachment = true;
+          itemData.name = game.i18n.localize("TWODSIX.Items.Equipment.NewAttachment");
+        } else {
+          itemData.system.max = 1;
+        }
+        break;
     }
   }
 

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -7,7 +7,7 @@ import TwodsixActor from "../entities/TwodsixActor";
 import {Skills, UsesConsumables, Component} from "../../types/template";
 import { TwodsixShipSheetData } from "../../types/twodsix";
 import {onPasteStripFormatting} from "../sheets/AbstractTwodsixItemSheet";
-import { getKeyByValue } from "../utils/sheetUtils";
+//import { getKeyByValue } from "../utils/sheetUtils";
 import { resolveUnknownAutoMode } from "../utils/rollItemMacro";
 import { TWODSIX } from "../config";
 //import { applyEncumberedEffect } from "../hooks/showStatusIcons";
@@ -469,9 +469,9 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
    */
   protected async _onRollChar(event, showThrowDiag: boolean): Promise<void> {
     const shortChar = $(event.currentTarget).data("label");
-    const fullCharLabel = getKeyByValue(TWODSIX.CHARACTERISTICS, shortChar);
-    const displayShortChar = (<TwodsixActor>this.actor).system["characteristics"][fullCharLabel].displayShortLabel;
-    await (<TwodsixActor>this.actor).characteristicRoll({ rollModifiers: {characteristic: shortChar}, "displayLabel": displayShortChar }, showThrowDiag);
+    //const fullCharLabel = getKeyByValue(TWODSIX.CHARACTERISTICS, shortChar);
+    //const displayShortChar = (<TwodsixActor>this.actor).system["characteristics"][fullCharLabel].displayShortLabel;
+    await (<TwodsixActor>this.actor).characteristicRoll({ rollModifiers: {characteristic: shortChar}}, showThrowDiag);
   }
 
   /**

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -101,6 +101,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     html.find(".item-fill-consumable").on("click", this._onAutoAddConsumable.bind(this));
     // Item State toggling
     html.find(".item-toggle").on("click", this._onToggleItem.bind(this));
+    html.find(".item-viewToggle").on("click", this._onViewToggle.bind(this));
 
   }
 
@@ -225,6 +226,16 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
         await consumableSelected.update({["system.equipped"]: itemSelected.system.equipped});
       }
     }
+  }
+
+  /**
+   * Handle toggling the view state of an Item class.
+   * @param {Event} event   The originating click event.
+   * @private
+   */
+  private async _onViewToggle(event): Promise<void> {
+    const itemType: string = $(event.currentTarget).data("itemType");
+    await this.actor.update({[`system.hideStoredItems.${itemType}`]: !this.actor.system.hideStoredItems[itemType]});
   }
 }
 

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -183,7 +183,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
         name: game.i18n.localize("TWODSIX.Items.Consumable.Types.magazine") + ": " + weaponSelected.name,
         type: "consumable",
         system: {
-          subtype: "other",
+          subtype: "magazine",
           quantity: 1,
           currentCount: max,
           max,

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -178,7 +178,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     const weaponSelected: any = this.actor.items.get(li.data("itemId"));
 
     const max = weaponSelected.system.ammo;
-    if (max > 0 && weaponSelected.system.consumableData.length === 0) {
+    if (max > 0 && (!weaponSelected.system.consumableData || weaponSelected.system.consumableData?.length === 0)) {
       const newConsumableData = {
         name: game.i18n.localize("TWODSIX.Items.Consumable.Types.magazine") + ": " + weaponSelected.name,
         type: "consumable",

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -178,7 +178,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     const weaponSelected: any = this.actor.items.get(li.data("itemId"));
 
     const max = weaponSelected.system.ammo;
-    if (max > 0 && (!weaponSelected.system.consumableData || weaponSelected.system.consumableData?.length === 0)) {
+    if (max > 0 && !weaponSelected.system.consumableData?.length) {
       const newConsumableData = {
         name: game.i18n.localize("TWODSIX.Items.Consumable.Types.magazine") + ": " + weaponSelected.name,
         type: "consumable",

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -178,7 +178,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     const weaponSelected: any = this.actor.items.get(li.data("itemId"));
 
     const max = weaponSelected.system.ammo;
-    if (max > 0 && weaponSelected.system.consumables.length === 0) {
+    if (max > 0 && weaponSelected.system.consumableData.length === 0) {
       const newConsumableData = {
         name: game.i18n.localize("TWODSIX.Items.Consumable.Types.magazine") + ": " + weaponSelected.name,
         type: "consumable",

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -79,6 +79,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
     }
 
     html.find('.consumable-create').on('click', this._onCreateConsumable.bind(this));
+    html.find('.attachment-create').on('click', this._onCreateAttachment.bind(this));
     html.find('.consumable-edit').on('click', this._onEditConsumable.bind(this));
     html.find('.consumable-delete').on('click', this._onDeleteConsumable.bind(this));
     html.find('.consumable-use-consumable-for-attack').on('change', this._onChangeUseConsumableForAttack.bind(this));
@@ -206,6 +207,21 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       },
       default: 'ok',
     }).render(true);
+  }
+
+  private async _onCreateAttachment():Promise<void> {
+    const newConsumableData = {
+      name: game.i18n.localize("TWODSIX.Items.Equipment.NewAttachment"),
+      type: "consumable",
+      system: {
+        subtype: "other",
+        quantity: 1,
+        isAttachment: true
+      }
+    };
+    const newConsumable = await this.item.actor?.createEmbeddedDocuments("Item", [newConsumableData]) || {};
+    await (<TwodsixItem>this.item).addConsumable(newConsumable[0].id);
+    this.render();
   }
 
   private async _onChangeUseConsumableForAttack(event): Promise<void> {

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -220,6 +220,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       }
     };
     const newConsumable = await this.item.actor?.createEmbeddedDocuments("Item", [newConsumableData]) || {};
+    //newConsumable.update({"system.isAttachment": true});
     await (<TwodsixItem>this.item).addConsumable(newConsumable[0].id);
     this.render();
   }

--- a/src/module/utils/dice.ts
+++ b/src/module/utils/dice.ts
@@ -1,0 +1,206 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+//Code directly from dnd5e system
+/**
+ * A standardized helper function for simplifying the constant parts of a multipart roll formula.
+ *
+ * @param {string} formula                          The original roll formula.
+ * @param {object} [options]                        Formatting options.
+ * @param {boolean} [options.preserveFlavor=false]  Preserve flavor text in the simplified formula.
+ *
+ * @returns {string}  The resulting simplified formula.
+ */
+export function simplifyRollFormula(formula, { preserveFlavor=false } = {}):string {
+  // Create a new roll and verify that the formula is valid before attempting simplification.
+  let roll;
+  try {
+    roll = new Roll(formula);
+  } catch(err) {
+    console.warn(`Unable to simplify formula '${formula}': ${err}`);
+  }
+  Roll.validate(roll.formula);
+
+  // Optionally strip flavor annotations.
+  if ( !preserveFlavor ) {
+    roll.terms = Roll.parse(roll.formula.replace(RollTerm.FLAVOR_REGEXP, ""));
+  }
+  // Perform arithmetic simplification on the existing roll terms.
+  roll.terms = _simplifyOperatorTerms(roll.terms);
+
+  if ( /[*/]/.test(roll.formula) ) {
+    return ( roll.isDeterministic ) && ( !/\[/.test(roll.formula) || !preserveFlavor )
+      ? roll.evaluate({ async: false }).total.toString()
+      : roll.constructor.getFormula(roll.terms);
+  }
+
+  // Flatten the roll formula and eliminate string terms.
+  roll.terms = _expandParentheticalTerms(roll.terms);
+  roll.terms = Roll.simplifyTerms(roll.terms);
+
+  // Group terms by type and perform simplifications on various types of roll term.
+  // eslint-disable-next-line prefer-const
+  let { poolTerms, diceTerms, mathTerms, numericTerms } = _groupTermsByType(roll.terms);
+  numericTerms = _simplifyNumericTerms(numericTerms ?? []);
+  diceTerms = _simplifyDiceTerms(diceTerms ?? []);
+
+  // Recombine the terms into a single term array and remove an initial + operator if present.
+  const simplifiedTerms = [diceTerms, poolTerms, mathTerms, numericTerms].flat().filter(Boolean);
+  if ( simplifiedTerms[0]?.operator === "+" ) {
+    simplifiedTerms.shift();
+  }
+  return roll.constructor.getFormula(simplifiedTerms);
+}
+
+/* -------------------------------------------- */
+
+/**
+ * A helper function to perform arithmetic simplification and remove redundant operator terms.
+ * @param {RollTerm[]} terms  An array of roll terms.
+ * @returns {RollTerm[]}      A new array of roll terms with redundant operators removed.
+ */
+function _simplifyOperatorTerms(terms) {
+  return terms.reduce((acc, term) => {
+    const prior = acc[acc.length - 1];
+    const ops = new Set([prior?.operator, term.operator]);
+
+    // If one of the terms is not an operator, add the current term as is.
+    if ( ops.has(undefined) ) {
+      acc.push(term);
+    // Replace consecutive "+ -" operators with a "-" operator.
+    } else if ( (ops.has("+")) && (ops.has("-")) ) {
+      acc.splice(-1, 1, new OperatorTerm({ operator: "-" }));
+    // Replace double "-" operators with a "+" operator.
+    } else if ( (ops.has("-")) && (ops.size === 1) ) {
+      acc.splice(-1, 1, new OperatorTerm({ operator: "+" }));
+    // Don't include "+" operators that directly follow "+", "*", or "/". Otherwise, add the term as is.
+    } else if ( !ops.has("+") ) {
+      acc.push(term);
+    }
+    return acc;
+  }, []);
+}
+
+/* -------------------------------------------- */
+
+/**
+ * A helper function for combining unannotated numeric terms in an array into a single numeric term.
+ * @param {object[]} terms  An array of roll terms.
+ * @returns {object[]}      A new array of terms with unannotated numeric terms combined into one.
+ */
+function _simplifyNumericTerms(terms) {
+  const simplified = [];
+  const { annotated, unannotated } = _separateAnnotatedTerms(terms);
+
+  // Combine the unannotated numerical bonuses into a single new NumericTerm.
+  if ( unannotated.length ) {
+    const staticBonus = Roll.safeEval(Roll.getFormula(unannotated));
+    if ( staticBonus === 0 ) {
+      return [...annotated];
+    }
+    // If the staticBonus is greater than 0, add a "+" operator so the formula remains valid.
+    if ( staticBonus > 0 ) {
+      simplified.push(new OperatorTerm({ operator: "+"}));
+    }
+    simplified.push(new NumericTerm({ number: staticBonus} ));
+  }
+  return [...simplified, ...annotated];
+}
+
+/* -------------------------------------------- */
+
+/**
+ * A helper function to group dice of the same size and sign into single dice terms.
+ * @param {object[]} terms  An array of DiceTerms and associated OperatorTerms.
+ * @returns {object[]}      A new array of simplified dice terms.
+ */
+function _simplifyDiceTerms(terms) {
+  const { annotated, unannotated } = _separateAnnotatedTerms(terms);
+
+  // Split the unannotated terms into different die sizes and signs
+  const diceQuantities = unannotated.reduce((obj, curr, i) => {
+    if ( curr instanceof OperatorTerm ) {
+      return obj;
+    }
+    const key = `${unannotated[i - 1].operator}${curr.faces}`;
+    obj[key] = (obj[key] ?? 0) + curr.number;
+    return obj;
+  }, {});
+
+  // Add new die and operator terms to simplified for each die size and sign
+  const simplified = Object.entries(diceQuantities).flatMap(([key, number]) => ([
+    new OperatorTerm({ operator: key.charAt(0) }),
+    new Die({ number, faces: parseInt(key.slice(1)) })
+  ]));
+  return [...simplified, ...annotated];
+}
+
+/* -------------------------------------------- */
+
+/**
+ * A helper function to extract the contents of parenthetical terms into their own terms.
+ * @param {object[]} terms  An array of roll terms.
+ * @returns {object[]}      A new array of terms with no parenthetical terms.
+ */
+function _expandParentheticalTerms(terms) {
+  terms = terms.reduce((acc, term) => {
+    if ( term instanceof ParentheticalTerm ) {
+      if ( term.isDeterministic ) {
+        term = new NumericTerm({ number: Roll.safeEval(term.term) });
+      } else {
+        const subterms = new Roll(term.term).terms;
+        term = _expandParentheticalTerms(subterms);
+      }
+    }
+    acc.push(term);
+    return acc;
+  }, []);
+  return _simplifyOperatorTerms(terms.flat());
+}
+
+/* -------------------------------------------- */
+
+/**
+ * A helper function to group terms into PoolTerms, DiceTerms, MathTerms, and NumericTerms.
+ * MathTerms are included as NumericTerms if they are deterministic.
+ * @param {RollTerm[]} terms  An array of roll terms.
+ * @returns {object}          An object mapping term types to arrays containing roll terms of that type.
+ */
+function _groupTermsByType(terms) {
+  // Add an initial operator so that terms can be rearranged arbitrarily.
+  if ( !(terms[0] instanceof OperatorTerm) ) {
+    terms.unshift(new OperatorTerm({ operator: "+" }));
+  }
+
+  return terms.reduce((obj, term, i) => {
+    let type;
+    if ( term instanceof DiceTerm ) {
+      type = DiceTerm;
+    } else if ( (term instanceof MathTerm) && (term.isDeterministic) ) {
+      type = NumericTerm;
+    } else {
+      type = term.constructor;
+    }
+    const key = `${type.name.charAt(0).toLowerCase()}${type.name.substring(1)}s`;
+
+    // Push the term and the preceding OperatorTerm.
+    (obj[key] = obj[key] ?? []).push(terms[i - 1], term);
+    return obj;
+  }, {});
+}
+
+/* -------------------------------------------- */
+
+/**
+ * A helper function to separate annotated terms from unannotated terms.
+ * @param {object[]} terms     An array of DiceTerms and associated OperatorTerms.
+ * @returns {Array | Array[]}  A pair of term arrays, one containing annotated terms.
+ */
+function _separateAnnotatedTerms(terms) {
+  return terms.reduce((obj, curr, i) => {
+    if ( curr instanceof OperatorTerm ) {
+      return obj;
+    }
+    obj[curr.flavor ? "annotated" : "unannotated"].push(terms[i - 1], curr);
+    return obj;
+  }, { annotated: [], unannotated: [] });
+}

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -250,6 +250,7 @@ export interface Traveller {
   woundedEffect:number;
   characteristicEdit:boolean;
   movement:MovementData;
+  hideStoredItems: StoredItemView;
 }
 
 export interface Animal {
@@ -299,6 +300,15 @@ export interface MovementData {
 export interface Age {
   value:number;
   min:number;
+}
+
+export interface StoredItemView {
+  weapon:boolean;
+  armor:boolean;
+  augment:boolean;
+  equipment:boolean;
+  consumable:boolean;
+  attachment:boolean;
 }
 
 export interface Characteristics {

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -490,6 +490,8 @@ export interface Consumable extends GearTemplate, LinkTemplate {
   subtype:string;
   location:string[];
   armorPiercing:number;
+  bonusDamage:string;
+  isAttachment:boolean;
 }
 
 export interface Equipment extends GearTemplate, LinkTemplate {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -96,6 +96,8 @@
         "CreateItem": "Create Item",
         "Damage": "Damage",
         "DeleteItem": "Delete Item",
+        "DisplayStored": "Displaying stored items",
+        "HideStored": "Hidding stored items",
         "EQUIPMENT": "EQUIPMENT",
         "EditItem": "Edit Item",
         "Effect": "Effect",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -86,6 +86,7 @@
       "Items": {
         "Amount": "Amount",
         "ARMOR": "ARMOR",
+        "ATTACHMENTS": "ATTACHMENTS",
         "AUGMENTS": "AUGMENTS",
         "Ammo": "Ammo",
         "Armor": "Armor",
@@ -357,7 +358,10 @@
         "ShortDescription": "Short Description",
         "SkillModifier": "Skill Modifier",
         "TL": "TL",
-        "Weight": "Weight"
+        "Weight": "Weight",
+        "isAttachment": "Attachment?",
+        "NewAttachment": "New Attachment",
+        "BonusDamage": "Bonus Damage"
       },
       "Items": {
         "AssignArmor": "Assign Armor",
@@ -418,6 +422,7 @@
         "Count": "Count",
         "ArmorPiercing": "Armor Piercing Value",
         "DropConsumablesHere": "You can drop consumables here.",
+        "DropAttachmentsHere": "You can drop attachments here.",
         "RemoveConsumable": "Remove consumable",
         "RemoveConsumableFrom": "Remove consumable _CONSUMABLE_NAME_ from _ITEM_NAME_?"
       },

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -188,7 +188,7 @@ input[type=number]::-webkit-outer-spin-button, input[type=number]::-webkit-inner
 }
 
 input[type=number] {
-  appearance: texfield;
+  appearance: textfield;
   -moz-appearance: textfield;
 }
 

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1528,7 +1528,7 @@ input.item-value-edit {
   display: inline;
 }
 
-.skill:nth-of-type(even) {
+.skill:nth-of-type(even), .even-skill {
   background: var(--s2d6-skill-list-even);
 }
 

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1877,6 +1877,8 @@ span.total-output {
     "ship-image ship-requirements"
     "ship-deck .";
   /* position: fixed; */
+  min-height: 305px;
+  max-height: 305px;
 }
 
 img.ship-mask-bg {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1346,6 +1346,7 @@ a.actor-notes-tab.active {
   padding-left: 0.3em;
   margin-right: 0.5em;
   width: fit-content;
+  margin-bottom: -1px;
 }
 
 .items-armor {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1100,7 +1100,7 @@ input.item-value-edit {
   /* padding-left: 1ch; */
 }
 
-.skill:nth-of-type(even) {
+.skill:nth-of-type(even), .even-skill {
   background: var(--s2d6-skill-list-even);
 }
 

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -927,6 +927,7 @@ a.skill-tab.active, a.item-tab.active, a.finances-tab.active, a.info-tab.active,
   border: 1px solid var(--s2d6-background-semi-opaque);
   padding-left: 0.4em;
   width: fit-content;
+  margin-bottom: -1px;
 }
 
 .items-armor {

--- a/static/template.json
+++ b/static/template.json
@@ -578,7 +578,9 @@
       "type": "consumable",
       "subtype": "other",
       "location": ["inventory", "storage"],
-      "armorPiercing": 0
+      "armorPiercing": 0,
+      "bonusDamage": "",
+      "isAttachment": false
     },
     "component": {
       "templates": ["gearTemplate", "referenceTemplate"],

--- a/static/template.json
+++ b/static/template.json
@@ -150,6 +150,14 @@
         "walk": 10,
         "units": "m",
         "hover": false
+      },
+      "hideStoredItems": {
+        "weapon": false,
+        "armor": false,
+        "augment": false,
+        "equipment": false,
+        "consumable": false,
+        "attachment": false
       }
     },
     "ship": {

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -17,7 +17,7 @@
   </div>
 </div>
 {{else}}
-<div class="items-weapons-abilities" data-consumable-id="{{id}}">
+<div class="consumable-row" data-consumable-id="{{id}}">
   <div class="wrapper">
     {{name}}
   </div>

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -1,3 +1,4 @@
+{{#unless system.isAttachment}}
 <div class="consumable-row" data-consumable-id="{{id}}">
   <div class="wrapper">
     {{name}}:
@@ -15,3 +16,10 @@
     {{/with}}
   </div>
 </div>
+{{else}}
+<div class="items-weapons-abilities" data-consumable-id="{{id}}">
+  <div class="wrapper">
+    {{name}}
+  </div>
+</div>
+{{/unless}}

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -11,11 +11,19 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Range"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Damage"}}</span>
-      <span class="item-name centre"><a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="weapon"><i
-        class="fa-solid fa-plus"></i></a></span>
+      <span class="item-name centre">
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="weapon"><i class="fa-solid fa-plus"></i></a>
+        <a class="item-control item-viewToggle" data-item-type="weapon">
+          {{#unless system.hideStoredItems.weapon}}
+          <i class="fa-solid fa-eye" data-tooltip='{{localize "TWODSIX.Actor.Items.DisplayStored"}}'></i></a>
+          {{else}}
+          <i class="fa-solid fa-eye-slash" data-tooltip='{{localize "TWODSIX.Actor.Items.HideStored"}}'></i></a>
+          {{/unless}}
+      </span>
     </div>
     <section class="item-list">
       {{#each_sort_item container.weapon as |item id|}}
+      {{#unless (twodsix_hideItem ../system.hideStoredItems.weapon item.system.equipped)}}
       <div class="item gear" data-item-id="{{item.id}}">
         <ol class="ol-no-indent">
           <li class="flexrow">
@@ -65,6 +73,7 @@
         {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
         {{/each}}
       </div>
+      {{/unless}}
       {{/each_sort_item}}
     </section>
   </div>
@@ -79,11 +88,20 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Armor"}}</span>
-      <span class="item-name centre"><a class="item-control item-create" data-tooltip="Create item" data-type="armor"><i class="fa-solid fa-plus"></i></a></span>
+      <span class="item-name centre">
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="armor"><i class="fa-solid fa-plus"></i></a>
+        <a class="item-control item-viewToggle" data-item-type="armor">
+          {{#unless system.hideStoredItems.armor}}
+          <i class="fa-solid fa-eye" data-tooltip='{{localize "TWODSIX.Actor.Items.DisplayStored"}}'></i></a>
+          {{else}}
+          <i class="fa-solid fa-eye-slash" data-tooltip='{{localize "TWODSIX.Actor.Items.HideStored"}}'></i></a>
+          {{/unless}}
+      </span>
     </div>
 
     <section class="item-list">
       {{#each_sort_item container.armor as |item id|}}
+      {{#unless (twodsix_hideItem ../system.hideStoredItems.armor item.system.equipped)}}
       <div class="item gear" data-item-id="{{item.id}}">
         <ol class="ol-no-indent">
           <li class="flexrow" >
@@ -109,6 +127,7 @@
         {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
         {{/each}}
       </div>
+      {{/unless}}
       {{/each_sort_item}}
     </section>
   </div>
@@ -123,11 +142,19 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Effect"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Location"}}</span>
-      <span class="item-name centre"><a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="augment"><i
-        class="fa-solid fa-plus"></i></a></span>
+      <span class="item-name centre">
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="augment"><i class="fa-solid fa-plus"></i></a>
+        <a class="item-control item-viewToggle" data-item-type="augment">
+          {{#unless system.hideStoredItems.augment}}
+          <i class="fa-solid fa-eye" data-tooltip='{{localize "TWODSIX.Actor.Items.DisplayStored"}}'></i></a>
+          {{else}}
+          <i class="fa-solid fa-eye-slash" data-tooltip='{{localize "TWODSIX.Actor.Items.HideStored"}}'></i></a>
+          {{/unless}}
+      </span>
     </div>
     <section class="item-list">
       {{#each_sort_item container.augment as |item id|}}
+      {{#unless (twodsix_hideItem ../system.hideStoredItems.augment item.system.equipped)}}
       <div class="item gear" data-item-id="{{item.id}}">
         <ol class="ol-no-indent">
           <li class="flexrow">
@@ -152,7 +179,8 @@
         {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
         {{/each}}
       </div>
-    {{/each_sort_item}}
+      {{/unless}}
+      {{/each_sort_item}}
     </section>
   </div>
 
@@ -165,11 +193,19 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.ShortDescr"}}</span>
-      <span class="item-name centre"><a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="equipment"><i
-        class="fa-solid fa-plus"></i></a></span>
+      <span class="item-name centre">
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="equipment"><i class="fa-solid fa-plus"></i></a>
+        <a class="item-control item-viewToggle" data-item-type="equipment">
+          {{#unless system.hideStoredItems.equipment}}
+          <i class="fa-solid fa-eye" data-tooltip='{{localize "TWODSIX.Actor.Items.DisplayStored"}}'></i></a>
+          {{else}}
+          <i class="fa-solid fa-eye-slash" data-tooltip='{{localize "TWODSIX.Actor.Items.HideStored"}}'></i></a>
+          {{/unless}}
+      </span>
     </div>
       <section class="item-list">
         {{#each_sort_item container.equipment as |item id|}}
+        {{#unless (twodsix_hideItem ../system.hideStoredItems.equipment item.system.equipped)}}
         <div class="item gear" data-item-id="{{item.id}}">
           <ol class="ol-no-indent">
             <li class="flexrow">
@@ -194,6 +230,7 @@
         {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
         {{/each}}
         </div>
+        {{/unless}}
         {{/each_sort_item}}
       </section>
   </div>
@@ -209,14 +246,19 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Count"}}</span>
       <span class="item-name centre">
-        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable" data-subtype = "consumable">
-          <i class="fa-solid fa-plus"></i>
-        </a>
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable" data-subtype="consumable"><i class="fa-solid fa-plus"></i></a>
+        <a class="item-control item-viewToggle" data-item-type="consumable">
+          {{#unless system.hideStoredItems.consumable}}
+          <i class="fa-solid fa-eye" data-tooltip='{{localize "TWODSIX.Actor.Items.DisplayStored"}}'></i></a>
+          {{else}}
+          <i class="fa-solid fa-eye-slash" data-tooltip='{{localize "TWODSIX.Actor.Items.HideStored"}}'></i></a>
+          {{/unless}}
       </span>
     </div>
 
     <div class="item-list">
       {{#each_sort_item container.consumable as |item id|}}
+      {{#unless (twodsix_hideItem ../system.hideStoredItems.consumable item.system.equipped)}}
         {{#unless item.system.isAttachment}}
         <div class="item gear" data-item-id="{{item.id}}">
               <ol class="ol-no-indent">
@@ -242,6 +284,7 @@
             {{/each}}
         </div>
         {{/unless}}
+        {{/unless}}
       {{/each_sort_item}}
     </div>
  </div>
@@ -257,13 +300,18 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
       <span class="item-name centre">
-        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable" data-subtype = "attachment">
-          <i class="fa-solid fa-plus"></i>
-        </a>
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable" data-subtype="attachment"><i class="fa-solid fa-plus"></i></a>
+        <a class="item-control item-viewToggle" data-item-type="attachment">
+          {{#unless system.hideStoredItems.attachment}}
+          <i class="fa-solid fa-eye" data-tooltip='{{localize "TWODSIX.Actor.Items.DisplayStored"}}'></i></a>
+          {{else}}
+          <i class="fa-solid fa-eye-slash" data-tooltip='{{localize "TWODSIX.Actor.Items.HideStored"}}'></i></a>
+          {{/unless}}
       </span>
     </div>
     <div class="item-list">
       {{#each_sort_item container.consumable as |item id|}}
+      {{#unless (twodsix_hideItem ../system.hideStoredItems.attachment item.system.equipped)}}
       {{#if item.system.isAttachment}}
       <div class="item gear" data-item-id="{{item.id}}">
         <ol class="ol-no-indent">
@@ -286,6 +334,7 @@
         </ol>
       </div>
       {{/if}}
+      {{/unless}}
       {{/each_sort_item}}
     </div>
   </div>

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -209,7 +209,7 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Count"}}</span>
       <span class="item-name centre">
-        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable">
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable" data-subtype = "consumable">
           <i class="fa-solid fa-plus"></i>
         </a>
       </span>
@@ -255,9 +255,9 @@
       <span class="item-name">{{localize "TWODSIX.Actor.Items.Name"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
-      <span></span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
       <span class="item-name centre">
-        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable">
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable" data-subtype = "attachment">
           <i class="fa-solid fa-plus"></i>
         </a>
       </span>
@@ -275,7 +275,7 @@
                 <span class="item-name rollable">{{item.name}}</span>
                 <span class="item-name centre">{{twodsix_localizeConsumable item.system.subtype}}</span>
                 <input class= "item-value-edit" type="number" min="0" step="1" value="{{item.system.quantity}}"/>
-                <span class="item-name centre">{{item.system.currentCount}}/{{item.system.max}}</span>
+                <span class="item-name centre">{{item.system.techLevel}}</span>
                 <span class="item-controls centre">
                   <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{item.system.equipped}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
                   <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -238,6 +238,9 @@
           </span>
       </li>
     </ol>
+    {{#each item.system.consumableData as |consumableData|}}
+    {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
+    {{/each}}
   </div>
   {{/unless}}
   {{/each_sort_item}}

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -198,7 +198,6 @@
         {{/each_sort_item}}
       </section>
   </div>
-</div>
 
  <!---- Consumables ---->
  <div>
@@ -217,74 +216,78 @@
       </span>
     </div>
 
-  {{#each_sort_item container.consumable as |item id|}}
-  {{#unless item.system.isAttachment}}
-  <div class="item gear">
-    <ol class="ol-no-indent">
-      <li class="item flexrow" data-item-id="{{item.id}}">
-          <span class="items-consumable">
-            <span class="mini-dice rollable" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}">
-              <i class="fa-solid fa-dice" alt="d6" ></i>
-            </span>
-            <span class="item-name rollable">{{item.name}}</span>
-            <span class="item-name centre">{{twodsix_localizeConsumable item.system.subtype}}</span>
-            <input class= "item-value-edit" type="number" min="0" step="1" value="{{item.system.quantity}}"/>
-            <span class="item-name centre">{{item.system.currentCount}}/{{item.system.max}}</span>
-            <span class="item-controls centre">
-              <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{item.system.equipped}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
-              <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
-              <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
-            </span>
-          </span>
-      </li>
-    </ol>
-    {{#each item.system.consumableData as |consumableData|}}
-    {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
-    {{/each}}
-  </div>
-  {{/unless}}
-  {{/each_sort_item}}
-</div>
+    <div class="item-list">
+      {{#each_sort_item container.consumable as |item id|}}
+        {{#unless item.system.isAttachment}}
+        <div class="item gear" data-item-id="{{item.id}}">
+              <ol class="ol-no-indent">
+                <li class="flexrow">
+                    <span class="items-consumable">
+                      <span class="mini-dice rollable" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}">
+                        <i class="fa-solid fa-dice" alt="d6" ></i>
+                      </span>
+                      <span class="item-name rollable">{{item.name}}</span>
+                      <span class="item-name centre">{{twodsix_localizeConsumable item.system.subtype}}</span>
+                      <input class= "item-value-edit" type="number" min="0" step="1" value="{{item.system.quantity}}"/>
+                      <span class="item-name centre">{{item.system.currentCount}}/{{item.system.max}}</span>
+                      <span class="item-controls centre">
+                        <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{item.system.equipped}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+                        <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
+                        <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
+                      </span>
+                    </span>
+                </li>
+              </ol>
+            {{#each item.system.consumableData as |consumableData|}}
+            {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
+            {{/each}}
+        </div>
+        {{/unless}}
+      {{/each_sort_item}}
+    </div>
+ </div>
 
-<!---- Attachments ---->
-<div>
-  <span class="pusher"></span>
-  <span class="item-title">{{localize "TWODSIX.Actor.Items.ATTACHMENTS"}}</span>
-  <div class="items-consumable gear-header">
-    <span></span>
-    <span class="item-name">{{localize "TWODSIX.Actor.Items.Name"}}</span>
-    <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
-    <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
-    <span></span>
-    <span class="item-name centre">
-      <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable">
-        <i class="fa-solid fa-plus"></i>
-      </a>
-    </span>
+  <!---- Attachments ---->
+  <div>
+    <span class="pusher"></span>
+    <span class="item-title">{{localize "TWODSIX.Actor.Items.ATTACHMENTS"}}</span>
+    <div class="items-consumable gear-header">
+      <span></span>
+      <span class="item-name">{{localize "TWODSIX.Actor.Items.Name"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
+      <span></span>
+      <span class="item-name centre">
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable">
+          <i class="fa-solid fa-plus"></i>
+        </a>
+      </span>
+    </div>
+    <div class="item-list">
+      {{#each_sort_item container.consumable as |item id|}}
+      {{#if item.system.isAttachment}}
+      <div class="item gear" data-item-id="{{item.id}}">
+        <ol class="ol-no-indent">
+          <li class="flexrow" >
+              <span class="items-consumable">
+                <span class="mini-dice rollable" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}">
+                  <i class="fa-solid fa-dice" alt="d6" ></i>
+                </span>
+                <span class="item-name rollable">{{item.name}}</span>
+                <span class="item-name centre">{{twodsix_localizeConsumable item.system.subtype}}</span>
+                <input class= "item-value-edit" type="number" min="0" step="1" value="{{item.system.quantity}}"/>
+                <span class="item-name centre">{{item.system.currentCount}}/{{item.system.max}}</span>
+                <span class="item-controls centre">
+                  <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{item.system.equipped}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+                  <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
+                  <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
+                </span>
+              </span>
+          </li>
+        </ol>
+      </div>
+      {{/if}}
+      {{/each_sort_item}}
+    </div>
   </div>
-
-{{#each_sort_item container.consumable as |item id|}}
-{{#if item.system.isAttachment}}
-<div class="item gear">
-  <ol class="ol-no-indent">
-    <li class="item flexrow" data-item-id="{{item.id}}">
-        <span class="items-consumable">
-          <span class="mini-dice rollable" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}">
-            <i class="fa-solid fa-dice" alt="d6" ></i>
-          </span>
-          <span class="item-name rollable">{{item.name}}</span>
-          <span class="item-name centre">{{twodsix_localizeConsumable item.system.subtype}}</span>
-          <input class= "item-value-edit" type="number" min="0" step="1" value="{{item.system.quantity}}"/>
-          <span class="item-name centre">{{item.system.currentCount}}/{{item.system.max}}</span>
-          <span class="item-controls centre">
-            <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{item.system.equipped}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
-            <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
-            <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
-          </span>
-        </span>
-    </li>
-  </ol>
-</div>
-{{/if}}
-{{/each_sort_item}}
 </div>

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -144,12 +144,6 @@
       <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Location"}}</span>
       <span class="item-name centre">
         <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="augment"><i class="fa-solid fa-plus"></i></a>
-        <a class="item-control item-viewToggle" data-item-type="augment">
-          {{#unless system.hideStoredItems.augment}}
-          <i class="fa-solid fa-eye" data-tooltip='{{localize "TWODSIX.Actor.Items.DisplayStored"}}'></i></a>
-          {{else}}
-          <i class="fa-solid fa-eye-slash" data-tooltip='{{localize "TWODSIX.Actor.Items.HideStored"}}'></i></a>
-          {{/unless}}
       </span>
     </div>
     <section class="item-list">

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -1,8 +1,7 @@
 {{!-- Sheet Body --}}
 <div class="character-tabs-info character-inventory">
+   <!---- WEAPONS ---->
   <div><span class="pusher"></span>
-
-    <!---- WEAPONS ---->
     <span class="item-title">{{localize "TWODSIX.Actor.Items.WEAPONS"}}</span>
     <div class="items-weapons gear-header">
       <span></span>

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -59,6 +59,9 @@
             {{/if}}
           </li>
         </ol>
+        {{#each item.system.attachmentData as |attachmentData|}}
+        {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" attachmentData}}
+        {{/each}}
         {{#each item.system.consumableData as |consumableData|}}
         {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
         {{/each}}
@@ -100,6 +103,9 @@
             </span>
           </li>
         </ol>
+        {{#each item.system.attachmentData as |attachmentData|}}
+        {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" attachmentData}}
+        {{/each}}
         {{#each item.system.consumableData as |consumableData|}}
         {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
         {{/each}}
@@ -140,6 +146,9 @@
             </span>
           </li>
         </ol>
+        {{#each item.system.attachmentData as |attachmentData|}}
+        {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" attachmentData}}
+        {{/each}}
         {{#each item.system.consumableData as |consumableData|}}
         {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
         {{/each}}
@@ -179,9 +188,12 @@
                 </span>
             </li>
           </ol>
-          {{#each item.system.consumableData as |consumableData|}}
-          {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
-          {{/each}}
+        {{#each item.system.attachmentData as |attachmentData|}}
+        {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" attachmentData}}
+        {{/each}}
+        {{#each item.system.consumableData as |consumableData|}}
+        {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
+        {{/each}}
         </div>
         {{/each_sort_item}}
       </section>
@@ -206,6 +218,7 @@
     </div>
 
   {{#each_sort_item container.consumable as |item id|}}
+  {{#unless item.system.isAttachment}}
   <div class="item gear">
     <ol class="ol-no-indent">
       <li class="item flexrow" data-item-id="{{item.id}}">
@@ -225,9 +238,50 @@
           </span>
       </li>
     </ol>
-    {{#each item.system.consumableData as |consumableData|}}
-    {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
-    {{/each}}
   </div>
+  {{/unless}}
   {{/each_sort_item}}
+</div>
+
+<!---- Attachments ---->
+<div>
+  <span class="pusher"></span>
+  <span class="item-title">{{localize "TWODSIX.Actor.Items.ATTACHMENTS"}}</span>
+  <div class="items-consumable gear-header">
+    <span></span>
+    <span class="item-name">{{localize "TWODSIX.Actor.Items.Name"}}</span>
+    <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Subtype"}}</span>
+    <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
+    <span></span>
+    <span class="item-name centre">
+      <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="consumable">
+        <i class="fa-solid fa-plus"></i>
+      </a>
+    </span>
+  </div>
+
+{{#each_sort_item container.consumable as |item id|}}
+{{#if item.system.isAttachment}}
+<div class="item gear">
+  <ol class="ol-no-indent">
+    <li class="item flexrow" data-item-id="{{item.id}}">
+        <span class="items-consumable">
+          <span class="mini-dice rollable" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}">
+            <i class="fa-solid fa-dice" alt="d6" ></i>
+          </span>
+          <span class="item-name rollable">{{item.name}}</span>
+          <span class="item-name centre">{{twodsix_localizeConsumable item.system.subtype}}</span>
+          <input class= "item-value-edit" type="number" min="0" step="1" value="{{item.system.quantity}}"/>
+          <span class="item-name centre">{{item.system.currentCount}}/{{item.system.max}}</span>
+          <span class="item-controls centre">
+            <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{item.system.equipped}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+            <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
+            <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
+          </span>
+        </span>
+    </li>
+  </ol>
+</div>
+{{/if}}
+{{/each_sort_item}}
 </div>

--- a/static/templates/actors/parts/actor/actor-npc-consumable.html
+++ b/static/templates/actors/parts/actor/actor-npc-consumable.html
@@ -1,4 +1,5 @@
 <div class="consumable-row npc" data-consumable-id="{{id}}">
+  {{#unless system.isAttachment}}
   <div class="wrapper">
     {{#with system}}
     <span class="consumable-count">
@@ -10,4 +11,9 @@
     </span>
     {{/with}}
   </div>
+  {{else}}
+  <div class="wrapper">
+    {{name}}
+  </div>
+  {{/unless}}
 </div>

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -66,7 +66,7 @@
 {{/each_sort_item}}
 </section>
 {{#if settings.hideUntrainedSkills}}
-<div class="skill">
+{{#if (twodsix_isOdd numberOfSkills)}}<div class="skill">{{else}}<div class="skill even-skill">{{/if}}
   <span class="item skill-container" data-item-id="{{untrainedSkill.id}}" draggable="false">
     <ol class="ol-no-indent">
       <li class="flexrow" >

--- a/static/templates/actors/parts/vehicle/weapon-components.html
+++ b/static/templates/actors/parts/vehicle/weapon-components.html
@@ -13,9 +13,8 @@
   </div>
 
   <div class="grid-columns-weapon">
-    {{#each component}}
+    {{#each componentObject}}
     {{#each this as |item id|}}
-
     <div class="grid-columns-single-row">
       <ol class="ol-no-indent">
         <li class="item weapons-stored " data-item-id="{{item.id}}">

--- a/static/templates/items/consumable-sheet.html
+++ b/static/templates/items/consumable-sheet.html
@@ -3,6 +3,13 @@
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
     <div class="item-data">
+      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Subtype"}}</label>
+        <select name="system.subtype">
+          {{selectOptions config.CONSUMABLES selected = system.subtype localize = true}}
+        </select>
+    </div>
+
+    <div class="item-data">
       <label class="resource-label">{{localize "TWODSIX.Items.Equipment.isAttachment"}}</label>
       <input type="checkbox" class="checkbox" name="system.isAttachment" {{checked system.isAttachment}} data-dtype="Boolean" />
     </div>
@@ -25,12 +32,6 @@
             /
             <input id="system.max" class="form-consumable-count" name="system.max" type="number" value="{{system.max}}" data-dtype="Number"/>
           </div>
-      </div>
-      <div class="item-data">
-        <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Subtype"}}</label>
-          <select name="system.subtype">
-            {{selectOptions config.CONSUMABLES selected = system.subtype localize = true}}
-          </select>
       </div>
     {{/unless}}
 

--- a/static/templates/items/consumable-sheet.html
+++ b/static/templates/items/consumable-sheet.html
@@ -3,33 +3,45 @@
     {{> "systems/twodsix/templates/items/parts/common-parts.html"}}
 
     <div class="item-data">
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.isAttachment"}}</label>
+      <input type="checkbox" class="checkbox" name="system.isAttachment" {{checked system.isAttachment}} data-dtype="Boolean" />
+    </div>
+
+    <div class="item-data">
       <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Quantity"}}</label>
       <input class="form-input" id="system.quantity" type="number" name="system.quantity" value="{{system.quantity}}" data-dtype="Number"/>
     </div>
 
-    <div class="item-data">
-      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.ArmorPiercing"}}</label>
-      <input class="form-input" id="system.armorPiercing" type="number" name="system.armorPiercing" value="{{system.armorPiercing}}" data-dtype="Number" step ="1" oninput="this.value = Math.round(this.value);"/>
-    </div>
+    {{#unless system.isAttachment}}
+      <div class="item-data">
+        <label class="resource-label">{{localize "TWODSIX.Items.Consumable.ArmorPiercing"}}</label>
+        <input class="form-input" id="system.armorPiercing" type="number" name="system.armorPiercing" value="{{system.armorPiercing}}" data-dtype="Number" step ="1" oninput="this.value = Math.round(this.value);"/>
+      </div>
 
-    <div class="item-data">
-      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Count"}}</label>
-        <div>
-          <input id="system.currentCount" class="form-consumable-count" name="system.currentCount" type="number" value="{{system.currentCount}}" data-dtype="Number"/>
-          /
-          <input id="system.max" class="form-consumable-count" name="system.max" type="number" value="{{system.max}}" data-dtype="Number"/>
-        </div>
-    </div>
-    <div class="item-data">
-      <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Subtype"}}</label>
-        <select name="system.subtype">
-          {{selectOptions config.CONSUMABLES selected = system.subtype localize = true}}
-        </select>
-    </div>
+      <div class="item-data">
+        <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Count"}}</label>
+          <div>
+            <input id="system.currentCount" class="form-consumable-count" name="system.currentCount" type="number" value="{{system.currentCount}}" data-dtype="Number"/>
+            /
+            <input id="system.max" class="form-consumable-count" name="system.max" type="number" value="{{system.max}}" data-dtype="Number"/>
+          </div>
+      </div>
+      <div class="item-data">
+        <label class="resource-label">{{localize "TWODSIX.Items.Consumable.Subtype"}}</label>
+          <select name="system.subtype">
+            {{selectOptions config.CONSUMABLES selected = system.subtype localize = true}}
+          </select>
+      </div>
+    {{/unless}}
 
     <div class="item-data">
       <label class="resource-label">{{localize "TWODSIX.Items.Equipment.Weight"}}</label>
       <input class="form-input" id="system.weight" type="number" name="system.weight" value="{{system.weight}}" data-dtype="Number"/>
+    </div>
+
+    <div class="item-data">
+      <label class="resource-label">{{localize "TWODSIX.Items.Equipment.BonusDamage"}}</label>
+      <input class="form-input" id="system.bonusDamage" type="text" name="system.bonusDamage" value="{{system.bonusDamage}}" data-dtype="String"/>
     </div>
 
     <div class="item-descr">

--- a/static/templates/items/parts/consumables-part.html
+++ b/static/templates/items/parts/consumables-part.html
@@ -42,7 +42,7 @@
     </tbody>
   </table>
 </div>
-
+{{#iff system.type "!==" "consumable"}}
 <div class="form-section">
   {{localize "TWODSIX.Actor.Items.ATTACHMENTS"}}: <br>
   <table>
@@ -86,4 +86,5 @@
     </tbody>
   </table>
 </div>
+{{/iff}}
 {{/if}}

--- a/static/templates/items/parts/consumables-part.html
+++ b/static/templates/items/parts/consumables-part.html
@@ -17,25 +17,69 @@
     </thead>
     <tbody>
       {{#each system.consumableData as |consumable|}}
-      <tr class="consumable" data-consumable-id="{{consumable.id}}">
-        <td>{{consumable.name}}</td>
-        <td>{{twodsix_localizeConsumable consumable.system.subtype}}</td>
-        <td>{{consumable.system.quantity}}</td>
-        <td>{{consumable.system.currentCount}}/{{consumable.system.max}}</td>
-        <td class="centre">
-          <a class="consumable-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'>
-            <i class="fa-solid fa-pen-to-square"></i>
-          </a>
-          <a class="consumable-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'>
-            <i class="fa-solid fa-trash"></i>
-          </a>
-        </td>
-      </tr>
+        <tr class="consumable" data-consumable-id="{{consumable.id}}">
+          <td>{{consumable.name}}</td>
+          <td>{{twodsix_localizeConsumable consumable.system.subtype}}</td>
+          <td>{{consumable.system.quantity}}</td>
+          <td>{{consumable.system.currentCount}}/{{consumable.system.max}}</td>
+          <td class="centre">
+            <a class="consumable-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'>
+              <i class="fa-solid fa-pen-to-square"></i>
+            </a>
+            <a class="consumable-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'>
+              <i class="fa-solid fa-trash"></i>
+            </a>
+          </td>
+        </tr>
       {{/each}}
       {{#unless system.consumableData}}
       <tr>
         <td colspan="5">
           {{localize "TWODSIX.Items.Consumable.DropConsumablesHere"}}
+        </td>
+      </tr>
+      {{/unless}}
+    </tbody>
+  </table>
+</div>
+
+<div class="form-section">
+  {{localize "TWODSIX.Actor.Items.ATTACHMENTS"}}: <br>
+  <table>
+    <thead>
+      <tr>
+        <td>{{localize "TWODSIX.Actor.Items.Name"}}</td>
+        <td>{{localize "TWODSIX.Actor.Items.Subtype"}}</td>
+        <td>{{localize "TWODSIX.Actor.Items.Qty"}}</td>
+        <td></td>
+        <td class="centre">
+          <a class="attachment-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}'>
+            <i class="fa-solid fa-plus"></i>
+          </a>
+        </td>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each system.attachmentData as |attachment|}}
+        <tr class="consumable" data-consumable-id="{{attachment.id}}">
+          <td>{{attachment.name}}</td>
+          <td>{{twodsix_localizeConsumable attachment.system.subtype}}</td>
+          <td>{{attachment.system.quantity}}</td>
+          <td></td>
+          <td class="centre">
+            <a class="consumable-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'>
+              <i class="fa-solid fa-pen-to-square"></i>
+            </a>
+            <a class="consumable-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'>
+              <i class="fa-solid fa-trash"></i>
+            </a>
+          </td>
+        </tr>
+      {{/each}}
+      {{#unless system.attachmentData}}
+      <tr>
+        <td colspan="5">
+          {{localize "TWODSIX.Items.Consumable.DropAttachmentsHere"}}
         </td>
       </tr>
       {{/unless}}

--- a/static/templates/items/parts/useConsumableForRoll.html
+++ b/static/templates/items/parts/useConsumableForRoll.html
@@ -5,7 +5,9 @@
       <option value="">---</option>
       {{#select system.useConsumableForAttack}}
       {{#each system.consumableData as |consumable|}}
-      <option value="{{consumable.id}}">{{consumable.name}}</option>
+        {{#unless consumable.isAttachment}}
+          <option value="{{consumable.id}}">{{consumable.name}}</option>
+        {{/unless}}
       {{/each}}
       {{/select}}
     </select>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

features

* **What is the current behavior?** (You can also link to an open issue here)
-- QOL Challenges exist when using consumables


* **What is the new behavior (if this is a feature change)?**
-- allow magazines to have bonus damage attribute (thanks to @romkre)
-- add code to simplify roll formulas (from dnd5e)
-- add option to make a consumable an attachment (thanks to @DarkBearmancula)
-- add attachment section on actor item page
-- make drag-drop reordering work for consumables
-- fix ship system status indicators when there is more than one component of same subtype
-- fix display of armament components for vehicles
-- check for multiple GM's when applying condition modifiers
-- fix overflow issue on ship sheet
-- add a toggle to hide items that are stored on ship
-- make unconsciousness rolls always 8+ (per rules)
-- fix shading on untrained skill in skills list
-- document updates

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Addresses #1146 and #463 