### PR TITLE
fix: Drag ruler settings when using other rules

### DIFF
--- a/src/module/hooks/dragRulerIntegration.ts
+++ b/src/module/hooks/dragRulerIntegration.ts
@@ -61,7 +61,6 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
               ];
             }
           case "CE":
-          case "OTHER":
             if ((actorData.encumbrance.value > actorData.encumbrance.max) && game.settings.get("twodsix", "useEncumbrance")) {
               return [];
             } else if ((actorData.encumbrance.value > actorData.encumbrance.max / 2) && game.settings.get("twodsix", "useEncumbrance")) {
@@ -69,6 +68,21 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
                 { range: 1.5, color: "walk" }
               ];
             } else if ((actorData.encumbrance.value > actorData.encumbrance.max / 6) && game.settings.get("twodsix", "useEncumbrance")) {
+              movementSpeed *= 0.75;
+            }
+            return [
+              { range: movementSpeed, color: "walk" },
+              { range: movementSpeed * 2, color: "dash" },
+              { range: movementSpeed * 3, color: "run" }
+            ];
+          case "OTHER":
+            if ((actorData.encumbrance.value > actorData.encumbrance.max) && game.settings.get("twodsix", "useEncumbrance")) {
+              return [];
+            } else if ((actorData.encumbrance.value > actorData.encumbrance.max * game.settings.get("twodsix", "encumbFractionOneSquare")) && game.settings.get("twodsix", "useEncumbrance")) {
+              return [
+                { range: 1.5, color: "walk" }
+              ];
+            } else if ((actorData.encumbrance.value > actorData.encumbrance.max * game.settings.get("twodsix", "encumbFraction75pct")) && game.settings.get("twodsix", "useEncumbrance")) {
               movementSpeed *= 0.75;
             }
             return [

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -74,6 +74,8 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(booleanSetting("animalsUseLocations", false));
     settings.push(booleanSetting("displayReactionMorale", false));
     settings.push(booleanSetting("useDodgeParry", false));
+    settings.push(numberSetting('encumbFractionOneSquare', 0.5));
+    settings.push(numberSetting('encumbFraction75pct', 0.33));
     return settings;
   }
 }

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -61,6 +61,8 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(booleanSetting('reverseHealingOrder', false));
     settings.push(stringSetting("maxEncumbrance", DEFAULT_MAX_ENCUMBRANCE_FORMULA, false, "world"));
     settings.push(stringSetting('encumbranceFraction', "0.5", false)); //Should be a number setting, but FVTT unhappy with vales other than 0.5
+    settings.push(numberSetting('encumbFractionOneSquare', 0.5));
+    settings.push(numberSetting('encumbFraction75pct', 0.33));
     settings.push(numberSetting('encumbranceModifier', -1, false));
     settings.push(numberSetting('defaultMovement', 10));
     settings.push(stringChoiceSetting('defaultMovementUnits', "m", true, TWODSIX.MovementUnits));
@@ -74,8 +76,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.push(booleanSetting("animalsUseLocations", false));
     settings.push(booleanSetting("displayReactionMorale", false));
     settings.push(booleanSetting("useDodgeParry", false));
-    settings.push(numberSetting('encumbFractionOneSquare', 0.5));
-    settings.push(numberSetting('encumbFraction75pct', 0.33));
+
     return settings;
   }
 }

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -42,7 +42,7 @@ export class TwodsixRollSettings {
     const tokenUUID:string = settings?.flags?.tokenUUID ?? (<Actor>sourceActor)?.getActiveTokens()[0]?.document.uuid ?? "";
     const actorUUID:string = settings?.flags?.actorUUID ?? (<Actor>sourceActor)?.uuid ?? "";
     let rollClass = "";
-    const bonusDamage:string = settings?.flags?.bonusDamage ?? "";
+    const bonusDamage:string = settings?.bonusDamage ?? "";
 
     let woundsValue = 0;
     let encumberedValue = 0;

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -129,6 +129,8 @@ declare global {
       'twodsix.useItemActiveEffects':boolean;
       'twodsix.showFeaturesInChat':boolean;
       'twodsix.showHitsChangesInChat':boolean;
+      'twodsix.encumbFractionOneSquare':number;
+      'twodsix.encumbFraction75Pct':number;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1051,11 +1051,11 @@
       },
       "encumbranceFraction": {
         "hint": "The fraction applied to the maximum encumbrance formula to indicate actor is encumbered.  For example, a value of 0.5 would mean the actor becomes encumbered when carried weight exceeds one half of maximum encumbrance.",
-        "name": "Fraction of maximum encumbrance when actor becomes encumbered"
+        "name": "Fraction of maximum encumbrance when encumbrance roll modifier applies"
       },
       "encumbranceModifier": {
         "hint": "The number to add to the physical (STR, END, DEX) characteristic modifier when encumbered. For example, -1 indicates one should be subtracted for all rolls involving physical characterisitcs.",
-        "name": "Modifier to physical characteristics when actor becomes encumbered"
+        "name": "Roll modifier using physical characteristics when actor is encumbered"
       },
       "transferDroppedItems": {
         "hint": "Overrides the default Foundry behavior of copying on drag-drop to transfering items (items removed from source actor) when drag-dropping equipment between actors.",
@@ -1095,11 +1095,11 @@
       },
       "encumbFractionOneSquare": {
         "hint": "This is a Drag Ruler module setting to set the one 'square' movement limit.  The fraction applied to the maximum encumbrance formula. It only applies when the OTHER ruleset is in use.",
-        "name": "Encumbrance Fraction for 1.5m/5ft of movement"
+        "name": "Fraction of maximum encumbrance for 1.5m/5ft of movement"
       },
       "encumbFraction75pct": {
         "hint": "This is a Drag Ruler module setting to set the 75 percent movement limit.  The fraction applied to the maximum encumbrance formula. It only applies when the OTHER ruleset is in use.",
-        "name": "Encumbrance Fraction for 75 percent movement rate"
+        "name": "Fraction of maximum encumbrance for 75 percent movement rate"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1097,7 +1097,7 @@
         "hint": "This is a Drag Ruler module setting to set the one 'square' movement limit.  The fraction applied to the maximum encumbrance formula. It only applies when the OTHER ruleset is in use.",
         "name": "Encumbrance Fraction for 1.5m/5ft of movement"
       },
-      "encumbFraction75Pct": {
+      "encumbFraction75pct": {
         "hint": "This is a Drag Ruler module setting to set the 75 percent movement limit.  The fraction applied to the maximum encumbrance formula. It only applies when the OTHER ruleset is in use.",
         "name": "Encumbrance Fraction for 1.5m/5ft of movement"
       }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1092,6 +1092,14 @@
       "showHitsChangesInChat": {
         "hint": "Show a whispered chat message to GM when damage/healing is appled to an actor.",
         "name": "Show damage / healing chat message to GM"
+      },
+      "encumbFractionOneSquare": {
+        "hint": "This is a Drag Ruler module setting to set the one 'square' movement limit.  The fraction applied to the maximum encumbrance formula. It only applies when the OTHER ruleset is in use.",
+        "name": "Encumbrance Fraction for 1.5m/5ft of movement"
+      },
+      "encumbFraction75Pct": {
+        "hint": "This is a Drag Ruler module setting to set the 75 percent movement limit.  The fraction applied to the maximum encumbrance formula. It only applies when the OTHER ruleset is in use.",
+        "name": "Encumbrance Fraction for 1.5m/5ft of movement"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1099,7 +1099,7 @@
       },
       "encumbFraction75pct": {
         "hint": "This is a Drag Ruler module setting to set the 75 percent movement limit.  The fraction applied to the maximum encumbrance formula. It only applies when the OTHER ruleset is in use.",
-        "name": "Encumbrance Fraction for 1.5m/5ft of movement"
+        "name": "Encumbrance Fraction for 75 percent movement rate"
       }
     },
     "CloseAndCreateNew": "Close and create new",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fixes


* **What is the current behavior?** (You can also link to an open issue here)
** can't configure drag ruler settings for OTHER ruleset
** bonus damage not applied when rolling from chat card

* **What is the new behavior (if this is a feature change)?**
** new settings for OTHER
** bonus damage now carries forward


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
