### PR TITLE
fix: ship positions characteristic override

### DIFF
--- a/src/module/sheets/TwodsixShipPositionSheet.ts
+++ b/src/module/sheets/TwodsixShipPositionSheet.ts
@@ -67,7 +67,7 @@ export class TwodsixShipPositionSheet extends AbstractTwodsixItemSheet {
     if (skillData.characteristic && skillData.characteristic !== "NONE"){
       command += `/${skillData.characteristic}`;
     }
-    command += ` ${difficulties[skillData.difficulty].target}+`;
+    command += `/ ${difficulties[skillData.difficulty].target}+`;
 
     actions[randomID()] = {
       "order": Object.keys(actions).length,

--- a/src/module/sheets/TwodsixShipPositionSheet.ts
+++ b/src/module/sheets/TwodsixShipPositionSheet.ts
@@ -78,13 +78,8 @@ export class TwodsixShipPositionSheet extends AbstractTwodsixItemSheet {
         "command": command
       }
     };
-
-    if (Object.values(position.system.actions).find(ac => ac.command === command && ac.type === TWODSIX.SHIP_ACTION_TYPE.skillRoll)) {
-      return;  //fix odd situation where the drop is called twice.  Don't double add.
-    } else {
-      const newActions = duplicate(Object.assign(actions, newAction));
-      await position.update({ "system.actions": newActions });
-    }
+    const newActions = duplicate(Object.assign(actions, newAction));
+    await position.update({ "system.actions": newActions });
   }
 
   _onDragStart(event: DragEvent):void {

--- a/src/module/sheets/TwodsixShipPositionSheet.ts
+++ b/src/module/sheets/TwodsixShipPositionSheet.ts
@@ -67,16 +67,24 @@ export class TwodsixShipPositionSheet extends AbstractTwodsixItemSheet {
     if (skillData.characteristic && skillData.characteristic !== "NONE"){
       command += `/${skillData.characteristic}`;
     }
-    command += `/ ${difficulties[skillData.difficulty].target}+`;
+    command += ` ${difficulties[skillData.difficulty].target}+`;
 
-    actions[randomID()] = {
-      "order": Object.keys(actions).length,
-      "name": "New action",
-      "icon": skill.img ?? "",
-      "type": TWODSIX.SHIP_ACTION_TYPE.skillRoll,
-      "command": command
+    const newAction = {
+      [randomID()]: {
+        "order": Object.keys(actions).length,
+        "name": skill.name,
+        "icon": skill.img ?? "",
+        "type": TWODSIX.SHIP_ACTION_TYPE.skillRoll,
+        "command": command
+      }
     };
-    await position.update({ "system.actions": actions });
+
+    if (Object.values(position.system.actions).find(ac => ac.command === command && ac.type === TWODSIX.SHIP_ACTION_TYPE.skillRoll)) {
+      return;  //fix odd situation where the drop is called twice.  Don't double add.
+    } else {
+      const newActions = duplicate(Object.assign(actions, newAction));
+      await position.update({ "system.actions": newActions });
+    }
   }
 
   _onDragStart(event: DragEvent):void {

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -280,7 +280,9 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
         return false;
       } else {
         super._onDrop(event);
-        return this._onSortItem(event, droppedObject.toJSON());
+        if (droppedObject.actor) {
+          return this._onSortItem(event, droppedObject.toJSON());
+        }
       }
     } catch (err) {
       console.warn(err); // uncomment when debugging

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -72,12 +72,12 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
       tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "ship-positions"}],
       scrollY: [".ship-positions", ".ship-crew", ".ship-component", ".ship-storage", ".storage-wrapper", ".finances", ".ship-notes"],
       dragDrop: [
-        {dropSelector: ".ship-position-box", dragSelector: ".drag"},
+        //{dropSelector: ".ship-positions-list", dragSelector: ".drag"},
         {
           dropSelector: ".ship-position-box",
           dragSelector: ".ship-position-actor-token"
         },
-        {dragSelector: ".item", dropSelector: null}
+        {dragSelector: ".item", dropSelector: ".item-list"}
       ]
     });
   }
@@ -276,13 +276,10 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
       } else if (droppedObject.type === "vehicle") {
         await this._addVehicleToComponents(droppedObject, dropData.uuid);
       } else if (droppedObject.type === "animal") {
-        ui.notifications.warn("TWODSIX.Warnings.AnimalsCantHoldPositions");
+        ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.AnimalsCantHoldPositions"));
         return false;
       } else {
-        super._onDrop(event);
-        if (droppedObject.actor) {
-          return this._onSortItem(event, droppedObject.toJSON());
-        }
+        await super._onDrop(event); //re-order is handled in abstract actor onDrop
       }
     } catch (err) {
       console.warn(err); // uncomment when debugging

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -192,7 +192,7 @@ export class TwodsixDiceRoll {
 
     if (this.settings.itemRoll) {
       const itemValue = TwodsixDiceRoll.addSign(this.settings.rollModifiers.item);
-      flavor += this.settings.skillRoll ? ` & ${this.item.name}(${itemValue})` : ` ${usingString} ${this.item.name}(${itemValue})`;
+      flavor += this.settings.skillRoll ? ` & ${this.settings.itemName}(${itemValue})` : ` ${usingString} ${this.settings.itemName}(${itemValue})`;
 
       if (this.settings.rollModifiers.rof) {
         flavor += ` + ${game.i18n.localize("TWODSIX.Rolls.ROF")} (${TwodsixDiceRoll.addSign(this.settings.rollModifiers.rof)})`;

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -32,7 +32,7 @@ export class TwodsixRollSettings {
     let skillValue = 0;
     const difficulty = skill?.difficulty ? this.difficulties[skill.difficulty] : this.difficulties.Average;
     const gear = <Gear>anItem?.system;
-    const characteristic = aSkill ? skill.characteristic : (settings?.rollModifiers?.characteristic ?? "NONE");
+    const characteristic = settings?.rollModifiers?.characteristic ?? (aSkill ? skill.characteristic : "NONE");
 
     let woundsValue = 0;
     let encumberedValue = 0;

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -17,6 +17,7 @@ export class TwodsixRollSettings {
   //characteristic:string;
   skillRoll:boolean;
   itemRoll:boolean;
+  itemName: string;
   difficulties:CE_DIFFICULTIES | CEL_DIFFICULTIES;
   displayLabel:string;
   extraFlavor:string;
@@ -32,6 +33,7 @@ export class TwodsixRollSettings {
     let skillValue = 0;
     const difficulty = skill?.difficulty ? this.difficulties[skill.difficulty] : this.difficulties.Average;
     const gear = <Gear>anItem?.system;
+    const itemName = anItem?.name ?? "";
     const characteristic = settings?.rollModifiers?.characteristic ?? (aSkill ? skill.characteristic : "NONE");
 
     let woundsValue = 0;
@@ -76,6 +78,7 @@ export class TwodsixRollSettings {
     this.rollMode = settings?.rollMode ?? game.settings.get('core', 'rollMode');
     this.skillRoll = !!(settings?.skillRoll ?? aSkill);
     this.itemRoll = !!(anItem);
+    this.itemName = settings?.itemName ?? itemName;
     this.displayLabel = settings?.displayLabel ?? displayLabel;
     this.extraFlavor = settings?.extraFlavor ?? "";
     this.selectedTimeUnit = "none";
@@ -85,7 +88,7 @@ export class TwodsixRollSettings {
       characteristic: characteristic,
       wounds: woundsValue,
       skill: skillValue ?? 0,
-      item: gear?.skillModifier ?? 0,
+      item: anItem?.type === "component" ? (parseInt(gear?.rollModifier, 10) || 0) : gear?.skillModifier ?? 0 ,  //need to check for component that uses rollModifier (needs a refactor)
       other: settings?.diceModifier ?? 0,
       encumbered: encumberedValue,
       dodgeParry: settings?.rollModifiers?.dodgeParry ?? 0,

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -49,7 +49,7 @@ export class TwodsixShipActions {
 
   public static async skillRoll(text: string, extra: ExtraData) {
     const useInvertedShiftClick: boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
-    const showTrowDiag = useInvertedShiftClick ? extra.event["shiftKey"] : !extra.event["shiftKey"];
+    const showTrowDiag = useInvertedShiftClick ? extra?.event["shiftKey"] : !extra?.event["shiftKey"];
     const difficulties = TWODSIX.DIFFICULTIES[(<number>game.settings.get('twodsix', 'difficultyListUsed'))];
     const re = new RegExp(/^(.[^/]+)\/?([a-zA-Z]{0,3}) ?(\d{0,2})\+? ?=? ?(.*?)$/);
     const parsedResult: RegExpMatchArray | null = re.exec(text);
@@ -57,7 +57,7 @@ export class TwodsixShipActions {
 
     if (parsedResult !== null) {
       const [, parsedSkill, char, diff] = parsedResult;
-      let skill = selectedActor.itemTypes.skills.find((itm: TwodsixItem) => itm.name === parsedSkill) as TwodsixItem;
+      let skill = selectedActor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === parsedSkill) as TwodsixItem;
 
       /*if skill missing, try to use Untrained*/
       if (!skill) {

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -5,6 +5,7 @@ import { Component, Skills } from "src/types/template";
 import { AvailableShipActionData, AvailableShipActions, ExtraData } from "../../types/twodsix";
 import { TWODSIX } from "../config";
 import TwodsixItem from "../entities/TwodsixItem";
+import TwodsixActor from "../entities/TwodsixActor";
 import { getKeyByValue } from "./sheetUtils";
 import { TwodsixRollSettings } from "./TwodsixRollSettings";
 import { DICE_ROLL_MODES } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs";
@@ -52,14 +53,15 @@ export class TwodsixShipActions {
     const difficulties = TWODSIX.DIFFICULTIES[(<number>game.settings.get('twodsix', 'difficultyListUsed'))];
     const re = new RegExp(/^(.[^/]+)\/?([a-zA-Z]{0,3}) ?(\d{0,2})\+? ?=? ?(.*?)$/);
     const parsedResult: RegExpMatchArray | null = re.exec(text);
+    const selectedActor = <TwodsixActor>extra?.actor;
 
     if (parsedResult !== null) {
       const [, parsedSkill, char, diff] = parsedResult;
-      let skill = extra.actor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === parsedSkill) as TwodsixItem;
+      let skill = selectedActor.itemTypes.skills.find((itm: TwodsixItem) => itm.name === parsedSkill) as TwodsixItem;
 
       /*if skill missing, try to use Untrained*/
       if (!skill) {
-        skill = (<TwodsixActor>extra.actor)?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
+        skill = selectedActor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
         if (!skill) {
           ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", extra.actor?.name ?? "").replace("_SKILL_", parsedSkill));
           return false;
@@ -71,10 +73,10 @@ export class TwodsixShipActions {
       if(!char) {
         characteristicKey = getKeyByValue(TWODSIX.CHARACTERISTICS, (<Skills>skill.system).characteristic);
       } else {
-        characteristicKey = getCharacteristicFromDisplayLabel(char, extra.actor);
+        characteristicKey = getCharacteristicFromDisplayLabel(char, selectedActor);
       }
 
-      const charObject = extra.actor?.system["characteristics"];
+      const charObject = selectedActor?.system["characteristics"];
       let shortLabel = "NONE";
       let displayLabel = "NONE";
       if (charObject && characteristicKey) {
@@ -89,7 +91,7 @@ export class TwodsixShipActions {
       if (diff) {
         settings["difficulty"] = Object.values(difficulties).filter((difficulty: Record<string, number>) => difficulty.target === parseInt(diff, 10))[0];
       }
-      const options = await TwodsixRollSettings.create(showTrowDiag, settings, skill, extra.component, extra.actor);
+      const options = await TwodsixRollSettings.create(showTrowDiag, settings, skill, <TwodsixItem>extra.component, selectedActor);
       if (!options.shouldRoll) {
         return false;
       }
@@ -104,7 +106,7 @@ export class TwodsixShipActions {
   public static async fireEnergyWeapons(text: string, extra: ExtraData) {
     const [skilText, componentId] = text.split("=");
     const component = extra.ship?.items.find(item => item.id === componentId);
-    extra.component = component;
+    extra.component = <TwodsixItem>component;
     const result = await TwodsixShipActions.skillRoll(skilText, extra);
     if (!result) {
       return false;

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -89,7 +89,7 @@ export class TwodsixShipActions {
       if (diff) {
         settings["difficulty"] = Object.values(difficulties).filter((difficulty: Record<string, number>) => difficulty.target === parseInt(diff, 10))[0];
       }
-      const options = await TwodsixRollSettings.create(showTrowDiag, settings, skill, undefined, extra.actor);
+      const options = await TwodsixRollSettings.create(showTrowDiag, settings, skill, extra.component, extra.actor);
       if (!options.shouldRoll) {
         return false;
       }
@@ -105,7 +105,7 @@ export class TwodsixShipActions {
     const [skilText, componentId] = text.split("=");
     const component = extra.ship?.items.find(item => item.id === componentId);
     if ((<Component>component?.system)?.rollModifier) {
-      extra.diceModifier = (<Component>component?.system)?.rollModifier;
+      extra.component = component;
     }
 
     const result = await TwodsixShipActions.skillRoll(skilText, extra);

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -49,21 +49,21 @@ export class TwodsixShipActions {
 
   public static async skillRoll(text: string, extra: ExtraData) {
     const useInvertedShiftClick: boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
-    const showTrowDiag = useInvertedShiftClick ? extra?.event["shiftKey"] : !extra?.event["shiftKey"];
+    const showTrowDiag = useInvertedShiftClick ? extra.event["shiftKey"] : !extra.event["shiftKey"];
     const difficulties = TWODSIX.DIFFICULTIES[(<number>game.settings.get('twodsix', 'difficultyListUsed'))];
     const re = new RegExp(/^(.[^/]+)\/?([a-zA-Z]{0,3}) ?(\d{0,2})\+? ?=? ?(.*?)$/);
     const parsedResult: RegExpMatchArray | null = re.exec(text);
-    const selectedActor = <TwodsixActor>extra?.actor;
+    const selectedActor = <TwodsixActor>extra.actor;
 
     if (parsedResult !== null) {
       const [, parsedSkill, char, diff] = parsedResult;
-      let skill = selectedActor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === parsedSkill) as TwodsixItem;
+      let skill = selectedActor.itemTypes.skills.find((itm: TwodsixItem) => itm.name === parsedSkill) as TwodsixItem;
 
       /*if skill missing, try to use Untrained*/
       if (!skill) {
-        skill = selectedActor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
+        skill = selectedActor.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
         if (!skill) {
-          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", extra.actor?.name ?? "").replace("_SKILL_", parsedSkill));
+          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", selectedActor.name ?? "").replace("_SKILL_", parsedSkill));
           return false;
         }
       }

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -57,13 +57,13 @@ export class TwodsixShipActions {
 
     if (parsedResult !== null) {
       const [, parsedSkill, char, diff] = parsedResult;
-      let skill = selectedActor.itemTypes.skills.find((itm: TwodsixItem) => itm.name === parsedSkill) as TwodsixItem;
+      let skill = selectedActor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === parsedSkill) as TwodsixItem;
 
       /*if skill missing, try to use Untrained*/
       if (!skill) {
-        skill = selectedActor.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
+        skill = selectedActor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
         if (!skill) {
-          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", selectedActor.name ?? "").replace("_SKILL_", parsedSkill));
+          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", selectedActor?.name ?? "").replace("_SKILL_", parsedSkill));
           return false;
         }
       }

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -104,10 +104,7 @@ export class TwodsixShipActions {
   public static async fireEnergyWeapons(text: string, extra: ExtraData) {
     const [skilText, componentId] = text.split("=");
     const component = extra.ship?.items.find(item => item.id === componentId);
-    if ((<Component>component?.system)?.rollModifier) {
-      extra.component = component;
-    }
-
+    extra.component = component;
     const result = await TwodsixShipActions.skillRoll(skilText, extra);
     if (!result) {
       return false;

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -159,6 +159,7 @@ declare interface ExtraData {
   actionName?: string;
   positionName?: string;
   diceModifier?: string;
+  component?:TwodsixItem;
 }
 
 declare interface AvailableShipActionData {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [/] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [/] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Ship positions "XXX/ATR 8+" ignores the ATR and uses the attribute of XXX instead(even for the untrained fallback)


* **What is the new behavior (if this is a feature change)?**
The attribute set in the roll settings has a higher priority than the attribute of the skill


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO


* **Other information**:
