### PR TITLE
feat: Misc Display Improvements

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -424,6 +424,20 @@ export default function registerHandlebarsHelpers(): void {
     return !["skills", "trait", "spell", "component", "ship_position"].includes(item.type);
   });
 
+  Handlebars.registerHelper('twodsix_getTLString', (itemData: any) => {
+    if(["skills", "trait", "spell", "ship_position"].includes(itemData.type)) {
+      return "";
+    } else if (itemData.system?.techLevel !== null && itemData.system?.techLevel !== undefined) {
+      if(isNaN(itemData.system.techLevel)) {
+        return "";
+      } else {
+        return ` (${game.i18n.localize("TWODSIX.Items.Equipment.TL")} ${itemData.system.techLevel})`;
+      }
+    } else {
+      return "";
+    }
+  });
+
   // Handy for debugging
   Handlebars.registerHelper('debug', function (context) {
     console.log(context);

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -431,7 +431,7 @@ export default function registerHandlebarsHelpers(): void {
       if(isNaN(itemData.system.techLevel)) {
         return "";
       } else {
-        return ` (${game.i18n.localize("TWODSIX.Items.Equipment.TL")} ${itemData.system.techLevel})`;
+        return `(${game.i18n.localize("TWODSIX.Items.Equipment.TL")} ${itemData.system.techLevel})`;
       }
     } else {
       return "";

--- a/src/module/hooks/ready.ts
+++ b/src/module/hooks/ready.ts
@@ -4,7 +4,7 @@ import migrateWorld from "../migration";
 import {createItemMacro} from "../utils/createItemMacro";
 import { applyToAllActors } from "../utils/migration-utils";
 import { correctMissingUntrainedSkill } from "../entities/TwodsixActor";
-import { updateStatusIcons } from "../settings/DisplaySettings";
+import { setDocumentPartials, updateStatusIcons } from "../settings/DisplaySettings";
 import { switchCss } from "../settings";
 Hooks.once("ready", async function () {
   //Prevent a conflict with Twodsix conditions
@@ -78,6 +78,17 @@ Hooks.once("ready", async function () {
       break;
     default:
       break;
+  }
+
+  //Set up custom partial on item tab
+  if (game.settings.get('twodsix', 'showTLonItemsTab')) {
+    setDocumentPartials();
+  }
+  //Add index
+  for (const pack of game.packs) {
+    if (pack.metadata.type === 'Item') {
+      pack.getIndex({fields: ['system.techLevel']});
+    }
   }
 
 });

--- a/src/module/hooks/updateItem.ts
+++ b/src/module/hooks/updateItem.ts
@@ -1,7 +1,23 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+
 import TwodsixActor from "../entities/TwodsixActor";
 
 Hooks.on('preUpdateOwnedItem', async (actor:TwodsixActor, oldItem: Record<string,any>, updateData: Record<string,any>) => {
   if (updateData.type && oldItem.system.useConsumableForAttack) {
     updateData["system.useConsumableForAttack"] = "";
+  }
+});
+
+Hooks.on('updateItem', async (item: TwodsixItem, update: any) => {
+  //Update item tab list if TL Changed
+  if (game.settings.get('twodsix', 'showTLonItemsTab')) {
+    if(["skills", "trait", "spell", "ship_position"].includes(item.type)) {
+      return;
+    } else if (item.isEmbedded || item.compendium) {
+      return;
+    } else if (update.system?.techLevel) {
+      ui.items.render();
+    }
   }
 });

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -7,7 +7,7 @@ import DebugSettings from "./settings/DebugSettings";
 
 import {TWODSIX} from "./config";
 import TwodsixActor from "./entities/TwodsixActor";
-import { booleanSetting, stringChoiceSetting } from "./settings/settingsUtils";
+import { booleanSetting, stringChoiceSetting, stringSetting } from "./settings/settingsUtils";
 
 
 
@@ -47,6 +47,9 @@ export const registerSettings = function ():void {
   booleanSetting('invertSkillRollShiftClick', false, true);
   booleanSetting('transferDroppedItems', false, true);
   booleanSetting('autoAddUnarmed', false, true);
+  //Store default partials for items and compendium tab - hidden
+  stringSetting('defaultItemPartial', ItemDirectory.entryPartial, false, "client");
+  stringSetting('defaultCompendiumPartial', Compendium.entryPartial, false, "client");
 
   function _onHideUntrainedSkillsChange(setting:boolean) {
     if (!setting) {

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -54,6 +54,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.token.push(booleanSetting('reduceStatusIcons', false, false, "world", updateStatusIcons));
     settings.general.push(booleanSetting('useTabbedViews', false));
     settings.actor.push(booleanSetting('showAllCharWithTable', true));
+    settings.general.push(booleanSetting('showTLonItemsTab', false, false, 'world', setDocumentPartials));
     return settings;
   }
 }
@@ -83,4 +84,15 @@ export const updateStatusIcons = function () {
   } else {
     window.location.reload();
   }
+};
+
+export const setDocumentPartials = function () {
+  if (game.settings.get('twodsix', 'showTLonItemsTab')) {
+    ItemDirectory.entryPartial = 'systems/twodsix/templates/misc/revised-document-partial.html';
+    Compendium.entryPartial = 'systems/twodsix/templates/misc/revised-compendium-index-partial.html';
+  } else {
+    ItemDirectory.entryPartial = game.settings.get('twodsix', 'defaultItemPartial');
+    Compendium.entryPartial = game.settings.get('twodsix', 'defaultCompendiumPartial');
+  }
+  ui.items.render();
 };

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -55,6 +55,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.general.push(booleanSetting('useTabbedViews', false));
     settings.actor.push(booleanSetting('showAllCharWithTable', true));
     settings.general.push(booleanSetting('showTLonItemsTab', false, false, 'world', setDocumentPartials));
+    settings.actor.push(booleanSetting('omitPSIifZero', false));
     return settings;
   }
 }

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -56,7 +56,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
 
     //Prepare characteristic display values
     setCharacteristicDisplay(returnData);
-    returnData.system.characteristics.displayOrder = getDisplayOrder();
+    returnData.system.characteristics.displayOrder = getDisplayOrder(returnData);
     //}
 
     // Add relevant data from system settings
@@ -346,13 +346,14 @@ export function setCharacteristicDisplay(returnData: object): void {
   returnData.system.characteristics.endurance.displayChar = true;
   returnData.system.characteristics.intelligence.displayChar = true;
   returnData.system.characteristics.lifeblood.displayChar = false;
-  returnData.system.characteristics.psionicStrength.displayChar = ['base', 'all'].includes(charMode);
+  returnData.system.characteristics.psionicStrength.displayChar = ['base', 'all'].includes(charMode) &&
+        (returnData.system.characteristics.psionicStrength.value !== 0 || !game.settings.get('twodsix', 'omitPSIifZero'));
   returnData.system.characteristics.socialStanding.displayChar = true;
   returnData.system.characteristics.stamina.displayChar = false;
   returnData.system.characteristics.strength.displayChar = true;
 }
 
-export function getDisplayOrder(): string[] {
+export function getDisplayOrder(returnData: any): string[] {
   const returnValue = ['strength', 'intelligence', 'dexterity', 'education', 'endurance', 'socialStanding'];
   const charMode = game.settings.get('twodsix', 'showAlternativeCharacteristics');
 
@@ -360,13 +361,18 @@ export function getDisplayOrder(): string[] {
     case 'core':
       break;
     case 'base':
-      returnValue.push('psionicStrength');
+      if (returnData.system.characteristics.psionicStrength.value !== 0 || !game.settings.get('twodsix', 'omitPSIifZero')) {
+        returnValue.push('psionicStrength');
+      }
       break;
     case 'alternate':
       returnValue.push('alternative1', 'alternative2');
       break;
     case 'all':
-      returnValue.push('alternative1', 'alternative2', 'psionicStrength');
+      returnValue.push('alternative1', 'alternative2');
+      if (returnData.system.characteristics.psionicStrength.value !== 0 || !game.settings.get('twodsix', 'omitPSIifZero')) {
+        returnValue.push('psionicStrength');
+      }
       break;
     default:
       break;

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -142,6 +142,9 @@ Hooks.once('init', async function () {
   //@ts-ignore
   await loadTemplates(handlebarsTemplateFiles);
 
+  //Add TL to compendium index
+  CONFIG.Item.compendiumIndexFields.push('system.techLevel');
+
   // All other hooks are found in the module/hooks directory, and should be in the system.json esModules section.
 
 });

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -144,6 +144,9 @@ declare global {
       'twodsix.showActorReferences': boolean;
       'twodsix.maxSpellLevel': number;
       'twodsix.showAllCharWithTable': boolean;
+      'twodsix.defaultItemPartial': string;
+      'twodsix.defaultCompendiumPartial': string;
+      'twodsix.showTLonItemsTab': boolean;
     }
   }
 }

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -147,6 +147,7 @@ declare global {
       'twodsix.defaultItemPartial': string;
       'twodsix.defaultCompendiumPartial': string;
       'twodsix.showTLonItemsTab': boolean;
+      'twodsix.omitPSIifZero': boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1267,6 +1267,11 @@
       "showAllCharWithTable": {
         "hint": "Use a table, instead of hex graphics, when displaying characteristics (when selected characteristics to display is all). Foundry Standard Style always uses table.",
         "name": "Use table when displaying all characteristics"
+      },
+      "showTLonItemsTab": {
+        "hint": "Displays the items tech level after the name for compendium item lists and items listed in the items tab.",
+        "name": "Display Tech Level in Compenium and Item Tab lists"
+
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1270,7 +1270,7 @@
       },
       "showTLonItemsTab": {
         "hint": "Displays the items tech level after the name for compendium item lists and items listed in the items tab.",
-        "name": "Display Tech Level in Compenium and Item Tab lists"
+        "name": "Display Tech Level in Compendium and Item Tab lists"
 
       },
       "omitPSIifZero": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1272,6 +1272,11 @@
         "hint": "Displays the items tech level after the name for compendium item lists and items listed in the items tab.",
         "name": "Display Tech Level in Compenium and Item Tab lists"
 
+      },
+      "omitPSIifZero": {
+        "hint": "Does not display PSI characteristic if value set to zero.",
+        "name": "Omit PSI from actor sheets if value zero"
+
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -3761,3 +3761,9 @@ input[type="text"].color {
   background: var(--s2d6-skill-list-even);
   width: fit-content;
 }
+
+.revised-partial {
+  display: flex;
+  justify-content: space-between;
+  padding-right: 1ch;
+}

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -3021,3 +3021,9 @@ Monk's Enhanced Journals
   display: unset;
   text-align: right;
 }
+
+.revised-partial {
+  display: flex;
+  justify-content: space-between;
+  padding-right: 1ch;
+}

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -296,8 +296,25 @@ div.pdf-app section.window-content {
   color: var(--s2d6-default-color);
 }
 
+.tah-fieldset > legend {
+  color: var(--s2d6-default-color);
+  text-shadow: 1px 1px 1px var(--s2d6-nav-background);
+}
+
 /******** Monk's Sound Enhancements *****/
 .sheet .sound-sheet .items-list,
 .sheet .sound-sheet .items-list .item .item-name {
     color: var(--s2d6-default-color);
+}
+
+/****** Code Mirror ******/
+.CodeMirror-code {
+	color: revert !important;
+	background: revert !important;
+	background-color: revert !important;
+	border: none !important;
+}
+
+.customCssSettings .stylesheet-editor {
+	background-color: var(--s2d6-form-light);
 }

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -315,6 +315,7 @@ div.pdf-app section.window-content {
 	border: none !important;
 }
 
+/**** Custom CSS ***/
 .customCssSettings .stylesheet-editor {
 	background-color: var(--s2d6-form-light);
 }

--- a/static/system.json
+++ b/static/system.json
@@ -26,7 +26,7 @@
   "compatibility":
     {
       "minimum": "11",
-      "verified": "11.313"
+      "verified": "11.314"
     },
   "description": "Twodsix: A system for use with the Cepheus Engine Core Rules, Traveller (unofficial), and other similar games. <br/>This Product is derived from the Traveller System Reference Document and other Open Gaming Content made available by the Open Gaming License, and does not contain closed content from products published by either Mongoose Publishing or Far Future Enterprises. This Product is not affiliated with either Mongoose Publishing or Far Future Enterprises, and it makes no claim to or challenge to any trademarks held by either entity. The use of the Traveller System Reference Document does not convey the endorsement of this Product by either Mongoose Publishing or Far Future Enterprises as a product of either of their product lines.<br/>Cepheus Engine and Samardan Press™ are the trademarks of Jason \"Flynn\" Kemp; we are not affiliated with Jason \"Flynn\" Kemp or Samardan Press™.<br/> See the files OpenGameLicense.md and LICENSE for license details.<br/>",
   "esmodules": ["twodsix.bundle.js"],

--- a/static/templates/misc/revised-compendium-index-partial.html
+++ b/static/templates/misc/revised-compendium-index-partial.html
@@ -4,5 +4,5 @@
   {{else if this.img}}
   <img class="thumbnail" title="{{this.name}}" alt="{{this.name}}" data-src="{{this.img}}"/>
   {{/if}}
-  <h4 class="entry-name document-name"><a>{{this.name}}{{twodsix_getTLString this}}</a></h4>
+  <h4 class="entry-name document-name"><a class="revised-partial"><span>{{this.name}}</span><span>{{twodsix_getTLString this}}</span></a></h4>
 </li>

--- a/static/templates/misc/revised-compendium-index-partial.html
+++ b/static/templates/misc/revised-compendium-index-partial.html
@@ -1,0 +1,8 @@
+<li class="directory-item document {{@root.documentCls}} flexrow" data-entry-id="{{this._id}}" data-document-id="{{this._id}}">
+  {{#if this.thumb}}
+  <img class="thumbnail" title="{{this.name}}" alt="{{this.name}}" data-src="{{this.thumb}}"/>
+  {{else if this.img}}
+  <img class="thumbnail" title="{{this.name}}" alt="{{this.name}}" data-src="{{this.img}}"/>
+  {{/if}}
+  <h4 class="entry-name document-name"><a>{{this.name}}{{twodsix_getTLString this}}</a></h4>
+</li>

--- a/static/templates/misc/revised-document-partial.html
+++ b/static/templates/misc/revised-document-partial.html
@@ -1,0 +1,6 @@
+<li class="directory-item document {{@root.documentCls}} flexrow" data-entry-id="{{this.id}}" data-document-id="{{this.id}}">
+  {{#if this.thumbnail}}
+  <img class="thumbnail" title="{{this.name}}" data-src="{{this.thumbnail}}"/>
+  {{/if}}
+  <h4 class="entry-name document-name"><a>{{this.name}}{{twodsix_getTLString this}}</a></h4>
+</li>

--- a/static/templates/misc/revised-document-partial.html
+++ b/static/templates/misc/revised-document-partial.html
@@ -2,5 +2,5 @@
   {{#if this.thumbnail}}
   <img class="thumbnail" title="{{this.name}}" data-src="{{this.thumbnail}}"/>
   {{/if}}
-  <h4 class="entry-name document-name"><a>{{this.name}}{{twodsix_getTLString this}}</a></h4>
+  <h4 class="entry-name document-name"><a class="revised-partial"><span>{{this.name}}</span><span>{{twodsix_getTLString this}}</span></a></h4>
 </li>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fixes, feature


* **What is the current behavior?** (You can also link to an open issue here)
code mirror and TAH interfaces have style clashes with core Twodsix style
no way to see TL in items tab lists
PSI isn't optional if there is no value


* **What is the new behavior (if this is a feature change)?**
fix display issues
add option to show TL for Items Tab
New option to omit PSI display when value is zero

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
