### PR TITLE
feat: add consumable indicators and toggles

### DIFF
--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -108,6 +108,8 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     // Item State toggling
     html.find(".item-toggle").on("click", this._onToggleItem.bind(this));
     html.find(".item-viewToggle").on("click", this._onViewToggle.bind(this));
+    //Consumable Toggling
+    html.find(".consumable-toggle").on("click", this._onToggleConsumable.bind(this));
 
   }
 
@@ -263,6 +265,21 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
   private async _onViewToggle(event): Promise<void> {
     const itemType: string = $(event.currentTarget).data("itemType");
     await this.actor.update({[`system.hideStoredItems.${itemType}`]: !this.actor.system.hideStoredItems[itemType]});
+  }
+
+  /**
+   * Handle toggling the active consumable.
+   * @param {Event} event   The originating click event.
+   * @private
+   */
+  private async _onToggleConsumable(event): Promise<void> {
+    const weaponId: string = $(event.currentTarget).data("weaponId");
+    const consumableId = $(event.currentTarget).data("consumableId");
+    const weaponItem = this.actor.items.get(weaponId);
+    if (weaponItem?.system.useConsumableForAttack != consumableId) {
+      await weaponItem.update({'system.useConsumableForAttack': consumableId});
+    }
+    //console.log("Made it to toggle");
   }
 }
 

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -274,8 +274,8 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
    */
   private async _onToggleConsumable(event): Promise<void> {
     const weaponId: string = $(event.currentTarget).data("weaponId");
-    const consumableId = $(event.currentTarget).data("consumableId");
-    const weaponItem = this.actor.items.get(weaponId);
+    const consumableId: string = $(event.currentTarget).data("consumableId");
+    const weaponItem: TwodsixItem = this.actor.items.get(weaponId);
     if (weaponItem?.system.useConsumableForAttack != consumableId) {
       await weaponItem.update({'system.useConsumableForAttack': consumableId});
     }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -477,7 +477,9 @@
         "DropConsumablesHere": "You can drop consumables here.",
         "DropAttachmentsHere": "You can drop attachments here.",
         "RemoveConsumable": "Remove consumable",
-        "RemoveConsumableFrom": "Remove consumable _CONSUMABLE_NAME_ from _ITEM_NAME_?"
+        "RemoveConsumableFrom": "Remove consumable _CONSUMABLE_NAME_ from _ITEM_NAME_?",
+        "SelectConsumable": "Select Consumable",
+        "ActiveConsumable": "Active Consumable"
       },
       "Weapon": {
         "Ammo": "Ammo",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2900,6 +2900,11 @@ select.form-input, input.form-input, span.form-input {
   flex-basis: 0;
   flex-grow: 1;
 }
+
+.consumable-toggle {
+  cursor: pointer;
+  color: var(--s2d6-nav-background);
+}
 /*--- Chat Log ---*/
 
 #sidebar-tabs.tabs .item.active {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -74,7 +74,7 @@ label.checkbox > input[type="checkbox"] {
 
 .content-container {
   display: grid;
-  grid-template-columns: 316px 493px;
+  grid-template-columns: 307px 500px;
   grid-template-rows: 607px;
   gap: 1px 1px;
   position: relative;
@@ -413,8 +413,8 @@ label.checkbox > input[type="checkbox"] {
   position: relative;
   border-style: none solid none none;
   border-color: inherit;
-  width: 95%;
-  padding-right: 8px;
+  width: 97%;
+  /*padding-right: 8px;*/
   border-width: medium;
 }
 
@@ -2341,6 +2341,11 @@ select.form-input, input.form-input, span.form-input {
 .edit-active-effect, .delete-active-effect, .create-active-effect {
   flex-basis: 0;
   flex-grow: 1;
+}
+
+.consumable-toggle {
+  cursor: pointer;
+  color: var(--s2d6-nav-background);
 }
 
 /*--- Chat Log ---*/

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -14,6 +14,7 @@
       {{twodsix_refillText subtype quantity}}
     </button>
     {{/with}}
+    <span {{#iff isSelected '===' consumableId}} style="color: green;" {{else}} style="color: var(--s2d6-nav-background);" {{/iff}}> <i class="fa-solid fa-circle-check"></i></span>
   </div>
 </div>
 {{else}}

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -1,5 +1,5 @@
 {{#unless system.isAttachment}}
-<div class="consumable-row" data-consumable-id="{{id}}">
+<div class="consumable-row" data-consumable-id="{{id}}" data-weapon-id="{{weaponID}}">
   <div class="wrapper">
     {{name}}:
     {{#with system}}
@@ -14,7 +14,7 @@
       {{twodsix_refillText subtype quantity}}
     </button>
     {{/with}}
-    <span {{#iff isSelected '===' consumableId}} style="color: green;" {{else}} style="color: var(--s2d6-nav-background);" {{/iff}}> <i class="fa-solid fa-circle-check"></i></span>
+    <span class="consumable-toggle" data-consumable-id="{{consumableId}}" data-weapon-id="{{weaponID}}" {{#iff isSelected '===' consumableId}} style="color: green;" {{else}} style="color: var(--s2d6-nav-background);" {{/iff}}> <i class="fa-solid fa-circle-check"></i></span>
   </div>
 </div>
 {{else}}

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -14,7 +14,13 @@
       {{twodsix_refillText subtype quantity}}
     </button>
     {{/with}}
-    <span class="consumable-toggle" data-consumable-id="{{consumableId}}" data-weapon-id="{{weaponID}}" {{#iff isSelected '===' consumableId}} style="color: green; cursor: pointer;" {{else}} style="color: var(--s2d6-nav-background); cursor: pointer;" {{/iff}}> <i class="fa-solid fa-circle-check"></i></span>
+    <span class="consumable-toggle" data-consumable-id="{{consumableId}}" data-weapon-id="{{weaponID}}"
+      {{#iff isSelected '===' consumableId}}
+        style="color: green;" data-tooltip="{{localize 'TWODSIX.Items.Consumable.ActiveConsumable'}}"
+      {{else}}
+        data-tooltip="{{localize 'TWODSIX.Items.Consumable.SelectConsumable'}}"
+      {{/iff}}> <i class="fa-solid fa-circle-check"></i>
+    </span>
   </div>
 </div>
 {{else}}

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -14,7 +14,7 @@
       {{twodsix_refillText subtype quantity}}
     </button>
     {{/with}}
-    <span class="consumable-toggle" data-consumable-id="{{consumableId}}" data-weapon-id="{{weaponID}}" {{#iff isSelected '===' consumableId}} style="color: green;" {{else}} style="color: var(--s2d6-nav-background);" {{/iff}}> <i class="fa-solid fa-circle-check"></i></span>
+    <span class="consumable-toggle" data-consumable-id="{{consumableId}}" data-weapon-id="{{weaponID}}" {{#iff isSelected '===' consumableId}} style="color: green; cursor: pointer;" {{else}} style="color: var(--s2d6-nav-background); cursor: pointer;" {{/iff}}> <i class="fa-solid fa-circle-check"></i></span>
   </div>
 </div>
 {{else}}

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -70,7 +70,7 @@
         {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" attachmentData}}
         {{/each}}
         {{#each item.system.consumableData as |consumableData|}}
-        {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData}}
+        {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData consumableId=consumableData._id isSelected=../system.useConsumableForAttack}}
         {{/each}}
       </div>
       {{/unless}}

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -70,7 +70,7 @@
         {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" attachmentData}}
         {{/each}}
         {{#each item.system.consumableData as |consumableData|}}
-        {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData consumableId=consumableData._id isSelected=../system.useConsumableForAttack}}
+        {{> "systems/twodsix/templates/actors/parts/actor/actor-consumable.html" consumableData consumableId=consumableData._id isSelected=../system.useConsumableForAttack weaponID= ../id}}
         {{/each}}
       </div>
       {{/unless}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)
no way to tell which magazine is selected on actor sheet
no easy way to switch consumables on actor sheet


* **What is the new behavior (if this is a feature change)?**
place indicators next to consumable lines to indicate if used for attack roll
add ability to toggle active consumable

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
