### PR TITLE
feat: initial cut at values for Traveller finances

### DIFF
--- a/src/module/hooks/preUpdateActor.ts
+++ b/src/module/hooks/preUpdateActor.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+
+import TwodsixActor from "../entities/TwodsixActor";
+import { updateFinances } from "./updateFinances";
+import { updateHits } from "./updateHits";
+
+Hooks.on('preUpdateActor', async (actor:TwodsixActor, update:Record<string, any>) => {
+  await updateHits(actor, update);
+  await updateFinances(actor, update);
+});

--- a/src/module/hooks/updateFinances.ts
+++ b/src/module/hooks/updateFinances.ts
@@ -1,0 +1,82 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+
+import TwodsixActor from "../entities/TwodsixActor";
+
+export async function updateFinances(actor:TwodsixActor, update:Record<string, any>): Promise<void> {
+  if (["traveller"].includes(actor.type)) {
+    if (update.system?.finances) {
+      await updateFinanceValues(update);
+    } else if (update.system?.financeValues) {
+      await updateFinanceText(actor, update);
+    }
+  }
+}
+
+async function updateFinanceValues(update:Record<string, any>) {
+  for (const financeField in update.system.finances) {
+    const parsedText = getParsedFinanceText(update.system.finances[financeField]);
+    if (parsedText) {
+      const newValue = parseLocaleNumber(parsedText.num) * getMultiplier(parsedText.units);
+      await Object.assign(update.system, {financeValues: {[financeField]: newValue}});
+    }
+  }
+}
+
+async function updateFinanceText(actor:TwodsixActor, update:Record<string, any>) {
+  for (const financeField in update.system.financeValues) {
+    const parsedText = getParsedFinanceText(actor.system.finances[financeField]);
+    let newValue = update.system.financeValues[financeField];
+    const numberDigits = Math.floor(Math.log10(newValue)) + 1;
+    if (parsedText?.units) {
+      newValue /= getMultiplier(parsedText.units);
+    }
+    const newText = ''.concat(newValue.toLocaleString(game.i18n.lang, {minimumSignificantDigits: numberDigits}), (parsedText?.units ? ' ' + parsedText.units : ''));
+    await Object.assign(update.system, {finances: {[financeField]: newText}});
+  }
+}
+
+/**
+ * Parse a localized number to a float.
+ * @param {string} stringNumber - the localized number
+ * @returns {number} - the float value of localized number
+ */
+function parseLocaleNumber(stringNumber:string): number {
+  const thousandSeparator = Intl.NumberFormat(game.i18n.lang).formatToParts(11111)[1].value;
+  const decimalSeparator = Intl.NumberFormat(game.i18n.lang).formatToParts(1.1)[1].value;
+
+  return parseFloat(stringNumber
+    .replace(new RegExp('\\' + thousandSeparator, 'g'), '')
+    .replace(new RegExp('\\' + decimalSeparator), '.')
+  );
+}
+
+/**
+ * Parse a finance text field into separate value and units.
+ * @param {string} stringNumber - the localized number
+ * @returns {Record<any>} - object with keys num and units
+ */
+function getParsedFinanceText(financeString: string): Record<string, any> | undefined {
+  const re = new RegExp(/^(?<pre>\D*?)(?<num>[0-9,.]*)(?<sp>\s*)(?<units>.*?)$/);
+  const parsedResult: RegExpMatchArray | null = re.exec(financeString);
+  return parsedResult?.groups;
+}
+
+/**
+ * Lookup the first letter of units and determine magnitude
+ * @param {string} stringNumber - the units
+ * @returns number - magnitude for units
+ */
+function getMultiplier(units: string): number {
+  switch (units[0]) {
+    case 'G':
+      return 1e+9;
+    case 'M':
+      return 1e+6;
+    case 'k':
+    case 'K':
+      return 1e+3;
+    default:
+      return 1;
+  }
+}

--- a/src/module/hooks/updateHits.ts
+++ b/src/module/hooks/updateHits.ts
@@ -19,7 +19,7 @@ async function getCurrentHits(actorType: string, ...args: Record<string, any>[])
   }, {value: 0, max: 0, lastDelta: 0});
 }
 
-Hooks.on('preUpdateActor', async (actor:TwodsixActor, update:Record<string, any>) => {
+export async function updateHits(actor:TwodsixActor, update:Record<string, any>): Promise<void> {
   if (update.system?.characteristics && (["traveller", "animal", "robot"].includes(actor.type))) {
     update.system.hits = await getCurrentHits(actor.type, (<Traveller>actor.system).characteristics, update.system.characteristics);
     await Object.assign(update.system.hits, {lastDelta: actor.system.hits.value - update.system.hits.value});
@@ -29,7 +29,7 @@ Hooks.on('preUpdateActor', async (actor:TwodsixActor, update:Record<string, any>
       ChatMessage.create({ flavor: `${actionWord} ${appliedType}: ${Math.abs(update.system.hits.lastDelta)}`, speaker: ChatMessage.getSpeaker({ actor: actor }), whisper: ChatMessage.getWhisperRecipients("GM") });
     }
   }
-});
+};
 
 //Not needed???
 /*

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -269,6 +269,7 @@ export interface Traveller {
   bio:string;
   notes:string;
   finances:Finances;
+  financeValues:FinanceValues;
   characteristics:Characteristics;
   skillRollTypes:Record<string,string>;
   characteristicEdit:boolean;
@@ -419,6 +420,14 @@ export interface Finances {
   payments:string;
   livingCosts:string;
   financialNotes:string;
+}
+
+export interface FinanceValues {
+  cash:number;
+  pension:number;
+  debt:number;
+  payments:number;
+  livingCosts:number;
 }
 
 export interface PrimaryArmor {

--- a/static/system.json
+++ b/static/system.json
@@ -26,7 +26,7 @@
   "compatibility":
     {
       "minimum": "11",
-      "verified": "11.311"
+      "verified": "11.313"
     },
   "description": "Twodsix: A system for use with the Cepheus Engine Core Rules, Traveller (unofficial), and other similar games. <br/>This Product is derived from the Traveller System Reference Document and other Open Gaming Content made available by the Open Gaming License, and does not contain closed content from products published by either Mongoose Publishing or Far Future Enterprises. This Product is not affiliated with either Mongoose Publishing or Far Future Enterprises, and it makes no claim to or challenge to any trademarks held by either entity. The use of the Traveller System Reference Document does not convey the endorsement of this Product by either Mongoose Publishing or Far Future Enterprises as a product of either of their product lines.<br/>Cepheus Engine and Samardan Press™ are the trademarks of Jason \"Flynn\" Kemp; we are not affiliated with Jason \"Flynn\" Kemp or Samardan Press™.<br/> See the files OpenGameLicense.md and LICENSE for license details.<br/>",
   "esmodules": ["twodsix.bundle.js"],

--- a/static/template.json
+++ b/static/template.json
@@ -178,6 +178,13 @@
         "livingCosts": "0",
         "financial-notes": ""
       },
+      "financeValues": {
+        "cash": 0,
+        "pension": 0,
+        "debt": 0,
+        "payments": 0,
+        "livingCosts": 0
+      },
       "hideStoredItems": {
         "weapon": false,
         "armor": false,


### PR DESCRIPTION
no migration

* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Traveller finances are text fields only


* **What is the new behavior (if this is a feature change)?**
Add fields that mirror finance fields as number


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
