### PR TITLE
feat: Add option for alternative skills in ship positions.

### DIFF
--- a/src/module/sheets/TwodsixShipPositionSheet.ts
+++ b/src/module/sheets/TwodsixShipPositionSheet.ts
@@ -18,6 +18,7 @@ export class TwodsixShipPositionSheet extends AbstractTwodsixItemSheet {
     context.sortedActions = Object.entries(actions).map(([id, ret]) => {
       ret.id = id;
       ret.placeholder = TwodsixShipActions.availableMethods[ret.type].placeholder;
+      ret.tooltip = TwodsixShipActions.availableMethods[ret.type].tooltip;
       return ret;
     });
     context.sortedActions.sort((a: ShipAction, b: ShipAction) => (a.order > b.order) ? 1 : -1);

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -14,17 +14,20 @@ export class TwodsixShipActions {
     [TWODSIX.SHIP_ACTION_TYPE.chatMessage]: <AvailableShipActionData>{
       action: TwodsixShipActions.chatMessage,
       name: "Chat",
-      placeholder: "Message"
+      placeholder: "Message",
+      tooltip: ""
     },
     [TWODSIX.SHIP_ACTION_TYPE.skillRoll]: <AvailableShipActionData>{
       action: TwodsixShipActions.skillRoll,
       name: "Skill Roll",
-      placeholder: "Skill/CHR 8+"
+      placeholder: "Skill/CHR 8+",
+      tooltip: "Possible options:\nSkill\nSkill|Alternative Skill 1|...\nSkills/ATR\nSkills/ 8+\nSkills/ATR 8+"
     },
     [TWODSIX.SHIP_ACTION_TYPE.fireEnergyWeapons]: <AvailableShipActionData>{
       action: TwodsixShipActions.fireEnergyWeapons,
-      name: "Fire Energy Weapons",
-      placeholder: "Skill/CHR 8+=COMPONENT_ID"
+      name: "Use a component",
+      placeholder: "Skill/CHR 8+=COMPONENT_ID",
+      tooltip: "Possible options:\nSkill=COMPONENT_ID\nSkill|Alternative Skill 1|...=COMPONENT_ID\nSkills/ATR=COMPONENT_ID\nSkills/ 8+=COMPONENT_ID\nSkills/ATR 8+=COMPONENT_ID"
     }
   };
 
@@ -54,14 +57,21 @@ export class TwodsixShipActions {
     const parsedResult: RegExpMatchArray | null = re.exec(text);
 
     if (parsedResult !== null) {
-      const [, parsedSkill, char, diff] = parsedResult;
-      let skill = extra.actor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === parsedSkill) as TwodsixItem;
+      const [, parsedSkills, char, diff] = parsedResult;
+      const skillOptions = parsedSkills.split("|");
+      let skill = "";
+      for (const skillOption in skillOptions) {
+        skill = extra.actor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === skillOption) as TwodsixItem;
+        if(skill){
+          break;
+        }
+      }
 
       /*if skill missing, try to use Untrained*/
       if (!skill) {
         skill = (<TwodsixActor>extra.actor)?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
         if (!skill) {
-          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", extra.actor?.name ?? "").replace("_SKILL_", parsedSkill));
+          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", extra.actor?.name ?? "").replace("_SKILL_", parsedSkills));
           return false;
         }
       }

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -14,21 +14,21 @@ export class TwodsixShipActions {
   public static availableMethods = <AvailableShipActions>{
     [TWODSIX.SHIP_ACTION_TYPE.chatMessage]: <AvailableShipActionData>{
       action: TwodsixShipActions.chatMessage,
-      name: "Chat",
-      placeholder: "Message",
-      tooltip: ""
+      name: "TWODSIX.Ship.Chat",
+      placeholder: "TWODSIX.Ship.chatPlaceholder",
+      tooltip: "TWODSIX.Ship.chatTooltip"
     },
     [TWODSIX.SHIP_ACTION_TYPE.skillRoll]: <AvailableShipActionData>{
       action: TwodsixShipActions.skillRoll,
-      name: "Skill Roll",
-      placeholder: "Skill/CHR 8+",
-      tooltip: "Possible options:\nSkill\nSkill|Alternative Skill 1|...\nSkills/ATR\nSkills/ 8+\nSkills/ATR 8+"
+      name: "TWODSIX.Ship.SkillRoll",
+      placeholder: "TWODSIX.Ship.skillPlaceholder",
+      tooltip: "TWODSIX.Ship.skillTooltip"
     },
     [TWODSIX.SHIP_ACTION_TYPE.fireEnergyWeapons]: <AvailableShipActionData>{
       action: TwodsixShipActions.fireEnergyWeapons,
-      name: "Use a component",
-      placeholder: "Skill/CHR 8+=COMPONENT_ID",
-      tooltip: "Possible options:\nSkill=COMPONENT_ID\nSkill|Alternative Skill 1|...=COMPONENT_ID\nSkills/ATR=COMPONENT_ID\nSkills/ 8+=COMPONENT_ID\nSkills/ATR 8+=COMPONENT_ID"
+      name: "TWODSIX.Ship.UseAComponent",
+      placeholder: "TWODSIX.Ship.firePlaceholder",
+      tooltip: "TWODSIX.Ship.fireTooltip"
     }
   };
 
@@ -62,8 +62,8 @@ export class TwodsixShipActions {
       const [, parsedSkills, char, diff] = parsedResult;
       const skillOptions = parsedSkills.split("|");
       let skill = "";
-      for (const skillOption in skillOptions) {
-        skill = extra.actor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === skillOption) as TwodsixItem;
+      for (const skillOption of skillOptions) {
+        skill = selectedActor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === skillOption) as TwodsixItem;
         if(skill){
           break;
         }
@@ -73,7 +73,7 @@ export class TwodsixShipActions {
       if (!skill) {
         skill = selectedActor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
         if (!skill) {
-          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", extra.actor?.name ?? "").replace("_SKILL_", parsedSkills));
+          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", selectedActor?.name ?? "").replace("_SKILL_", parsedSkills));
           return false;
         }
       }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -547,7 +547,16 @@
       "ShipValue": "Ship Value",
       "MortgagePerMonth": "Est. Mortgage Payment",
       "MaintenancePerMonth": "Maintenance Cost",
-      "CrPerMonth": "Cr/month"
+      "CrPerMonth": "Cr/month",
+      "Chat": "Chat",
+      "UseAComponent": "Component",
+      "SkillRoll": "Skill",
+      "chatPlaceholder": "Chat Message",
+      "skillPlaceholder": "Skill/CHR 8+",
+      "firePlaceholder": "Skill/CHR 8+=COMPONENT_ID",
+      "skillTooltip": "Possible options:\nSkill\nSkill|Alternative Skill 1|...\nSkills/ATR\nSkills/ 8+\nSkills/ATR 8+",
+      "fireTooltip": "Possible options:\nSkill=COMPONENT_ID\nSkill|Alternative Skill 1|...=COMPONENT_ID\nSkills/ATR=COMPONENT_ID\nSkills/ 8+=COMPONENT_ID\nSkills/ATR 8+=COMPONENT_ID",
+      "chatTooltip": "Ahoy!"
     },
     "Vehicle": {
       "SystemStatus": "System Status",

--- a/static/templates/items/ship_position-sheet.html
+++ b/static/templates/items/ship_position-sheet.html
@@ -62,7 +62,7 @@
             </td>
             <td>
               <input type="text" placeholder="{{action.placeholder}}" name="system.actions.{{id}}.command"
-                value="{{action.command}}">
+                value="{{action.command}}" data-tooltip="{{action.tooltip}}"">
             </td>
             <td>
               <select style="width: 100px;" name="system.actions.{{action.id}}.type" value={{action.type}}>

--- a/static/templates/items/ship_position-sheet.html
+++ b/static/templates/items/ship_position-sheet.html
@@ -65,12 +65,8 @@
                 value="{{action.command}}" data-tooltip="{{localize action.tooltip}}">
             </td>
             <td>
-              <select style="width: 100px;" name="system.actions.{{action.id}}.type" value={{action.type}}>
-                {{#select action.type}}
-                {{#each ../availableActions as |value key|}}
-                <option value="{{key}}">{{localize value.name}}</option>
-                {{/each}}
-                {{/select}}
+              <select style="width: 100px;" name="system.actions.{{action.id}}.type">
+                {{selectOptions ../availableActions selected = action.type labelAttr = "name" localize=true}}
               </select>
             </td>
             <td class="centre">

--- a/static/templates/items/ship_position-sheet.html
+++ b/static/templates/items/ship_position-sheet.html
@@ -61,14 +61,14 @@
               <input type="text" style="width: 100px;" name="system.actions.{{id}}.name" value="{{action.name}}">
             </td>
             <td>
-              <input type="text" placeholder="{{action.placeholder}}" name="system.actions.{{id}}.command"
-                value="{{action.command}}" data-tooltip="{{action.tooltip}}"">
+              <input type="text" placeholder="{{localize action.placeholder}}" name="system.actions.{{id}}.command"
+                value="{{action.command}}" data-tooltip="{{localize action.tooltip}}">
             </td>
             <td>
               <select style="width: 100px;" name="system.actions.{{action.id}}.type" value={{action.type}}>
                 {{#select action.type}}
                 {{#each ../availableActions as |value key|}}
-                <option value="{{key}}">{{value.name}}</option>
+                <option value="{{key}}">{{localize value.name}}</option>
                 {{/each}}
                 {{/select}}
               </select>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [/] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [/] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Actions of ship positions allow only 1 named skill


* **What is the new behavior (if this is a feature change)?**
Actions of ship positions allow more than 1 named skill(p.e. "Gunner turret" and "Gunner" if a character didn't learn the specialization)



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
old stuff keeps valid only new options are added


* **Other information**:
