### PR TITLE
fix: refactor prompt for unknown auto mode

### DIFF
--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -6,8 +6,7 @@ import {getDataFromDropEvent, getItemDataFromDropData, isDisplayableSkill} from 
 import TwodsixActor from "../entities/TwodsixActor";
 import {Skills, UsesConsumables, Component} from "../../types/template";
 import {onPasteStripFormatting} from "../sheets/AbstractTwodsixItemSheet";
-//import { getKeyByValue } from "../utils/sheetUtils";
-import { resolveUnknownAutoMode } from "../utils/rollItemMacro";
+//import { getKeyByValue } from "../utils/sheetUtils"
 import { TWODSIX } from "../config";
 
 export abstract class AbstractTwodsixActorSheet extends ActorSheet {
@@ -147,7 +146,7 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
     const item = this.getItem(event);
     //console.log("Sheet Item Attack: ", item);
     if (this.options.template?.includes("npc-sheet")) {
-      resolveUnknownAutoMode(item);
+      item.resolveUnknownAutoMode();
     } else {
       await item.performAttack(attackType, showThrowDiag, rof);
     }

--- a/src/module/utils/rollItemMacro.ts
+++ b/src/module/utils/rollItemMacro.ts
@@ -2,8 +2,6 @@
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
 
 import TwodsixItem from "../entities/TwodsixItem";
-import { TWODSIX } from "../config";
-import {Weapon} from "../../types/template";
 
 /**
  * Use a previously created macro.
@@ -31,137 +29,8 @@ export async function rollItemMacro(itemId: string): Promise<void> {
     if (item.type != "weapon") {
       await item.skillRoll(!game.settings.get("twodsix", "invertSkillRollShiftClick"));
     } else {
-      resolveUnknownAutoMode(item);
+      await item.resolveUnknownAutoMode();
     }
   }
 }
 
-export function shouldShowCELAutoFireDialog(weapon: TwodsixItem): boolean {
-  const rateOfFire: string = (<Weapon>weapon.system).rateOfFire;
-  return (
-    (game.settings.get('twodsix', 'autofireRulesUsed') === TWODSIX.RULESETS.CEL.key) &&
-    (Number(rateOfFire) > 1  || (weapon.system.doubleTap && game.settings.get('twodsix', 'ShowDoubleTap')))
-  );
-}
-
-export function shouldShowCEAutoFireDialog(weapon: TwodsixItem): boolean {
-  const modes = ((<Weapon>weapon.system).rateOfFire ?? "").split(/[-/]/);
-  return (
-    (game.settings.get('twodsix', 'autofireRulesUsed') === TWODSIX.RULESETS.CE.key) &&
-    (modes.length > 1)
-  );
-}
-
-export async function promptForCELROF(weapon: TwodsixItem): Promise<string> {
-  if (weapon.system.doubleTap && game.settings.get('twodsix', 'ShowDoubleTap')) {
-    return new Promise((resolve) => {
-      new Dialog({
-        title: game.i18n.localize("TWODSIX.Dialogs.ROFPickerTitle"),
-        content: "",
-        buttons: {
-          single: {
-            label: game.i18n.localize("TWODSIX.Dialogs.ROFSingle"), callback: () => {
-              resolve('');
-            }
-          },
-          doubleTap: {
-            label: game.i18n.localize("TWODSIX.Dialogs.ROFDoubleTap"), callback: () => {
-              resolve('double-tap');
-            }
-          }
-        },
-        default: 'single',
-      }).render(true);
-    });
-  } else {
-    return new Promise((resolve) => {
-      new Dialog({
-        title: game.i18n.localize("TWODSIX.Dialogs.ROFPickerTitle"),
-        content: "",
-        buttons: {
-          single: {
-            label: game.i18n.localize("TWODSIX.Dialogs.ROFSingle"), callback: () => {
-              resolve('');
-            }
-          },
-          burst: {
-            label: game.i18n.localize("TWODSIX.Dialogs.ROFBurst"), callback: () => {
-              resolve('auto-burst');
-            }
-          },
-          full: {
-            label: game.i18n.localize("TWODSIX.Dialogs.ROFFull"), callback: () => {
-              resolve('auto-full');
-            }
-          }
-        },
-        default: 'single',
-      }).render(true);
-    });
-  }
-}
-
-export async function promptAndAttackForCE(modes: string[], item: TwodsixItem) {
-  const buttons = {};
-
-  for ( const mode of modes) {
-    const number = Number(mode);
-    const attackDM = TwodsixItem.burstAttackDM(number);
-    const bonusDamage =TwodsixItem.burstBonusDamage(number);
-
-    if (number === 1) {
-      buttons["single"] = {
-        "label": game.i18n.localize("TWODSIX.Dialogs.ROFSingle"),
-        "callback": () => {
-          item.performAttack("", true, 1);
-        }
-      };
-    } else if (number > 1){
-      let key = game.i18n.localize("TWODSIX.Rolls.AttackDM")+ ' +' + attackDM;
-      buttons[key] = {
-        "label": key,
-        "callback": () => {
-          item.performAttack('burst-attack-dm', true, number);
-        }
-      };
-
-      key = game.i18n.localize("TWODSIX.Rolls.BonusDamage") + ' +' + bonusDamage;
-      buttons[key] = {
-        "label": key,
-        "callback": () => {
-          item.performAttack('burst-bonus-damage', true, number);
-        }
-      };
-    }
-  }
-
-  await new Dialog({
-    title: game.i18n.localize("TWODSIX.Dialogs.ROFPickerTitle"),
-    content: "",
-    buttons: buttons,
-    default: "single"
-  }).render(true);
-}
-
-export async function resolveUnknownAutoMode(item: TwodsixItem) {
-  let attackType = "";
-  const modes = ((<Weapon>item.system).rateOfFire ?? "").split(/[-/]/);;
-  switch (game.settings.get('twodsix', 'autofireRulesUsed')) {
-    case TWODSIX.RULESETS.CEL.key:
-      if (shouldShowCELAutoFireDialog(item)) {
-        attackType = await promptForCELROF(item);
-      }
-      await item.performAttack(attackType, true);
-      break;
-    case TWODSIX.RULESETS.CE.key:
-      if (modes.length > 1) {
-        await promptAndAttackForCE(modes, item);
-      } else {
-        await item.performAttack("", true, Number(modes[0]));
-      }
-      break;
-    default:
-      await item.performAttack(attackType, true);
-      break;
-  }
-}

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -3260,7 +3260,7 @@ form .notes, form .hint {
   color: var(--s2d6-form-light);
 }
 
-.dialog .dialog-buttons button:last-child {
+.dialog .dialog-buttons button {
   margin-right: 0;
   border: 2px groove var(--s2d6-item-border);
   color: var(--s2d6-dialog-color);
@@ -3273,10 +3273,10 @@ form .notes, form .hint {
   border-color: var(--s2d6-light-color)!important; /*must keep important*/
 }
 
-.dialog .dialog-buttons button.default {
+/*.dialog .dialog-buttons button.default {
   background: var(--s2d6-item-active);
   border: 2px groove var(--s2d6-item-border);
-}
+}*/
 
 option {
   background-color: var(--s2d6-item-active);

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -392,7 +392,7 @@ form .form-group span.units {
 }
 /*div {border: thin dotted #FFF;}*/
 
-.window-content, .window-app .window-content, .app-content, .window-content, section.app-content, section.window-app, section.window-content {
+.window-content, .window-app .window-content, .app-content, section.app-content, section.window-app, section.window-content {
   background-attachment: fixed;
   background-image: url(../assets/bg2.jpg);
   background-repeat: repeat-x;

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -182,3 +182,14 @@ div.pdf-app section.window-content {
   color: var(--s2d6-default-color);
   border-color: var(--s2d6-default-color);
 }
+
+/******** Token Action HUD ******/
+
+.tah-dialog-light-button {
+  background: var(--s2d6-background-nearly-opaque);
+  border: 1px solid var(--color-border-light-primary);
+}
+
+.tagify__tag__removeBtn, .tagify__tag>div, .tah-dialog-tagify .tagify__input, .tagify__input:focus:empty::before {
+  color: var(--s2d6-default-color);
+}

--- a/static/system.json
+++ b/static/system.json
@@ -26,7 +26,7 @@
   "compatibility":
     {
       "minimum": "11",
-      "verified": "11.307"
+      "verified": "11.308"
     },
   "description": "Twodsix: A system for use with the Cepheus Engine Core Rules, Traveller (unofficial), and other similar games. <br/>This Product is derived from the Traveller System Reference Document and other Open Gaming Content made available by the Open Gaming License, and does not contain closed content from products published by either Mongoose Publishing or Far Future Enterprises. This Product is not affiliated with either Mongoose Publishing or Far Future Enterprises, and it makes no claim to or challenge to any trademarks held by either entity. The use of the Traveller System Reference Document does not convey the endorsement of this Product by either Mongoose Publishing or Far Future Enterprises as a product of either of their product lines.<br/>Cepheus Engine and Samardan Press™ are the trademarks of Jason \"Flynn\" Kemp; we are not affiliated with Jason \"Flynn\" Kemp or Samardan Press™.<br/> See the files OpenGameLicense.md and LICENSE for license details.<br/>",
   "esmodules": ["twodsix.bundle.js"],


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
refactor


* **What is the current behavior?** (You can also link to an open issue here)
only run item macro can call prompt for unknown fire mode
style issues with TAH tagify inputs

* **What is the new behavior (if this is a feature change)?**
make it an item method so that Token Action HUD integration can call (rather than duplicate code)
add style fixes for TAH tagify use

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
yes...Token Action HUD Integration will need to change


* **Other information**:
