### PR TITLE
fix: drop Item without effects and Monk's Journal Loot & Shop Sheets

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -734,7 +734,13 @@ export default class TwodsixActor extends Actor {
       return false;
     }
 
-    const transferData = itemData.toJSON();
+    let transferData = {};
+    //Need to catach because Monk's enhanced Journal drops item data not TwodsixItem
+    try {
+      transferData = itemData.toJSON();
+    } catch(err) {
+      transferData = itemData;
+    }
     let numberToMove = itemData.system?.quantity ?? 1;
 
     //Handle moving items from another actor if enabled by settings
@@ -780,7 +786,7 @@ export default class TwodsixActor extends Actor {
     // Prepare effects
     transferData.system.equipped = "ship";
     transferData._id = "";
-    if (game.settings.get('twodsix', "useItemActiveEffects")  && transferData.effects.length > 0) {
+    if (game.settings.get('twodsix', "useItemActiveEffects")  && transferData.effects?.length > 0) {
       //clear extra item effects - should be fixed
       while (transferData.effects.length > 1) {
         transferData.effects.pop();

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -36,7 +36,7 @@ export default class TwodsixItem extends Item {
       item.update({"system.value": 0});
     }
 
-    //Remove any attached consumables - needed????
+    //Remove any attached consumables - needed for modules (like Monks Enhanced Journals) that have own drop management
     if (item?.system?.consumables?.length > 0) {
       await item.update({"system.consumables": []});
     }

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -37,7 +37,7 @@ export default class TwodsixItem extends Item {
     }
 
     //Remove any attached consumables - needed????
-    if (item.system.consumables?.length > 0) {
+    if (item?.system?.consumables?.length > 0) {
       await item.update({"system.consumables": []});
     }
 

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -35,6 +35,12 @@ export default class TwodsixItem extends Item {
     if (item?.type === "skills" && game.settings.get('twodsix', 'hideUntrainedSkills')) {
       item.update({"system.value": 0});
     }
+
+    //Remove any attached consumables - needed????
+    if (item.system.consumables?.length > 0) {
+      await item.update({"system.consumables": []});
+    }
+
     return item;
   }
 

--- a/src/module/hooks/chatCard.ts
+++ b/src/module/hooks/chatCard.ts
@@ -137,8 +137,10 @@ function onChatCardToggleContent(event: Event) {
   event.preventDefault();
   const header = event.currentTarget;
   const card = header.closest(".chat-card");
-  const content = card.querySelector(".card-content");
-  content.style.display = content.style.display === "none" ? "block" : "none";
+  if (card) { //Check needed for MEJ Messages
+    const content = card.querySelector(".card-content");
+    content.style.display = content.style.display === "none" ? "block" : "none";
+  }
 }
 
 /* -------------------------------------------- */

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -189,7 +189,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
     } else if (fromUuidSync(this.item.uuid)) {
       const editSheet = this.item.effects.contents[0].sheet?.render(true);
       try {
-        editSheet.bringToTop();
+        editSheet?.bringToTop();
       } catch(err) {
         //nothing
       }

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -159,19 +159,23 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
           flags: {twodsix: {sourceId: newId}}
 
         }).toObject()];
-        await this.item.update({effects: effects }, {recursive: true});
-        const newEffect = this.item.effects.contents[0].toObject();
-        //newEffect.flags = {twodsix: {sourceId: newEffect._id}};
-        //await this.item.update({effects: [newEffect] }, {recursive: true});
+        if (fromUuidSync(this.item.uuid)) {
+          await this.item.update({effects: effects }, {recursive: true});
+          const newEffect = this.item.effects.contents[0].toObject();
+          //newEffect.flags = {twodsix: {sourceId: newEffect._id}};
+          //await this.item.update({effects: [newEffect] }, {recursive: true});
 
-        if (this.actor) {
-          newEffect.transfer = false;
-          const oldId = newEffect._id;
-          newEffect._id = "";
-          await this.actor.createEmbeddedDocuments("ActiveEffect", [newEffect]);
-          this.actor.effects.find(effect => effect.getFlag("twodsix", "sourceId") === oldId)?.sheet?.render(true);
+          if (this.actor) {
+            newEffect.transfer = false;
+            const oldId = newEffect._id;
+            newEffect._id = "";
+            await this.actor.createEmbeddedDocuments("ActiveEffect", [newEffect]);
+            this.actor.effects.find(effect => effect.getFlag("twodsix", "sourceId") === oldId)?.sheet?.render(true);
+          } else {
+            this.item.effects.contents[0].sheet?.render(true);
+          }
         } else {
-          this.item.effects.contents[0].sheet?.render(true);
+          ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.CantCreateEffect"));
         }
       }
     }
@@ -182,8 +186,15 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       this.actor.effects.find(effect => effect.getFlag("twodsix", "sourceId") === this.item.effects.contents[0].id)?.sheet?.render(true);
     } else if (this.actor?.type === "ship" || this.actor?.type === "vehicle") {
       ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.CantEditCreateInCargo"));
+    } else if (fromUuidSync(this.item.uuid)) {
+      const editSheet = this.item.effects.contents[0].sheet?.render(true);
+      try {
+        editSheet.bringToTop();
+      } catch(err) {
+        //nothing
+      }
     } else {
-      this.item.effects.contents[0].sheet?.render(true);
+      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.CantEditEffect"));
     }
   }
 
@@ -192,13 +203,17 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       title: game.i18n.localize("TWODSIX.ActiveEffects.DeleteEffect"),
       content: game.i18n.localize("TWODSIX.ActiveEffects.ConfirmDelete"),
       yes: async () => {
-        if (this.actor) {
-          const id = this.actor.effects.find(effect => effect.getFlag("twodsix", "sourceId") === this.item.effects.contents[0].id)?.id;
-          if (id) {
-            this.actor.deleteEmbeddedDocuments("ActiveEffect", [id]);
+        if (fromUuidSync(this.item.uuid)) {
+          if (this.actor) {
+            const id = this.actor.effects.find(effect => effect.getFlag("twodsix", "sourceId") === this.item.effects.contents[0].id)?.id;
+            if (id) {
+              await this.actor.deleteEmbeddedDocuments("ActiveEffect", [id]);
+            }
           }
+          await this.item.update({effects: [] }, {recursive: false});
+        } else {
+          ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.CantDeleteEffect"));
         }
-        await this.item.update({effects: [] }, {recursive: false});
       },
       no: () => {
         //Nothing

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -69,7 +69,7 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
       classes: ["twodsix", "ship", "actor"],
       template: "systems/twodsix/templates/actors/ship-sheet.html",
       width: 825,
-      height: 674,
+      height: 686,
       resizable: false,
       tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "ship-positions"}],
       scrollY: [".ship-positions", ".ship-crew", ".ship-component", ".ship-storage", ".storage-wrapper", ".finances", ".ship-notes"],

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -212,8 +212,8 @@ export async function getItemDataFromDropData(dropData:Record<string, any>) {
   let item;
   if (game.modules.get("monks-enhanced-journal")?.active && dropData.itemId && dropData.uuid.includes("JournalEntry")) {
     const journalEntry = await fromUuidSync(dropData.uuid);
-    const lootItems = await journalEntry.getFlag('monks-enhanced-journal', 'items');
-    item = await lootItems.find((it:TwodsixItem) => it._id === dropData.itemId);
+    const lootItems = await journalEntry.getFlag('monks-enhanced-journal', 'items'); // Note that MEJ items are JSON data and not full item documents
+    item = await lootItems.find((it) => it._id === dropData.itemId);
     if (item.system.consumables?.length > 0) {
       item.system.consumables = [];
     }

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -1,8 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
-
 //Assorted utility functions likely to be helpful when displaying characters
-
 
 // export function pseudoHex(value:number):string {
 //   switch (value) {
@@ -211,7 +209,18 @@ export function getDataFromDropEvent(event:DragEvent):Record<string, any> {
 }
 
 export async function getItemDataFromDropData(dropData:Record<string, any>) {
-  let item = await fromUuidSync(dropData.uuid);  //NOTE THIS MAY NEED TO BE CHANGED TO fromUuidSync  ****
+  let item;
+  if (game.modules.get("monks-enhanced-journal")?.active && dropData.itemId && dropData.uuid.includes("JournalEntry")) {
+    const journalEntry = await fromUuidSync(dropData.uuid);
+    const lootItems = await journalEntry.getFlag('monks-enhanced-journal', 'items');
+    item = await lootItems.find((it:TwodsixItem) => it._id === dropData.itemId);
+    if (item.system.consumables?.length > 0) {
+      item.system.consumables = [];
+    }
+  } else {
+    item = await fromUuidSync(dropData.uuid);  //NOTE THIS MAY NEED TO BE CHANGED TO fromUuidSync  ****
+  }
+
   if (!item) {
     throw new Error(game.i18n.localize("TWODSIX.Errors.CouldNotFindItem").replace("_ITEM_ID_", dropData.uuid));
   }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1212,7 +1212,9 @@
       "NoSkillSelected": "Must select a skill to make a roll",
       "NoDamageForWeapon": "This weapon has not specified the damage it does.",
       "ActionWarningNoToken": "No targets selected for action.",
-      "CantEditEffect": "Can't edit effect for item that is not embedded in Actor."
+      "CantEditEffect": "Can't edit effect for item that is embedded in non-Actor.",
+      "CantCreateEffect": "Can't create an effect for item that is embedded in non-Actor.",
+      "CantDeleteEffect": "Can't delete an effect for item that is embedded in non-Actor."
     }
   },
   "VeryDifficult": "Very Difficult"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -517,7 +517,8 @@
         "Modifiers": "Modifiers",
         "Attack": "Attack",
         "Consumables": "Consumables",
-        "DefaultMagazine": "Default Magazine Size"
+        "DefaultMagazine": "Default Magazine Size",
+        "HandlingExample": "e.g., DEX 6/-3 10/+4"
       },
       "Spells": {
         "CircleSchool": "Spell Circle/School",
@@ -1210,7 +1211,8 @@
       "NoActorSelected": "An actor must be selected or controlled",
       "NoSkillSelected": "Must select a skill to make a roll",
       "NoDamageForWeapon": "This weapon has not specified the damage it does.",
-      "ActionWarningNoToken": "No targets selected for action."
+      "ActionWarningNoToken": "No targets selected for action.",
+      "CantEditEffect": "Can't edit effect for item that is not embedded in Actor."
     }
   },
   "VeryDifficult": "Very Difficult"

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2060,7 +2060,7 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
   /*margin-top: 1.1em;*/
   overflow-y: auto;
   height: 12em;
-  width: 784px;
+  width: 778px;
   margin-left: 15px;
   /*padding: 0 0.5em;*/
 }

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2847,3 +2847,48 @@ input[type="text"].color {
   display: inline-flex;
   padding-bottom: 4px;
 }
+
+/* ******************************
+Monk's Enhanced Journals
+************************** */
+.monks-enhanced-journal .editor-edit {
+  z-index: 100;
+  display: block;
+}
+
+
+.monks-journal-sheet.sheet .editor {
+  overflow: auto;
+  height: 100%;
+}
+
+.monks-journal-sheet.sheet .journal-subsheet .items-list .item-controls {
+  margin-top: unset;
+  text-align: center;
+  display: unset;
+}
+
+.monks-journal-sheet.sheet .items-list {
+  position: revert;
+}
+
+.loot-character > .character-name {
+    position: unset;
+    margin-top: unset;
+    text-align: unset;
+    z-index: unset;
+    left: unset
+}
+
+.monks-journal-sheet.sheet .items-list .items-header > *, #journal-editcurrency .items-list .items-header > * {
+  display: unset;
+}
+
+.edit-currency .items-list {
+  position: unset;
+}
+
+.edit-currency .items-list input, .item-total.flexrow, .item-price.flexrow, .item-quantity.flexrow  {
+  display: unset;
+  text-align: right;
+}

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -116,3 +116,14 @@ div.pdf-app section.window-content {
 .monks-enhanced-journal .mainbar .navigation .nav-button.disabled, .monks-enhanced-journal footer.navigation .nav-button.disabled {
   color: var(--s2d6-default-color);
 }
+
+.monks-journal-sheet.sheet .items-list {
+  position: revert;
+}
+.loot-character > .character-name {
+    position: unset;
+    margin-top: unset;
+    text-align: unset;
+    z-index: unset;
+    left: unset
+}

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -103,6 +103,7 @@ div.pdf-app section.window-content {
 
 .monks-journal-sheet.sheet .journal-subsheet .items-list .item-controls {
   margin-top: unset;
+  text-align: center;
 }
 
 .monks-enhanced-journal .mainbar .navigation .button-group {
@@ -126,4 +127,20 @@ div.pdf-app section.window-content {
     text-align: unset;
     z-index: unset;
     left: unset
+}
+
+.monks-journal-sheet.sheet .items-list .items-header > *, #journal-editcurrency .items-list .items-header > * {
+  display: unset;
+}
+
+.edit-currency .items-list {
+  position: unset;
+}
+
+.edit-currency .items-list input {
+  color: var(--s2d6-default-color);
+}
+.item-price.flexrow {
+  display: unset;
+  text-align: right;
 }

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -97,13 +97,14 @@ div.pdf-app section.window-content {
   height: 100%;
 }
 
-.monks-journal-sheet.sheet .items-list .item .item-name {
-  color: revert;
+.monks-journal-sheet.sheet .items-list .item .item-name, .monks-journal-sheet.sheet .form-group label, .monks-journal-sheet.sheet .items-list {
+  color: var(--s2d6-form-light);
 }
 
 .monks-journal-sheet.sheet .journal-subsheet .items-list .item-controls {
   margin-top: unset;
   text-align: center;
+  display: unset;
 }
 
 .monks-enhanced-journal .mainbar .navigation .button-group {
@@ -137,10 +138,8 @@ div.pdf-app section.window-content {
   position: unset;
 }
 
-.edit-currency .items-list input {
+.edit-currency .items-list input, .item-total.flexrow, .item-price.flexrow, .item-quantity.flexrow  {
   color: var(--s2d6-default-color);
-}
-.item-price.flexrow {
   display: unset;
   text-align: right;
 }

--- a/static/templates/items/parts/weapon-sheet-flat.html
+++ b/static/templates/items/parts/weapon-sheet-flat.html
@@ -27,7 +27,7 @@
 
   <div class="item-handling">
     <label class="resource-label">{{localize "TWODSIX.Items.Weapon.HandlingModifiers"}}</label>
-    <input class="form-input" id="system.handlingModifiers" type="text" placeholder="DEX 6/-3 10/+4" name="system.handlingModifiers" value="{{system.handlingModifiers}}">
+    <input class="form-input" id="system.handlingModifiers" type="text" placeholder="{{localize 'TWODSIX.Items.Weapon.HandlingExample'}}" name="system.handlingModifiers" value="{{system.handlingModifiers}}">
   </div>
   {{> "systems/twodsix/templates/items/parts/aoe-parts.html"}}
   <div class="item-ammo">

--- a/static/templates/items/parts/weapon-sheet-tabbed.html
+++ b/static/templates/items/parts/weapon-sheet-tabbed.html
@@ -120,7 +120,7 @@
 
       <div class="item-handling">
         <label class="resource-label">{{localize "TWODSIX.Items.Weapon.HandlingModifiers"}}</label>
-        <input class="form-input" id="system.handlingModifiers" type="text" placeholder="DEX 6/-3 10/+4" name="system.handlingModifiers" value="{{system.handlingModifiers}}">
+        <input class="form-input" id="system.handlingModifiers" type="text" placeholder="{{localize 'TWODSIX.Items.Weapon.HandlingExample'}}" name="system.handlingModifiers" value="{{system.handlingModifiers}}">
       </div>
 
       {{#if settings.useItemAEs}}{{> "systems/twodsix/templates/items/parts/footer.html"}}{{/if}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fixes


* **What is the current behavior?** (You can also link to an open issue here)

items without effects cause error on drop
Monks journal Loot sheet doesn't work as it drops itemData and not item object
Monks Journal Items not compatible with AE embedded on items.
MEJ css incompatibilities.

* **What is the new behavior (if this is a feature change)?**
fix above


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
