### PR TITLE
fix: Update ship roll parsing

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -772,10 +772,10 @@ export default class TwodsixActor extends Actor {
 
   public async handleDroppedItem(itemData): Promise<boolean> {
     //handle drop from compendium
-    if (itemData?.pack) {
-      const pack = game.packs.get(itemData.pack);
-      itemData = await pack?.getDocument(itemData._id);
-    }
+    //if (itemData?.pack) {
+    //  const pack = game.packs.get(itemData.pack);
+    //  itemData = await pack?.getDocument(itemData._id);
+    //}
 
     if(!itemData) {
       return false;

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -270,9 +270,14 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
         }
         this.actor.items.get(currentShipPositionId)?.sheet?.render();
       } else if ((droppedObject.type === "skills") && event.target !== null && $(event.target).parents(".ship-position").length === 1) {
-        const shipPositionId = $(event.target).parents(".ship-position").data("id");
-        const shipPosition = <TwodsixItem>this.actor.items.get(shipPositionId);
-        await TwodsixShipPositionSheet.createActionFromSkill(shipPosition, droppedObject);
+        //check for double drop trigger, not clear why this occurs
+        if (event.currentTarget.className === "ship-position-box") {
+          const shipPositionId = $(event.target).parents(".ship-position").data("id");
+          const shipPosition = <TwodsixItem>this.actor.items.get(shipPositionId);
+          await TwodsixShipPositionSheet.createActionFromSkill(shipPosition, droppedObject);
+        } else {
+          return false;
+        }
       } else if (droppedObject.type === "vehicle") {
         await this._addVehicleToComponents(droppedObject, dropData.uuid);
       } else if (droppedObject.type === "animal") {

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -58,7 +58,8 @@ export class TwodsixShipActions {
     const useInvertedShiftClick: boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
     const showTrowDiag = useInvertedShiftClick ? extra.event["shiftKey"] : !extra.event["shiftKey"];
     const difficulties = TWODSIX.DIFFICULTIES[(<number>game.settings.get('twodsix', 'difficultyListUsed'))];
-    const re = new RegExp(/^(.[^/]+)\/?([a-zA-Z]{0,3}) ?(\d{0,2})\+? ?=? ?(.*?)$/);
+    // eslint-disable-next-line no-useless-escape
+    const re = new RegExp(/^(.[^\/]+)\/?([a-zA-Z0-9]{0,4}) (\d{0,2})\+? ?=? ?(.*?)$/);
     const parsedResult: RegExpMatchArray | null = re.exec(text);
     const selectedActor = <TwodsixActor>extra.actor;
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fixes


* **What is the current behavior?** (You can also link to an open issue here)
- ship skill rolls aren't correct if characteristic is missing
- dropping skill on ship sheet position will duplicate skill roll
- not all drops handle compendiums


* **What is the new behavior (if this is a feature change)?**
- REGEX redone to handle missing characteristic
- Prevent duplication of skill roll
- refactor getItemData to include handling compendium drops


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

NO

* **Other information**:
address #1238 