### PR TITLE
fix: text colors on pop-outs

### DIFF
--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -405,6 +405,10 @@ form .form-group span.units {
   overflow: hidden !important;
 }
 
+.app.sidebar-popout .window-content {
+  color: var(--color-border-light-1) !important;
+}
+
 .character-name h2 {
   margin-bottom: -0.5em;
   border: none;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)
Pop-outs from standard menu (e.g. compendiums) have text in default color rather than white (in normal menu)


* **What is the new behavior (if this is a feature change)?**
Popout text to use same white colored text as normal menu list


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
