### PR TITLE
fix: actor damage dialog and notification issues

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -729,6 +729,30 @@ export default class TwodsixActor extends Actor {
     }
     return false;
   }
+
+  /**
+   * Display changes to health as scrolling combat text.
+   * Adapt the font size relative to the Actor's HP total to emphasize more significant blows.
+   * @param {number} damageApplied     The change in hit points that was applied
+   * @public
+   */
+  public scrollDamage(damageApplied:number): void {
+    if ( !damageApplied ) {
+      return;
+    }
+    const tokens = this.isToken ? [this.token?.object] : this.getActiveTokens(true);
+    for ( const t of tokens ) {
+      const pct = Math.clamped(Math.abs(damageApplied) / this.system.hits.max, 0, 1);
+      canvas.interface.createScrollingText(t.center, -damageApplied.signedString(), {
+        anchor: CONST.TEXT_ANCHOR_POINTS.TOP,
+        fontSize: 22 + (32 * pct), // Range between [22, 54]
+        fill: -damageApplied < 0 ? 16711680 : 65280,
+        stroke: 0x000000,
+        strokeThickness: 4,
+        jitter: 0.25
+      });
+    }
+  }
 }
 
 export function getPower(item: Component): number{

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -8,9 +8,14 @@ import { getDamageCharacteristics } from "../utils/actorDamage";
 
 Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>) => {
   const firstGM = game.users.find(u => u.isGM);
-  if (game.settings.get('twodsix', 'useWoundedStatusIndicators')) {
-    if (checkForWounds(update.system, actor.type) && (actor.type === 'traveller' || actor.type === 'animal') && game.user?.id === firstGM?.id) {
-      await applyWoundedEffect(actor).then();
+  if (checkForWounds(update.system, actor.type) && (actor.type === 'traveller' || actor.type === 'animal')) {
+    if (game.settings.get('twodsix', 'useWoundedStatusIndicators')) {
+      if (game.user?.id === firstGM?.id) {
+        await applyWoundedEffect(actor).then();
+      }
+    }
+    if (actor.system.hits.lastDelta !== 0 && actor.isOwner) {
+      actor.scrollDamage(actor.system.hits.lastDelta);
     }
   }
   if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators')) {

--- a/src/module/hooks/updateHits.ts
+++ b/src/module/hooks/updateHits.ts
@@ -6,7 +6,7 @@ import { getDamageCharacteristics } from "../utils/actorDamage";
 import { mergeDeep } from "../utils/utils";
 import {Traveller} from "../../types/template";
 
-function getCurrentHits(actorType: string, ...args: Record<string, any>[]) {
+async function getCurrentHits(actorType: string, ...args: Record<string, any>[]) {
   const characteristics = mergeDeep({}, ...args);
   const hitsCharacteristics: string[] = getDamageCharacteristics(actorType);
 
@@ -16,13 +16,13 @@ function getCurrentHits(actorType: string, ...args: Record<string, any>[]) {
       hits.max += chr.value;
     }
     return hits;
-  }, {value: 0, max: 0});
+  }, {value: 0, max: 0, lastDelta: 0});
 }
 
 Hooks.on('preUpdateActor', async (actor:TwodsixActor, update:Record<string, any>) => {
   if (update.system?.characteristics && (actor.type === 'traveller' || actor.type === 'animal')) {
-    update.system.hits = getCurrentHits(actor.type, (<Traveller>actor.system).characteristics, update.system.characteristics);
-    Object.assign(update.system.hits, {lastDelta: actor.system.hits.value - update.system.hits.value});
+    update.system.hits = await getCurrentHits(actor.type, (<Traveller>actor.system).characteristics, update.system.characteristics);
+    await Object.assign(update.system.hits, {lastDelta: actor.system.hits.value - update.system.hits.value});
     if (update.system.hits.lastDelta !== 0 && game.settings.get("twodsix", "showHitsChangesInChat")) {
       const appliedType = update.system.hits.lastDelta > 0 ? game.i18n.localize("TWODSIX.Actor.damage") : game.i18n.localize("TWODSIX.Actor.healing");
       const actionWord = game.i18n.localize("TWODSIX.Actor.Applied");

--- a/src/module/hooks/updateHits.ts
+++ b/src/module/hooks/updateHits.ts
@@ -22,6 +22,12 @@ function getCurrentHits(actorType: string, ...args: Record<string, any>[]) {
 Hooks.on('preUpdateActor', async (actor:TwodsixActor, update:Record<string, any>) => {
   if (update.system?.characteristics && (actor.type === 'traveller' || actor.type === 'animal')) {
     update.system.hits = getCurrentHits(actor.type, (<Traveller>actor.system).characteristics, update.system.characteristics);
+    Object.assign(update.system.hits, {lastDelta: actor.system.hits.value - update.system.hits.value});
+    if (update.system.hits.lastDelta !== 0 && game.settings.get("twodsix", "showHitsChangesInChat")) {
+      const appliedType = update.system.hits.lastDelta > 0 ? game.i18n.localize("TWODSIX.Actor.damage") : game.i18n.localize("TWODSIX.Actor.healing");
+      const actionWord = game.i18n.localize("TWODSIX.Actor.Applied");
+      ChatMessage.create({ flavor: `${actionWord} ${appliedType}: ${Math.abs(update.system.hits.lastDelta)}`, speaker: ChatMessage.getSpeaker({ actor: actor }), whisper: ChatMessage.getWhisperRecipients("GM") });
+    }
   }
 });
 

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -42,6 +42,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.push(booleanSetting('showFeaturesInChat', false));
     settings.push(colorSetting('defaultColor', "#29aae1", "Color", false, 'world', changeDefaultColor));
     settings.push(colorSetting('lightColor', "#00e5ff", "Color", false, 'world', changeLightColor));
+    settings.push(booleanSetting('showHitsChangesInChat', false));
     return settings;
   }
 }

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -137,7 +137,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
     const attackType = event.currentTarget["dataset"].attackType;
     const rof = event.currentTarget["dataset"].rof ? parseInt(event.currentTarget["dataset"].rof, 10) : null;
     const item = this.getItem(event);
-    console.log("Sheet Item Attack: ", item);
+    //console.log("Sheet Item Attack: ", item);
     if (this.options.template?.includes("npc-sheet")) {
       resolveUnknownAutoMode(item);
     } else {

--- a/src/module/utils/actorDamage.ts
+++ b/src/module/utils/actorDamage.ts
@@ -205,10 +205,12 @@ class DamageDialogHandler {
         chrHtml.find(`.damage-input`).val(stat.damage);
       }
 
-      if (characteristic === this.stats.damageCharacteristics[0] && stat.current() !== 0 && this.stats.currentDamage() - stat.damage > 0 && stat.original.damage === 0) {
+      if (characteristic === this.stats.damageCharacteristics[0] && stat.current() !== 0 && this.stats.currentDamage() - stat.damage > 0) {
         if (!chrHtml.find(`.damage-input`).hasClass("orange-border")) {
           chrHtml.find(`.damage-input`).addClass("orange-border");
-          ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.DecreaseEnduranceFirst"));
+          if (stat.original.damage === 0) {
+            ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.DecreaseEnduranceFirst"));
+          }
         }
       } else {
         chrHtml.find(`.damage-input`).removeClass("orange-border");
@@ -293,8 +295,8 @@ export async function renderDamageDialog(damageData: Record<string, any>): Promi
   } else {
     actor = (canvas.tokens?.placeables?.find((t: Token) => t.id === damageData.tokenId) || null)?.actor || null;
   }
-  const actorUsers = game.users?.filter(user => user.active && actor && actor.testUserPermission(user, 3)) || null;
-  if ((game.user?.isGM && actorUsers && actorUsers.length > 1) || (!game.user?.isGM && !actor.isOwner)) {
+  const actorUsersNonGM = game.users?.filter(user => user.active && actor && actor.testUserPermission(user, 3) && !user.isGM) || null;
+  if ((game.user?.isGM && actorUsersNonGM?.length > 0) || (!game.user?.isGM && !actor.isOwner)) {
     return;
   }
 

--- a/src/module/utils/actorDamage.ts
+++ b/src/module/utils/actorDamage.ts
@@ -205,7 +205,7 @@ class DamageDialogHandler {
         chrHtml.find(`.damage-input`).val(stat.damage);
       }
 
-      if (characteristic === this.stats.damageCharacteristics[0] && stat.current() !== 0 && this.stats.currentDamage() - stat.damage > 0) {
+      if (characteristic === this.stats.damageCharacteristics[0] && stat.current() !== 0 && this.stats.currentDamage() - stat.damage > 0 && stat.original.damage === 0) {
         if (!chrHtml.find(`.damage-input`).hasClass("orange-border")) {
           chrHtml.find(`.damage-input`).addClass("orange-border");
           ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.DecreaseEnduranceFirst"));

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -221,6 +221,7 @@ export interface Hits {
   value:number;
   min:number;
   max:number;
+  lastDelta?:number;
 }
 
 export interface Fuel {

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -127,6 +127,7 @@ declare global {
       'twodsix.defaultColor':string;
       'twodsix.lightColor':string;
       'twodsix.showFeaturesInChat':boolean;
+      'twodsix.showHitsChangesInChat':boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -69,6 +69,9 @@
       "Gender": "Gender",
       "HeroPoints": "Hero Points",
       "Hits": "Hits",
+      "healing": "healing",
+      "damage": "damage",
+      "Applied": "Applied",
       "Contamination": "Contamination",
       "Lifeblood": "Lifeblood",
       "Stamina": "Stamina",
@@ -1018,6 +1021,10 @@
       "showFeaturesInChat": {
         "hint" : "Show item features text at bottom of chat messages for rolls.",
         "name": "Show Item Features in Chat"
+      },
+      "showHitsChangesInChat": {
+        "hint": "Show a whispered chat message to GM when damage/healing is appled to an actor.",
+        "name": "Show damage / healing chat message to GM"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/template.json
+++ b/static/template.json
@@ -13,7 +13,8 @@
       "hits": {
         "value": 21,
         "min": 0,
-        "max": 21
+        "max": 21,
+        "lastDelta": 0
       },
       "gender": "",
       "radiationDose": {

--- a/static/templates/chat/throw-dialog.html
+++ b/static/templates/chat/throw-dialog.html
@@ -56,7 +56,6 @@
       </div>
       {{/if}}
       {{#if itemRoll}}
-        {{log rollModifiers}}
         <div class="form-group">
           <label>{{localize "TWODSIX.Chat.Roll.ItemModifier"}}
             <input type="number" name="rollModifiers.item" value="{{rollModifiers.item}}" placeholder="0" onClick="this.select();" style="width: 8ch;"/>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

warning always triggered to decrease endurance / first attribute even if attribute is already damaged
no way to see how player changes hits/stats
if multiple GM's active, damage dialog sides not appear

* **What is the new behavior (if this is a feature change)?**

only trigger warning when no damage to endurance
scrolling text added for healing/damage if actor owner
optional whispered message to chat for damage /healing
allow damage dialog to be seen by all GM's

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
