### PR TITLE
fix: warning for dropping actor onto non-editing field

### DIFF
--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -261,6 +261,11 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       return false;
     }
 
+    if (actor.type === "traveller" && dropData.type === "Actor") {
+      ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.CantDragActorOntoActor"));
+      return false;
+    }
+
     if (dropData.type === 'damageItem') {
       const useInvertedShiftClick:boolean = (<boolean>game.settings.get('twodsix', 'invertSkillRollShiftClick'));
       const showDamageDialog = useInvertedShiftClick ? event["shiftKey"] : !event["shiftKey"];

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1204,6 +1204,7 @@
       "CantAutoDamage": "Automatic damage of ship or vehicle is not supported",
       "CantDropOnToken": "Dropping items on ship or vehicle tokens is not supported",
       "CantDragOntoActor": "This item can't be dragged onto this actor",
+      "CantDragActorOntoActor": "Can only drag actor reference onto an active ProseMirror text box.",
       "PDFPagerNotInstalled": "PDF Pager must be installed to use source links.",
       "NoSpecfiedLink": "No document and page specified for document link.",
       "NoTargetFound": "No target for dropping found.",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Error when dropping actor onto actor sheet in non-Prose mirror field


* **What is the new behavior (if this is a feature change)?**
Create warning that can't drop actor


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


No
* **Other information**:
