### PR TITLE
feat: add damage type calcs to secondary armor

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -379,14 +379,25 @@ export default class TwodsixItem extends Item {
         }
       }
 
+      //Deterime Damage type
+      let damageType:string = this.getConsumableDamageType();
+      if (damageType === '') {
+        damageType = weapon.damageType;
+      }
+
       const contentData = {};
-      const flavor = `${game.i18n.localize("TWODSIX.Rolls.DamageUsing")} ${this.name}, ${game.i18n.localize("TWODSIX.Damage.AP")}(${apValue})`;
+      let flavor = `${game.i18n.localize("TWODSIX.Rolls.DamageUsing")} ${this.name}, ${game.i18n.localize("TWODSIX.Damage.AP")}(${apValue})`;
+      if (damageType) {
+        flavor += `, ${game.i18n.localize("TWODSIX.Items.Weapon.damageType")}: ${damageType}`;
+      }
+
       Object.assign(contentData, {
         flavor: flavor,
         roll: damage,
         dice: getDiceResults(damage), //damage.terms[0]["results"]
         armorPiercingValue: apValue,
-        damage: (damage.total && damage.total > 0) ? damage.total : 0
+        damageValue: (damage.total && damage.total > 0) ? damage.total : 0,
+        damageType: damageType
       });
 
       if (radDamage.total) {
@@ -447,6 +458,15 @@ export default class TwodsixItem extends Item {
       if (magazine?.type === "consumable" && magazine?.system[type]) {
         returnValue += (<Consumable>magazine.system)[type];
       }
+    }
+    return returnValue;
+  }
+
+  public getConsumableDamageType():string {
+    let returnValue = "";
+    if (this.system.useConsumableForAttack && this.actor) {
+      const magazine = this.actor.items.get(this.system.useConsumableForAttack);
+      returnValue = magazine ? magazine.system.damageType : "";
     }
     return returnValue;
   }

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -254,7 +254,7 @@ export interface Traveller {
   radiationDose:Hits;
   encumbrance:Encumbrance;
   primaryArmor:PrimaryArmor;
-  secondaryArmor:PrimaryArmor;
+  secondaryArmor:SecondaryArmor;
   heroPoints:number;
   radiationProtection:PrimaryArmor;
   contacts:string;
@@ -396,6 +396,11 @@ export interface Finances {
 
 export interface PrimaryArmor {
   value:number;
+}
+
+export interface SecondaryArmor {
+  value:number;
+  protectionTypes:string;
 }
 
 export interface ShipAction {
@@ -553,6 +558,7 @@ export interface Consumable extends GearTemplate, LinkTemplate {
   isAttachment:boolean;
   bandwidth:number;
   softwareActive:boolean;
+  damageType:string;
 }
 
 export interface Equipment extends GearTemplate, LinkTemplate {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -319,7 +319,8 @@
         "Armor": "Armor",
         "SecondaryArmor": "Secondary Armor",
         "RadProt": "Rad Protection",
-        "IsPowered": "Powered Armor"
+        "IsPowered": "Powered Armor",
+        "SecondaryArmorProtectionTypes": "Secondary Protection Types"
       },
       "Augmentation": {
         "Arms": "Arms",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -3526,9 +3526,9 @@ div.app.window-app.minimized.twodsix.ship.actor header a.close {
   width: 30px;
 }
 
-.damage-dialog .damage, .damage-dialog .armor{
+/*.damage-dialog .damage, .damage-dialog .armor{
   width: 50px;
-}
+}*/
 
 .damage-dialog .center-table-text {
   text-align: center;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2777,9 +2777,9 @@ form .form-group > label {
   width: 30px;
 }
 
-.damage-dialog .damage, .damage-dialog .armor{
+/*.damage-dialog .damage, .damage-dialog .armor{
   width: 50px;
-}
+}*/
 
 .damage-dialog .center-table-text {
   text-align: center;

--- a/static/template.json
+++ b/static/template.json
@@ -577,7 +577,8 @@
       "templates": ["gearTemplate", "referenceTemplate"],
       "armor": 0,
       "secondaryArmor": {
-        "value": 0
+        "value": 0,
+        "protectionTypes": ""
       },
       "radiationProtection": {
         "value": 0
@@ -639,7 +640,8 @@
       "bonusDamage": "",
       "isAttachment": false,
       "bandwidth": 0,
-      "softwareActive": true
+      "softwareActive": true,
+      "damageType": ""
     },
     "component": {
       "templates": ["gearTemplate", "referenceTemplate"],

--- a/static/templates/actors/damage-dialog.html
+++ b/static/templates/actors/damage-dialog.html
@@ -4,16 +4,29 @@
     <thead>
       <tr>
         <td>{{localize "TWODSIX.Damage.Damage"}}</td>
+        <td>{{localize "TWODSIX.Items.Armor.Armor"}}</td>
+        <td>{{localize "TWODSIX.Items.Armor.SecondaryArmor"}}</td>
         <td>{{localize "TWODSIX.Actor.Items.EffectiveArmor"}}</td>
         <td>{{localize "TWODSIX.Damage.TotalDamage"}}</td>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td><input type="number" value="{{damage}}" class="damage"></td>
-        <td><input type="number" value="{{armor}}" class="armor"></td>
+        <td><input type="number" value="{{damageValue}}" class="damage"></td>
+        <td><input type="number" value="{{primaryArmor}}" class="armor" readonly></td>
+        <td><input type="number" value="{{secondaryArmor}}" class="armor" readonly></td>
+        <td><input type="number" value="{{effectiveArmor}}" class="armor"></td>
         <td class="applied-damage"></td>
       </tr>
+      {{#iff damageType "!==" ""}}
+      <tr>
+        <td></td>
+        <td></td>
+        <td>({{damageType}})</td>
+        <td></td>
+        <td></td>
+      </tr>
+      {{/iff}}
     </tbody>
   </table>
 

--- a/static/templates/chat/damage-message.html
+++ b/static/templates/chat/damage-message.html
@@ -19,8 +19,8 @@
           </div>
         </section>
       </div>
-      {{#iff damage '>' '0'}}
-        <h4 class="dice-total">{{damage}}</h4>
+      {{#iff damageValue '>' '0'}}
+        <h4 class="dice-total">{{damageValue}}</h4>
       {{else}}
         <h4 class="dice-total">{{localize "TWODSIX.Damage.NoRegularDamage"}}</h4>
       {{/iff}}

--- a/static/templates/items/armor-sheet.html
+++ b/static/templates/items/armor-sheet.html
@@ -13,6 +13,11 @@
       <input class="form-input" id="system.secondaryArmor.value" type="text" name="system.secondaryArmor.value" value="{{system.secondaryArmor.value}}" data-dtype="Number"/>
     </div>
 
+    <div class="item-secondaryArmor">
+      <label for="system.secondaryArmor.protectionTypes" class="resource-label">{{localize "TWODSIX.Items.Armor.SecondaryArmorProtectionTypes"}}</label>
+      <input class="form-input" id="system.secondaryArmor.protectionTypes" type="text" name="system.secondaryArmor.protectionTypes" value="{{system.secondaryArmor.protectionTypes}}"/>
+    </div>
+
     <div class="item-radiationProtection">
       <label for="system.radiationProtection.value" class="resource-label">{{localize "TWODSIX.Items.Armor.RadProt"}}</label>
       <input class="form-input" id="system.radiationProtection.value" type="text" name="system.radiationProtection.value" value="{{system.radiationProtection.value}}" data-dtype="Number"/>

--- a/static/templates/items/consumable-sheet.html
+++ b/static/templates/items/consumable-sheet.html
@@ -57,6 +57,11 @@
       <input class="form-input" id="system.bonusDamage" type="text" name="system.bonusDamage" value="{{system.bonusDamage}}" data-dtype="String"/>
     </div>
 
+    <div class="item-data">
+      <label class="resource-label">{{localize "TWODSIX.Items.Weapon.damageType"}}</label>
+      <input class="form-input" id="system.damageType" type="text" name="system.damageType" value="{{system.damageType}}" data-dtype="String"/>
+    </div>
+
     <div class="item-descr">
       <span class="resource-label">{{localize "TWODSIX.Items.Equipment.Description"}}</span>
       <div contenteditable="true" data-edit="system.description">{{{system.description}}}</div>

--- a/static/templates/items/parts/weapon-sheet-flat.html
+++ b/static/templates/items/parts/weapon-sheet-flat.html
@@ -10,6 +10,13 @@
     <input class="form-input" id="system.damage" type="text" name="system.damage" value="{{system.damage}}">
   </div>
 
+  {{#if settings.ShowDamageType}}
+  <div class="item-damageType">
+    <label class="resource-label">{{localize "TWODSIX.Items.Weapon.damageType"}}</label>
+    <input class="form-input" id="system.damageType" type="text" name="system.damageType" value= "{{system.damageType}}"></div>
+  </div>
+  {{/if}}
+
   <div class="item-damage">
     <label class="resource-label">{{localize "TWODSIX.Items.Weapon.ArmorPiercing"}}</label>
     <input class="form-input" id="system.armorPiercing" type="number" name="system.armorPiercing" value="{{system.armorPiercing}}" step="1" oninput="this.value = Math.round(this.value);">
@@ -56,13 +63,6 @@
   <div class="item-weaponType">
     <label class="resource-label">{{localize "TWODSIX.Items.Weapon.weaponType"}}</label>
     <input class="form-input" id="system.weaponType" type= "text" name="system.weaponType" value="{{system.weaponType}}">
-  </div>
-  {{/if}}
-
-  {{#if settings.ShowDamageType}}
-  <div class="item-damageType">
-    <label class="resource-label">{{localize "TWODSIX.Items.Weapon.damageType"}}</label>
-    <input class="form-input" id="system.damageType" type="text" name="system.damageType" value= "{{system.damageType}}"></div>
   </div>
   {{/if}}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Secondary armor does nothing


* **What is the new behavior (if this is a feature change)?**
Secondary armor is used depending on damage type


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
