### PR TITLE
fix: augment AEs enabled by default

### DIFF
--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -150,7 +150,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
           tint: "#ffffff",
           label: this.item.name,
           transfer: true,
-          disabled: (<Gear>this.item.system).equipped !== undefined && (<Gear>this.item.system).equipped !== "equipped",
+          disabled: (<Gear>this.item.system).equipped !== undefined && (<Gear>this.item.system).equipped !== "equipped" && this.item.type !== "augment",
           _id: newId,
           flags: {twodsix: {sourceId: newId}}
 

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -150,7 +150,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
           tint: "#ffffff",
           label: this.item.name,
           transfer: true,
-          disabled: (<Gear>this.item.system).equipped !== undefined && (<Gear>this.item.system).equipped !== "equipped" && this.item.type !== "augment",
+          disabled: (<Gear>this.item.system).equipped !== undefined && (<Gear>this.item.system).equipped !== "equipped" && !["augment", "trait"].includes(this.item.type),
           _id: newId,
           flags: {twodsix: {sourceId: newId}}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Augment AE disabled by default


* **What is the new behavior (if this is a feature change)?**

Enable augment AE's by default

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
