### PR TITLE
fix: add junk and storage items back to actor sheet

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -151,7 +151,7 @@ export default class TwodsixActor extends Actor {
 
   getActorEncumbrance():number {
     let encumbrance = 0;
-    const actorItems = this.items.filter( i => !["skills", "junk", "storage", "trait", "ship_position"].includes(i.type));
+    const actorItems = this.items.filter( i => !["skills", "trait", "ship_position", "storage"].includes(i.type));
     for (const item of actorItems) {
       encumbrance += getEquipmentWeight(<TwodsixItem>item);
     }
@@ -896,7 +896,7 @@ export default class TwodsixActor extends Actor {
       case 'traveller':
         if (itemData.type === 'skills') {
           return this._addDroppedSkills(itemData);
-        } else if (!["component", "junk", "storage", "ship_position"].includes(itemData.type)) {
+        } else if (!["component", "ship_position"].includes(itemData.type)) {
           return this._addDroppedEquipment(itemData);
         }
         break;
@@ -1092,7 +1092,7 @@ async function deleteIdFromShipPositions(actorId: string) {
 }
 
 function getEquipmentWeight(item:TwodsixItem):number {
-  if (["weapon", "armor", "equipment", "tool", "junk", "consumable"].includes(item.type)) {
+  if (["weapon", "armor", "equipment", "tool", "junk", "consumable", "computer"].includes(item.type)) {
     if (item.system.equipped !== "ship") {
       let q = item.system.quantity || 0;
       const w = item.system.weight || 0;

--- a/src/module/hooks/itemPilesIntegration.ts
+++ b/src/module/hooks/itemPilesIntegration.ts
@@ -3,7 +3,7 @@
 Hooks.once("item-piles-ready", async function() {
   /// Called once Item Piles is ready to be used
   game.itempiles.API.addSystemIntegration({
-    "VERSION": "1.0.3",
+    "VERSION": "1.0.5",
 
     // The actor class type is the type of actor that will be used for the default item pile actor that is created on first item drop.
     "ACTOR_CLASS_TYPE": "traveller",
@@ -26,6 +26,15 @@ Hooks.once("item-piles-ready", async function() {
       }
     ],
 
+    "PILE_DEFAULTS": {
+      "merchantColumns": [{
+        "label": "TWODSIX.Actor.Items.TL",
+        "path": "system.techLevel",
+        "formatting": "{#}",
+        "mapping": {}
+      }]
+    },
+
     // Item similarities determines how item piles detect similarities and differences in the system
     "ITEM_SIMILARITIES": ["name", "type", "techLevel"],
 
@@ -47,5 +56,9 @@ Hooks.once("item-piles-ready", async function() {
     ],
 
     "CURRENCY_DECIMAL_DIGITS": 0.01
+    /*"CSS_VARIABLES": {
+      "even-color": "#00000080",
+      "odd-color": "#00000000",
+    }*/
   });
 });

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -358,6 +358,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
     // Prepare Containers for sheetData
     sheetData.container = actor.itemTypes;
     sheetData.container.equipmentAndTools = actor.itemTypes.equipment.concat(actor.itemTypes.tool).concat(actor.itemTypes.computer);
+    sheetData.container.storageAndJunk = actor.itemTypes.storage.concat(actor.itemTypes.junk);
     sheetData.container.skills = skillsList;
     if (actor.type === "traveller") {
       sheetData.numberOfSkills = numberOfSkills + (sheetData.jackOfAllTrades > 0 ? 1 : 0);

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -43,9 +43,9 @@ export interface AugmentDataSource {
   system:Augment;
 }
 
-export interface StorageDataSource {
+export interface StorageItemDataSource {
   type:'storage';
-  system:Storage;
+  system:Equipment;
 }
 
 export interface ToolDataSource {
@@ -106,7 +106,7 @@ export type ItemTwodsixDataSource = ArmorDataSource
   | ToolDataSource
   | JunkDataSource
   | SkillsDataSource
-  | StorageDataSource
+  | StorageItemDataSource
   | TraitDataSource
   | SpellDataSource
   | WeaponDataSource
@@ -117,7 +117,6 @@ export type ItemTwodsixDataSource = ArmorDataSource
 export type Gear = Armor
   | Equipment
   | Tool
-  | Storage
   | Weapon
   | Component
   | Computer

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -121,6 +121,7 @@
         "HideStored": "Hiding stored items",
         "EQUIPMENT": "EQUIPMENT",
         "EQUIPMENT_TOOLS": "EQUIPMENT & TOOLS",
+        "STORAGE_JUNK": "STORAGE & JUNK",
         "EditItem": "Edit Item",
         "Effect": "Effect",
         "Location": "Location",
@@ -434,7 +435,8 @@
         "ItemType": "Type",
         "MoveStorage": "Move Storage",
         "New": "New",
-        "Storage": "Storage"
+        "Storage": "Storage",
+        "Junk": "Junk"
       },
       "Skills": {
         "DEX": "DEX",

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -145,6 +145,10 @@ div.pdf-app section.window-content {
 }
 
 /************Item Piles*******/
-.item-piles-odd-color:nth-child(odd), .item-piles-even-color:nth-child(even) {
-  background-color: var(--s2d6-light-background-transparent);
+/*.item-piles-odd-color:nth-child(odd), .item-piles-even-color:nth-child(even), .item-piles-item-row:nth-child(odd) {
+  background-color: var(--s2d6-light-background-transparent) !important;
+}*/
+
+:root {
+  --item-piles-even-color: var(--s2d6-light-background-transparent) !important;
 }

--- a/static/template.json
+++ b/static/template.json
@@ -161,7 +161,8 @@
         "augment": false,
         "equipment": false,
         "consumable": false,
-        "attachment": false
+        "attachment": false,
+        "junk": false
       },
       "experience": {
         "value": 0,
@@ -682,6 +683,16 @@
       "type":"computer",
       "useConsumableForAttack": "",
       "processingPower": 0
+    },
+    "storage": {
+      "templates": ["gearTemplate", "referenceTemplate"],
+      "type": "storage",
+      "useConsumableForAttack": ""
+    },
+    "junk": {
+      "templates": ["gearTemplate", "referenceTemplate"],
+      "type": "junk",
+      "useConsumableForAttack": ""
     }
   }
 }

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -233,6 +233,53 @@
       </section>
   </div>
 
+  <!---- STORAGE & JUNK ---->
+  <div><span class="pusher"></span>
+    <span class="item-title">{{localize "TWODSIX.Actor.Items.STORAGE_JUNK"}}</span>
+    <div class="items-armor gear-header">
+      <span></span>
+      <span class="item-name">{{localize "TWODSIX.Actor.Items.Name"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.TL"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Qty"}}</span>
+      <span class="item-name centre">{{localize "TWODSIX.Actor.Items.Weight"}}</span>
+      <span></span>
+      <span class="item-name centre">
+        <a class="item-control item-create" data-tooltip='{{localize "TWODSIX.Actor.Items.CreateItem"}}' data-type="junk"><i class="fa-solid fa-plus"></i></a>
+        <a class="item-control item-viewToggle" data-item-type="junk">
+          {{#unless system.hideStoredItems.junk}}
+          <i class="fa-solid fa-eye" data-tooltip='{{localize "TWODSIX.Actor.Items.DisplayStored"}}'></i></a>
+          {{else}}
+          <i class="fa-solid fa-eye-slash" data-tooltip='{{localize "TWODSIX.Actor.Items.HideStored"}}'></i></a>
+          {{/unless}}
+      </span>
+    </div>
+      <section class="item-list">
+        {{#each_sort_item container.storageAndJunk as |item id|}}
+        {{#unless (twodsix_hideItem ../system.hideStoredItems.junk item.system.equipped)}}
+        <div class="item gear" data-item-id="{{item.id}}">
+          <ol class="ol-no-indent">
+            <li class="flexrow">
+                <span class="items-armor">
+                  <span class="mini-dice rollable" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-label="{{item.name}}"><i class="fa-solid fa-dice" alt="d6" ></i></span>
+                  <span class="item-name rollable">{{item.name}}</span>
+                  <span class="item-name centre">{{item.system.techLevel}}</span>
+                  <span class="item-name centre">{{item.system.quantity}}</span>
+                  <span class="item-name centre">{{item.system.weight}}</span>
+                  <span></span>
+                  <span class="item-controls centre">
+                    {{#iff item.type "===" "junk"}}<a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{item.system.equipped}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>{{/iff}}
+                    <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
+                    <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
+                  </span>
+                </span>
+            </li>
+          </ol>
+        </div>
+        {{/unless}}
+        {{/each_sort_item}}
+      </section>
+  </div>
+
  <!---- Consumables ---->
  <div>
     <span class="pusher"></span>

--- a/static/templates/items/junk-sheet.html
+++ b/static/templates/items/junk-sheet.html
@@ -22,6 +22,5 @@
       <div contenteditable="true" data-edit="system.description">{{{system.description}}}</div>
     </div>
     {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
-    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>

--- a/static/templates/items/storage-sheet.html
+++ b/static/templates/items/storage-sheet.html
@@ -22,6 +22,5 @@
       <div contenteditable="true" data-edit="system.description">{{{system.description}}}</div>
     </div>
     {{> "systems/twodsix/templates/items/parts/reference-footer.html"}}
-    {{> "systems/twodsix/templates/items/parts/consumables-part.html"}}
   </div>
 </form>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
storage and items can't be added


* **What is the new behavior (if this is a feature change)?**
allow storage and junk to be added


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
