### PR TITLE
Revert "chore(deps-dev): bump prettier from 2.8.8 to 3.0.0 (#1405)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "fs-extra": "^11.1.1",
         "gulp": "^4.0.2",
         "marked": "^5.1.1",
-        "prettier": "^3.0.0",
+        "prettier": "^2.8.8",
         "rollup": "^3.26.3",
         "rollup-plugin-esbuild": "^5.0.0",
         "rollup-plugin-multi-input": "^1.4.1",
@@ -14271,15 +14271,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
-        "prettier": "bin/prettier.cjs"
+        "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "fs-extra": "^11.1.1",
     "gulp": "^4.0.2",
     "marked": "^5.1.1",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "rollup": "^3.26.3",
     "rollup-plugin-esbuild": "^5.0.0",
     "rollup-plugin-multi-input": "^1.4.1",


### PR DESCRIPTION
This reverts commit e3d71bdefda288bf800e498ff26df0f5fa52846b.

* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
conflict with prettier


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not certain how this got out of sync


* **Other information**:
