### PR TITLE
fix: Chain rolls and Computer attachments

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -260,9 +260,11 @@ export default function registerHandlebarsHelpers(): void {
       return 0;
     } else {
       let bandwidth = 0;
-      for (const attch of item.system.attachmentData) {
-        if (attch.system.subtype === "software" && attch.system.softwareActive) {
-          bandwidth += attch.system.bandwidth;
+      if (item.system?.attachmentData) {
+        for (const attch of item.system.attachmentData) {
+          if (attch.system.subtype === "software" && attch.system.softwareActive) {
+            bandwidth += attch.system.bandwidth;
+          }
         }
       }
       return (bandwidth);

--- a/src/module/hooks/chatCard.ts
+++ b/src/module/hooks/chatCard.ts
@@ -56,7 +56,7 @@ async function onChatCardAction(event: Event): Promise<any> {
   }
 
   // Validate permission to proceed with the roll
-  const isTargetted = action === "save";
+  const isTargetted = ["chain", "opposed", "expand"].includes(action);
   if ( !( isTargetted || game.user.isGM || actor.isOwner ) ) {
     return;
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fixes


* **What is the current behavior?** (You can also link to an open issue here)
- Players can't make chain or opposed rolls from other actor chat cards
- Computers with no attachments break actor sheet


* **What is the new behavior (if this is a feature change)?**
- Players can roll from other player's chat cards
- Handlebar now checks for no attachments first.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
