### PR TITLE
fix: ship layout display in default style

### DIFF
--- a/static/templates/actors/parts/ship/ship-state-grid.html
+++ b/static/templates/actors/parts/ship/ship-state-grid.html
@@ -27,7 +27,9 @@
   </div>
   <div class="ship-hull">
     <span class="hull-label">{{localize "TWODSIX.Ship.ShipHull"}}</span>
+    {{#unless settings.useFoundryStandardStyle}}
     {{> "systems/twodsix/templates/actors/parts/ship/ship-hull.html"}}
+    {{/unless}}
     <span class="ship-hull-value"><input type="number" value="{{actor.system.shipStats.hull.value}}" name="system.shipStats.hull.value" placeholder="0" min="0" max="{{actor.system.shipStats.hull.max}}" step = "1"/></span>
     <span class="ship-hull-max"><input type="number" value="{{actor.system.shipStats.hull.max}}" name="system.shipStats.hull.max" placeholder="0" min="0" step="1"/></span>
   </div>

--- a/static/templates/actors/ship-sheet.html
+++ b/static/templates/actors/ship-sheet.html
@@ -25,7 +25,9 @@
       {{> "systems/twodsix/templates/actors/parts/ship/ship-state-grid.html"}}
     </div>
     <div class="ship-power-management">
-      {{> "systems/twodsix/templates/actors/parts/ship/ship-power-management.html"}}
+      {{#unless settings.useFoundryStandardStyle}}
+        {{> "systems/twodsix/templates/actors/parts/ship/ship-power-management.html"}}
+      {{/unless}}
     {{#if settings.showWeightUsage}}
     <span class ="power-title">{{localize "TWODSIX.Ship.PowerWeightManagement"}}</span>
     {{else}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)

ship sheet does not display power management or stats correctly in FVTT default style

* **What is the new behavior (if this is a feature change)?**
Display correctly


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
