### PR TITLE
feat: add armament ammo counter

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -937,10 +937,10 @@ export function getPower(item: Component): number{
 }
 
 export function getWeight(item: Component, actorData): number{
-  let q = item.quantity ?? 1;
-  if (["armament", "fuel"].includes(item.subtype) && item.availableQuantity) {
+  const q = item.quantity ?? 1;
+  /*if (["armament", "fuel"].includes(item.subtype) && item.availableQuantity) {
     q = parseInt(item.availableQuantity);
-  }
+  }  make true displacement and not mass*/
   let w = 0;
   if (item.weightIsPct) {
     w = (item.weight ?? 0) / 100 * actorData.system.shipStats.mass.max;

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -523,6 +523,7 @@ export interface Component extends GearTemplate, LinkTemplate {
   actorLink: string;
   hardened: boolean;
   associatedSkillName:string;
+  ammunition:Encumbrance;
 }
 
 export interface Consumable extends GearTemplate, LinkTemplate {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -331,6 +331,7 @@
         "ValueCr": "Value in Cr"
       },
       "Component": {
+        "Ammunition":"Ammuniton",
         "componentName": "Component",
         "accomodations": "accomodations",
         "armament": "armament",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2570,13 +2570,14 @@ a.ship-notes-tab.active {
 
 .grid-columns-double-row:nth-of-type(4n+3), .grid-columns-double-row:nth-of-type(4n+4) {
   background: var(--s2d6-skill-list-even);
-  height: -webkit-fill-available;
-  height: -moz-available;
+  height: 100%;
+  align-items: center;
+  display: grid;
 }
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 12.5em 3em 6em 3em 4em 4em 4em 4.5em 1.5em 4.5em 3.2em 3em;
+  grid-template-columns: 12.5em 2em 6em 3em 4em 4em 5.5em 4.5em 1.5em 4em 3.2em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
   grid-template-areas:

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1990,18 +1990,21 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
   /*border-right: 1px solid var(--s2d6-form-light);*/
 }
 
-grid-columns-double-row {
+.grid-columns-double-row {
   align-self: center;
 }
 
 .grid-columns-double-row:nth-of-type(4n+3), .grid-columns-double-row:nth-of-type(4n+4) {
   background: var(--s2d6-skill-list-even);
   border-right: 1px solid var(--s2d6-form-light);
+  height: 100%;
+  align-items: center;
+  display: grid;
 }
 
 .components-stored-single {
   display: grid;
-  grid-template-columns: 12.5em 3em 6em 3em 4em 4em 4em 4.5em 1.5em 4.5em 3.2em 3em;
+  grid-template-columns: 12.5em 2em 6em 3em 4em 4em 5.5em 4.5em 1.5em 4em 3.2em 3em;
   grid-template-rows: 1fr;
   gap: 1px;
   grid-template-areas: ". . . . . . . . . . . .";

--- a/static/system.json
+++ b/static/system.json
@@ -24,8 +24,8 @@
   ],
   "compatibility":
     {
-      "minimum": "10",
-      "verified": "10"
+      "minimum": "10.291",
+      "verified": "10.291"
     },
   "description": "Twodsix: A system for use with the Cepheus Engine Core Rules, Traveller (unofficial), and other similar games. <br/>This Product is derived from the Traveller System Reference Document and other Open Gaming Content made available by the Open Gaming License, and does not contain closed content from products published by either Mongoose Publishing or Far Future Enterprises. This Product is not affiliated with either Mongoose Publishing or Far Future Enterprises, and it makes no claim to or challenge to any trademarks held by either entity. The use of the Traveller System Reference Document does not convey the endorsement of this Product by either Mongoose Publishing or Far Future Enterprises as a product of either of their product lines.<br/>Cepheus Engine and Samardan Press™ are the trademarks of Jason \"Flynn\" Kemp; we are not affiliated with Jason \"Flynn\" Kemp or Samardan Press™.<br/> See the files OpenGameLicense.md and LICENSE for license details.<br/>",
   "esmodules": ["twodsix.bundle.js"],

--- a/static/template.json
+++ b/static/template.json
@@ -659,7 +659,11 @@
       "armorPiercing": 0,
       "actorLink": "",
       "hardened": false,
-      "associatedSkillName": ""
+      "associatedSkillName": "",
+      "ammunition": {
+        "value": 0,
+        "max":0
+      }
     },
     "ship_position": {
       "name": "",

--- a/static/templates/actors/parts/ship/ship-component-double-item.html
+++ b/static/templates/actors/parts/ship/ship-component-double-item.html
@@ -6,7 +6,20 @@
       {{else}}
         <a class="item-link orange" data-uuid="{{item.system.actorLink}}">{{item.name}}{{#if settings.allowDragDropOfLists}} <i class= '{{twodsix_getComponentIcon item.system.subtype}}' data-tooltip='{{localize (concat "TWODSIX.Items.Component." item.system.subtype)}}'></i>{{/if}}</a>
       {{/iff}}
-      <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
+      {{#iff item.system.subtype "===" "armament"}}
+          {{#iff item.system.ammunition.max "!==" 0}}
+            <span class="item-name centre">{{item.system.ammunition.value}}
+              <span class="combined-buttons" data-field="ammo">
+                <button class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+                <button class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
+              </span>
+            </span>
+          {{else}}
+            <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
+          {{/iff}}
+      {{else}}
+        <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
+      {{/iff}}
       <span class="item-name centre">{{#iff item.system.techLevel ">" "0"}}{{item.system.techLevel}}{{else}}&mdash;{{/iff}}</span>
       <span class="item-name centre">{{item.system.rating}}</span>
       <span class="item-name centre component-toggle">

--- a/static/templates/actors/parts/ship/ship-component-single-item.html
+++ b/static/templates/actors/parts/ship/ship-component-single-item.html
@@ -28,8 +28,20 @@
       {{/if}}
       <span class="item-name centre">{{getComponentWeight item}}</span>
       <span class="item-name centre">{{getComponentPower item}}</span>
-      <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
-
+      {{#iff item.system.subtype "===" "armament"}}
+          {{#iff item.system.ammunition.max "!==" 0}}
+            <span class="item-name centre">{{item.system.ammunition.value}}
+              <span class="combined-buttons" data-field="ammo">
+                <button class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+                <button class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
+              </span>
+            </span>
+          {{else}}
+            <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
+          {{/iff}}
+      {{else}}
+        <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
+      {{/iff}}
       <span class="item-name centre">
         {{#iff item.system.subtype "===" "armament"}}
           {{#iff item.system.damage "!==" ""}}<span class="roll-damage orange">{{twodsix_limitLength item.system.damage 3}}{{else}}&mdash;{{/iff}}</span>
@@ -39,10 +51,10 @@
       </span>
       <span class="item-name centre">{{#if item.system.hardened}}<i class="fa-solid fa-gem"></i>{{else}}&mdash;{{/if}}</span>
       <span class="item-name centre">{{item.system.hits}}
-      <span class="combined-buttons">
-        <button class="left-button adjust-hits" {{#iff currentCount "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-        <button class="right-button adjust-hits" {{#iff currentCount "===" 9}}disabled{{/iff}} data-value="1" >+</button>
-      </span>
+        <span class="combined-buttons" data-field="hits">
+          <button class="left-button adjust-counter" {{#iff item.system.hits "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+          <button class="right-button adjust-counter" {{#iff item.system.hits "===" settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
+        </span>
       </span>
       <span class="item-name centre component-toggle">
         {{#iff item.system.status "===" 'operational'}} <i class="fa-solid fa-circle-check" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.operational"}}'></i>

--- a/static/templates/items/component-sheet.html
+++ b/static/templates/items/component-sheet.html
@@ -152,6 +152,14 @@
       <label for = "system.associatedSkillName" class="resource-label">{{localize "TWODSIX.Items.Equipment.AssociatedSkillName"}}</label>
       <input class="form-input" id = "system.associatedSkillName" type="text" name="system.associatedSkillName" value="{{system.associatedSkillName}}" />
     </div>
+    <div class="item-data">
+      <label class="resource-label">{{localize "TWODSIX.Items.Component.Ammunition"}}</label>
+        <div>
+          <input id="system.ammunition.value" class="form-consumable-count" name="system.ammunition.value" type="number" value="{{system.ammunition.value}}" data-dtype="Number"/>
+          /
+          <input id="system.ammunition.max" class="form-consumable-count" name="system.ammunition.max" type="number" value="{{system.ammunition.max}}" data-dtype="Number"/>
+        </div>
+    </div>
     {{/iff}}
     <div class="item-hits">
       <label for="system.hits" class="resource-label">{{localize "TWODSIX.Items.Component.hits"}}</label>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)
No ability to count ammo load out for armament components


* **What is the new behavior (if this is a feature change)?**
add new counter field on ship sheet


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO


* **Other information**:
Fix displacement mass calc to always use value for armament and fuel components