### PR TITLE
fix: Fix skill drop and damage labels

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -676,11 +676,6 @@ export default class TwodsixActor extends Actor {
       //return this.sheet._onSortItem(event, sameActor);
       return false;
     }
-    //handle drop from compendium
-    if (itemData.pack) {
-      const pack = game.packs.get(itemData.pack);
-      itemData = await pack?.getDocument(itemData._id);
-    }
 
     const transferData = itemData.toJSON();
     let numberToMove = itemData.system?.quantity ?? 1;
@@ -776,6 +771,12 @@ export default class TwodsixActor extends Actor {
   }
 
   public async handleDroppedItem(itemData): Promise<boolean> {
+    //handle drop from compendium
+    if (itemData?.pack) {
+      const pack = game.packs.get(itemData.pack);
+      itemData = await pack?.getDocument(itemData._id);
+    }
+
     if(!itemData) {
       return false;
     }

--- a/static/templates/actors/animal-sheet.html
+++ b/static/templates/actors/animal-sheet.html
@@ -81,7 +81,7 @@
         <span >
          {{#each_sort_item container.weapon as |item id|}}
             <span class="item" data-item-id="{{item.id}}">
-              <span class="item-name perform-attack" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}">{{item.name}}</span>&dash;<span class="item-name centre roll-damage orange">{{twodsix_limitLength item.system.damage 4}}</span>
+              <span class="item-name perform-attack" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}">{{item.name}}</span>&dash;<span class="item-name centre roll-damage orange">{{twodsix_limitLength item.system.damage 6}}</span>
               {{#each item.system.consumableData as |consumableData|}}
               {{> "systems/twodsix/templates/actors/parts/actor/actor-npc-consumable.html" consumableData}}{{/each}}
               <span class="item-controls centre">

--- a/static/templates/actors/npc-sheet.html
+++ b/static/templates/actors/npc-sheet.html
@@ -86,7 +86,7 @@
         <span >
          {{#each_sort_item container.weapon as |item id|}}
             <span class="item" data-item-id="{{item.id}}">
-              <span class="item-name perform-attack" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}">{{item.name}}</span>&dash;<span class="item-name centre roll-damage orange">{{twodsix_limitLength item.system.damage 4}}</span>
+              <span class="item-name perform-attack" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}">{{item.name}}</span>&dash;<span class="item-name centre roll-damage orange">{{twodsix_limitLength item.system.damage 6}}</span>
               {{#each item.system.consumableData as |consumableData|}}
               {{> "systems/twodsix/templates/actors/parts/actor/actor-npc-consumable.html" consumableData}}{{/each}}{{#unless @last}}, {{/unless}}
             </span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fixes


* **What is the current behavior?** (You can also link to an open issue here)
Can't drop skill on actor from compendium
Damage roll labels too short on animal and npc sheet

* **What is the new behavior (if this is a feature change)?**
Fix dropping of skill from a compendium
Lengthen damage labels

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
