### PR TITLE
feat: add maximum spell level setting and ship references

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -287,7 +287,7 @@ export default class TwodsixItem extends Item {
       if(this.type === "spell") {
         // Spells under SOC and Barbaric have a sequential difficulty class based on spell level.  Create an override to system difficulties.
         const workingSettings = {"difficulties": {}, "difficulty": ""};
-        for (let i = 1; i <= 6; i++) {
+        for (let i = 1; i <= game.settings.get("twodsix", "maxSpellLevel"); i++) {
           const levelKey = game.i18n.localize("TWODSIX.Items.Spells.Level") + " " + i;
           workingSettings.difficulties[levelKey] = {mod: -i, target: i+6};
         }

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -7,7 +7,7 @@ import DebugSettings from "./settings/DebugSettings";
 
 import {TWODSIX} from "./config";
 import TwodsixActor from "./entities/TwodsixActor";
-import { booleanSetting, numberSetting, stringChoiceSetting } from "./settings/settingsUtils";
+import { booleanSetting, stringChoiceSetting } from "./settings/settingsUtils";
 
 
 

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -47,7 +47,6 @@ export const registerSettings = function ():void {
   booleanSetting('invertSkillRollShiftClick', false, true);
   booleanSetting('transferDroppedItems', false, true);
   booleanSetting('autoAddUnarmed', false, true);
-  numberSetting('weightModifierForWornArmor', 1.0, true);
 
   function _onHideUntrainedSkillsChange(setting:boolean) {
     if (!setting) {

--- a/src/module/settings/AdvancedSettings.ts
+++ b/src/module/settings/AdvancedSettings.ts
@@ -42,6 +42,7 @@ export default class AdvancedSettings extends FormApplication {
       });
       data.settings[group] = Object.fromEntries(settings);
     }
+    data.dtypes = ["String", "Number", "Boolean"];
     return data;
   }
 

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -36,6 +36,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.actor.push(booleanSetting('useWoundedStatusIndicators', false));
     settings.actor.push(booleanSetting('useEncumbranceStatusIndicators', false));
     settings.ship.push(booleanSetting('showWeightUsage', false));
+    settings.general.push(booleanSetting('showActorReferences', true));
     settings.general.push(booleanSetting('usePDFPagerForRefs', false));
     settings.actor.push(booleanSetting('showIcons', false));
     settings.actor.push(booleanSetting('useEncumbrance', false));
@@ -52,7 +53,6 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.general.push(booleanSetting('showHitsChangesInChat', false));
     settings.token.push(booleanSetting('reduceStatusIcons', false, false, "world", updateStatusIcons));
     settings.general.push(booleanSetting('useTabbedViews', false));
-    settings.actor.push(booleanSetting('showActorReferences', true));
     return settings;
   }
 }

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -78,7 +78,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.encumbrance.push(stringSetting("maxEncumbrance", DEFAULT_MAX_ENCUMBRANCE_FORMULA, false, "world"));
     settings.encumbrance.push(stringSetting('encumbranceFraction', "0.5", false)); //Should be a number setting, but FVTT unhappy with values other than 0.5
     settings.encumbrance.push(numberSetting('encumbranceModifier', -1, false));
-    settings.encumbrance.push(numberSetting('weightModifierForWornArmor', 1.0, true));
+    settings.encumbrance.push(stringSetting('weightModifierForWornArmor', "1.0", false));
     settings.movement.push(numberSetting('defaultMovement', 10));
     settings.movement.push(stringChoiceSetting('defaultMovementUnits', "m", true, TWODSIX.MovementUnits));
     settings.movement.push(stringSetting('encumbFractionOneSquare', "0.5")); //Should be a number setting, but FVTT unhappy with values other than 0.5

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -78,6 +78,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.encumbrance.push(stringSetting("maxEncumbrance", DEFAULT_MAX_ENCUMBRANCE_FORMULA, false, "world"));
     settings.encumbrance.push(stringSetting('encumbranceFraction', "0.5", false)); //Should be a number setting, but FVTT unhappy with values other than 0.5
     settings.encumbrance.push(numberSetting('encumbranceModifier', -1, false));
+    settings.encumbrance.push(numberSetting('weightModifierForWornArmor', 1.0, true));
     settings.movement.push(numberSetting('defaultMovement', 10));
     settings.movement.push(stringChoiceSetting('defaultMovementUnits', "m", true, TWODSIX.MovementUnits));
     settings.movement.push(stringSetting('encumbFractionOneSquare', "0.5")); //Should be a number setting, but FVTT unhappy with values other than 0.5
@@ -87,6 +88,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.roll.push(booleanSetting("showTimeframe", false));
     settings.general.push(stringChoiceSetting('showHullAndArmor', "armorOnly", true, TWODSIX.VehicleProtection));
     settings.general.push(stringSetting("sorcerySkill", "Sorcery", false, "world"));
+    settings.general.push(numberSetting("maxSpellLevel", 7, false, "world"));
     settings.general.push(booleanSetting("useNationality", false));
     settings.animals_robots.push(booleanSetting("animalsUseHits", false));
     settings.animals_robots.push(booleanSetting("robotsUseHits", false));

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -133,11 +133,11 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       html.find('.condition-icon').on('click', this._onEditEffect.bind(this));
       html.find('.condition-icon').on('contextmenu', this._onDeleteEffect.bind(this));
       html.find('.effect-control').on('click', this._modifyEffect.bind(this));
-
-      //Document links
-      html.find('.open-link').on('click', openPDFReference.bind(this, this.actor.system.docReference));
-      html.find('.delete-link').on('click', deletePDFReference.bind(this));
     }
+
+    //Document links
+    html.find('.open-link').on('click', openPDFReference.bind(this, this.actor.system.docReference));
+    html.find('.delete-link').on('click', deletePDFReference.bind(this));
   }
 
   /**

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -50,7 +50,9 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
       showComponentRating: game.settings.get('twodsix', 'showComponentRating'),
       showComponentDM: game.settings.get('twodsix', 'showComponentDM'),
       allowDragDropOfLists: game.settings.get('twodsix', 'allowDragDropOfLists'),
-      maxComponentHits: game.settings.get('twodsix', 'maxComponentHits')
+      maxComponentHits: game.settings.get('twodsix', 'maxComponentHits'),
+      usePDFPager: game.settings.get('twodsix', 'usePDFPagerForRefs'),
+      showActorReferences: game.settings.get('twodsix', 'showActorReferences')
     };
 
     if (context.settings.useProseMirror) {
@@ -247,8 +249,9 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
 
     try {
       const dropData:any = getDataFromDropEvent(event);
-      if (dropData.type === 'html') {
-        return false;
+      if (dropData.type === 'html' || dropData.type === 'pdf') {
+        await super._onDrop(event);
+        return true;
       }
       const droppedObject:any = await getItemDataFromDropData(dropData);
 

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -79,7 +79,7 @@ declare global {
       'twodsix.absoluteCriticalEffectValue': number;
       'twodsix.maxSkillLevel': number;
       'twodsix.modifierForZeroCharacteristic': number;
-      'twodsix.weightModifierForWornArmor': number;
+      'twodsix.weightModifierForWornArmor': string;
       'twodsix.autofireRulesUsed': string; //TODO Should be more specific, really
       'twodsix.difficultyListUsed': number; //TODO Should be more specific, really
       'twodsix.ruleset': string; //TODO Should be more specific, really
@@ -142,6 +142,7 @@ declare global {
       'twodsix.autoDamageTarget': boolean;
       'twodsix.overrideDamageRoll': boolean;
       'twodsix.showActorReferences': boolean;
+      'twodsix.maxSpellLevel': number;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1259,6 +1259,10 @@
       "showActorReferences": {
         "hint": "Display pdf references (using pdf pager module) or url links on all actor sheets.",
         "name": "Show PDF References or URL links on actor sheets"
+      },
+      "maxSpellLevel": {
+        "hint": "Maximum spell level that can be used in a spell roll.",
+        "name": "Maximum Spell Level"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2746,7 +2746,8 @@ a.ship-notes-tab.active {
   padding: 0.2em;
   overflow-y: auto;
 }
-.ship-notes-container, .ship-finances-container {
+
+.ship-notes-container, .ship-notes-container-short, .ship-finances-container {
   margin-left: 17px;
   padding-top: 24px;
   height: 294px;
@@ -2754,7 +2755,7 @@ a.ship-notes-tab.active {
   overflow-x: hidden;
 }
 
-.ship-notes-container .editor, .ship-finances-container .editor, .cargo-wrapper .editor {
+.ship-notes-container .editor, .ship-notes-container-short .editor, .ship-finances-container .editor, .cargo-wrapper .editor {
   border: 1px solid var(--s2d6-default-color);
   border-radius: 0 3px 3px;
   width: 100%;
@@ -2762,7 +2763,7 @@ a.ship-notes-tab.active {
   overflow: auto;
 }
 
-.ship-notes-container >div[contenteditable], .ship-finances-container >div[contenteditable] {
+.ship-notes-container >div[contenteditable], .ship-notes-container-short >div[contenteditable], .ship-finances-container >div[contenteditable] {
   border: 1px solid var(--s2d6-default-color);
   border-radius: 0 3px 3px;
   font-size: 15px;
@@ -2771,6 +2772,14 @@ a.ship-notes-tab.active {
   padding: 0.2em;
   height: 90%;
   overflow-y: auto;
+}
+
+.ship-notes-container-short .editor {
+  height: 81%;
+}
+
+.ship-notes-container-short >div[contenteditable] {
+  height: 80%;
 }
 
 .ship-finances-container {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -3704,7 +3704,7 @@ div.app.window-app.minimized.twodsix.ship.actor header a.close {
 
 .prosemirror menu {
   flex-wrap: nowrap;
-  justify-content: space-around;
+  justify-content: flex-start;
 }
 
 .prosemirror menu > li {

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2175,7 +2175,7 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
   height: 10em;
 }*/
 
-.ship-notes-container, .ship-finances-container {
+.ship-notes-container, .ship-notes-container-short, .ship-finances-container {
   margin-left: 15px;
   padding-top: 14px;
   height: 302px;
@@ -2183,7 +2183,7 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
   overflow-x: hidden;
 }
 
-.ship-notes-container .editor, .ship-finances-container .editor, .cargo-wrapper .editor {
+.ship-notes-container .editor, .ship-notes-container-short .editor, .ship-finances-container .editor, .cargo-wrapper .editor {
   border: 1px solid var(--color-border-light-tertiary);
   border-radius: 0 3px 3px;
   width: 100%;
@@ -2192,7 +2192,7 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
   background-color: var(--s2d6-input-background) !important;
 }
 
-.ship-notes-container >div[contenteditable], .ship-finances-container >div[contenteditable], .cargo-wrapper >div[contenteditable] {
+.ship-notes-container >div[contenteditable], .ship-notes-container-short >div[contenteditable], .ship-finances-container >div[contenteditable], .cargo-wrapper >div[contenteditable] {
   border: 1px solid var(--color-border-light-tertiary) !important;
   border-radius: 0 3px 3px;
   font-size: 15px;
@@ -2202,6 +2202,15 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
   height: 90%;
   overflow-y: auto;
 }
+
+.ship-notes-container-short .editor {
+  height: 81%;
+}
+
+.ship-notes-container-short >div[contenteditable] {
+  height: 80%;
+}
+
 .ship-finances-container {
   display: flex;
   justify-content: space-around;

--- a/static/system.json
+++ b/static/system.json
@@ -26,7 +26,7 @@
   "compatibility":
     {
       "minimum": "11",
-      "verified": "11.309"
+      "verified": "11.311"
     },
   "description": "Twodsix: A system for use with the Cepheus Engine Core Rules, Traveller (unofficial), and other similar games. <br/>This Product is derived from the Traveller System Reference Document and other Open Gaming Content made available by the Open Gaming License, and does not contain closed content from products published by either Mongoose Publishing or Far Future Enterprises. This Product is not affiliated with either Mongoose Publishing or Far Future Enterprises, and it makes no claim to or challenge to any trademarks held by either entity. The use of the Traveller System Reference Document does not convey the endorsement of this Product by either Mongoose Publishing or Far Future Enterprises as a product of either of their product lines.<br/>Cepheus Engine and Samardan Press™ are the trademarks of Jason \"Flynn\" Kemp; we are not affiliated with Jason \"Flynn\" Kemp or Samardan Press™.<br/> See the files OpenGameLicense.md and LICENSE for license details.<br/>",
   "esmodules": ["twodsix.bundle.js"],

--- a/static/template.json
+++ b/static/template.json
@@ -194,6 +194,7 @@
       "xpNotes": ""
     },
     "ship": {
+      "templates": ["referenceTemplateActor"],
       "name": "",
       "deckPlan": "",
       "techLevel": 0,

--- a/static/templates/actors/parts/ship/ship-notes.html
+++ b/static/templates/actors/parts/ship/ship-notes.html
@@ -1,8 +1,13 @@
+{{#if settings.showActorReferences}}
+<div class="ship-notes-container-short">
+{{else}}
 <div class="ship-notes-container">
+{{/if}}
   <span class="item-title">{{localize "TWODSIX.Ship.SHIPNOTES"}}</span>
-  {{#if settings.useProseMirror}}
-    {{editor richText.notes target="system.notes" button=true owner=owner editable=editable async=true engine="prosemirror" collaborate=true}}
-  {{else}}
-      <div contenteditable="true" data-edit="system.notes">{{#if actor.system.notes}}{{{actor.system.notes}}}{{/if}}</div>
-  {{/if}}
+    {{#if settings.useProseMirror}}
+      {{editor richText.notes target="system.notes" button=true owner=owner editable=editable async=true engine="prosemirror" collaborate=true}}
+    {{else}}
+        <div contenteditable="true" data-edit="system.notes">{{#if actor.system.notes}}{{{actor.system.notes}}}{{/if}}</div>
+    {{/if}}
+  {{> "systems/twodsix/templates/actors/parts/actor/actor-reference.html"}}
 </div>


### PR DESCRIPTION
and move weight for worn armor to encumbrance settings

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
no setting for maximum spell level
no ship references


* **What is the new behavior (if this is a feature change)?**
add new setting to set max spell level for a spell roll
add reference area to ship notes


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
