### PR TITLE
fix: Fix drop from compendium

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -620,8 +620,14 @@ export default class TwodsixActor extends Actor {
       //return this._onSortItem(event, sameActor);
       return false;
     }
+    //handle drop from compendium
+    if (itemData.pack) {
+      const pack = game.packs.get(itemData.pack);
+      itemData = await pack?.getDocument(itemData._id);
+    }
 
-    let numberToMove = itemData.system.quantity;
+    let numberToMove = itemData.system?.quantity ?? 1;
+    const transferData = itemData.toJSON();
 
     //Handle moving items from another actor if enabled by settings
     if (itemData.actor  && game.settings.get("twodsix", "transferDroppedItems")) {

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -627,7 +627,6 @@ export default class TwodsixActor extends Actor {
     }
 
     let numberToMove = itemData.system?.quantity ?? 1;
-    const transferData = itemData.toJSON();
 
     //Handle moving items from another actor if enabled by settings
     if (itemData.actor  && game.settings.get("twodsix", "transferDroppedItems")) {

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -39,6 +39,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.push(booleanSetting('showComponentSummaryIcons', false));
     settings.push(booleanSetting('showSpells', false));
     settings.push(booleanSetting('showModifierDetails', false));
+    settings.push(booleanSetting('showFeaturesInChat', false));
     settings.push(colorSetting('defaultColor', "#29aae1", "Color", false, 'world', changeDefaultColor));
     settings.push(colorSetting('lightColor', "#00e5ff", "Color", false, 'world', changeLightColor));
     return settings;

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -166,13 +166,15 @@ export class TwodsixDiceRoll {
 
     //Initialize flavor strings
     let flavorText = ``;
-    if (this.skill?.img) {
+    if (this.settings.itemRoll && this.item?.img) {
+      flavorText += `<section style="align-self: center;"><img src=${this.item.img} class="chat-image"></section>`;
+    } else if (this.settings.skillRoll && this.skill?.img) {
       flavorText += `<section style="align-self: center;"><img src=${this.skill.img} class="chat-image"></section>`;
     }
     let flavorTable = `<table><tr><th>${game.i18n.localize("TWODSIX.Chat.Roll.Modifier")}</th><th>${game.i18n.localize("TWODSIX.Chat.Roll.Description")}</th><th class="centre">${game.i18n.localize("TWODSIX.Chat.Roll.DM")}</th></tr>`;
 
     //Difficulty Text
-    flavorText += `${rollingString}: ${difficulty}`;
+    flavorText += `<section><p><b>${rollingString}</b>: ${difficulty}`;
     flavorTable += `<tr><td>${game.i18n.localize("TWODSIX.Chat.Roll.Difficulty")}</td><td>${difficulty}</td>`;
     if (game.settings.get('twodsix', 'difficultiesAsTargetNumber')) {
       flavorText += showModifiers ? `(${this.settings.difficulty.target}+)` : ``;
@@ -244,6 +246,12 @@ export class TwodsixDiceRoll {
       flavorText += ` + ${game.i18n.localize("TWODSIX.Chat.Roll.Custom")}`+ (showModifiers ? `(${this.settings.rollModifiers.custom})` : ``);
       flavorTable += `<tr><td>${game.i18n.localize("TWODSIX.Chat.Roll.Condition")}</td><td>${game.i18n.localize("TWODSIX.Chat.Roll.Custom")}</td><td class="centre">${this.settings.rollModifiers.custom}</td></tr>`;
     }
+    flavorText +=`</p>`;
+
+    //add features
+    if (this.settings.itemRoll && this.item?.system?.features !== "") {
+      flavorText += `<p><b>${game.i18n.localize("TWODSIX.Items.Weapon.Features")}</b>: ${this.item.system.features}</p>`;
+    }
 
     // Add timeframe if requred
     let timeToComplete = ``;
@@ -252,7 +260,7 @@ export class TwodsixDiceRoll {
         timeToComplete = new Roll(this.settings.timeRollFormula).evaluate({async: false}).total.toString() + ` ` + game.i18n.localize(TWODSIX.TimeUnits[this.settings.selectedTimeUnit]);
       }
     }
-
+    flavorText +=`</section>`;
     flavorTable += `</table>`;
     const flavor = (this.settings.extraFlavor ? `<section>${this.settings.extraFlavor}</section>`: ``) + `<section class="dice-roll"><section class="flavor-line">`+ flavorText + `</section><section class="dice-tooltip">` + flavorTable + `</section></section>`;
 

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -249,7 +249,7 @@ export class TwodsixDiceRoll {
     flavorText +=`</p>`;
 
     //add features
-    if (this.settings.itemRoll && this.item?.system?.features !== "") {
+    if (this.settings.itemRoll && this.item?.system?.features !== ""  && game.settings.get("twodsix", "showFeaturesInChat")) {
       flavorText += `<p><b>${game.i18n.localize("TWODSIX.Items.Weapon.Features")}</b>: ${this.item.system.features}</p>`;
     }
 

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -65,7 +65,7 @@ export class TwodsixShipActions {
     if (parsedResult !== null) {
       const [, parsedSkills, char, diff] = parsedResult;
       const skillOptions = parsedSkills.split("|");
-      let skill = "";
+      let skill = {};
       for (const skillOption of skillOptions) {
         skill = selectedActor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === skillOption) as TwodsixItem;
         if(skill){
@@ -110,7 +110,12 @@ export class TwodsixShipActions {
       if (!options.shouldRoll) {
         return false;
       }
-      return skill.skillRoll(showTrowDiag, options);
+
+      if (extra.component) {
+        return extra.component.skillRoll(showTrowDiag, options);
+      } else {
+        return skill.skillRoll(showTrowDiag, options);
+      }
 
     } else {
       ui.notifications.error(game.i18n.localize("TWODSIX.Ship.CannotParseArgument"));
@@ -119,10 +124,10 @@ export class TwodsixShipActions {
   }
 
   public static async fireEnergyWeapons(text: string, extra: ExtraData) {
-    const [skilText, componentId] = text.split("=");
+    const [skillText, componentId] = text.split("=");
     const component = extra.ship?.items.find(item => item.id === componentId);
     extra.component = <TwodsixItem>component;
-    const result = await TwodsixShipActions.skillRoll(skilText, extra);
+    const result = await TwodsixShipActions.skillRoll(skillText, extra);
     if (!result) {
       return false;
     }

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -126,6 +126,7 @@ declare global {
       'twodsix.showModifierDetails':boolean;
       'twodsix.defaultColor':string;
       'twodsix.lightColor':string;
+      'twodsix.showFeaturesInChat':boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1014,6 +1014,10 @@
       "lightColor": {
         "hint": "Change the theme highlight color. Delete value to reset.",
         "name": "Set Highlight Color"
+      },
+      "showFeaturesInChat": {
+        "hint" : "Show item features text at bottom of chat messages for rolls.",
+        "name": "Show Item Features in Chat"
       }
     },
     "CloseAndCreateNew": "Close and create new",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)

can't drop items from compendium
chat rolls for items display skill image not item
no features listed in chat

* **What is the new behavior (if this is a feature change)?**
allow items drops from compendium
chat rolls display item image, if appropriate
New setting to list item features/traits in chat roll


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
