### PR TITLE
fix: AE not active for linked actors on load

### DIFF
--- a/src/module/hooks/ready.ts
+++ b/src/module/hooks/ready.ts
@@ -102,9 +102,9 @@ async function toggleTokenEffect(actor:TwodsixActor): Promise<void> {
 }
 
 //This function is a kludge to reset linked actors overrides not being calculated correctly on initialize
-async function toggleActorEffect(actor:TwodsixActor): Promise<void> {
-  await toggleFirstActiveEffect(actor, false);
-}
+//async function toggleActorEffect(actor:TwodsixActor): Promise<void> {
+//  await toggleFirstActiveEffect(actor, false);
+//}
 
 /**
  * Toggles first AE on actor so that AE are correctly calculated on load.  This is a hack to fix an issue with FVTT or Twodsix that I can't find

--- a/src/module/hooks/ready.ts
+++ b/src/module/hooks/ready.ts
@@ -31,20 +31,23 @@ Hooks.once("ready", async function () {
   }
 
   // Perform the migration
-  if (game.user?.isGM) {
+  if (game.users.activeGM?.isSelf) {
     await migrateWorld(worldVersion);
   }
 
   // Check for missing untrained skills
-  if (game.user?.isGM) {
+  if (game.users.activeGM?.isSelf) {
     await applyToAllActors(async (actor: TwodsixActor) => {
       await correctMissingUntrainedSkill(actor);
     });
   }
 
-  //Toggle token actors' effect to correct off calc on refresh, should be fixed in version 11.306 onward
-  if (game.user?.isGM && (game.release.build < 306)) {
-    await applyToAllActors(toggleTokenEffect);
+  //Toggle actors' effect to correct off calc on refresh, should be fixed in version 11.306 onward for tokens
+  if (game.users.activeGM?.isSelf) {
+    if (game.release.build < 306) {
+      await applyToAllActors(toggleTokenEffect);
+    }
+    //await applyToAllActors(toggleActorEffect);
   }
 
   // A socket hook proxy
@@ -53,7 +56,7 @@ Hooks.once("ready", async function () {
   });
 
   // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
-  Hooks.on("hotbarDrop", (bar, data, slot) => createItemMacro(data, slot));
+  Hooks.on("hotbarDrop", (_bar, data, slot) => createItemMacro(data, slot));
 
   //set status icons
   if (game.settings.get('twodsix', 'reduceStatusIcons')) {
@@ -95,11 +98,26 @@ Hooks.once("ready", async function () {
 
 //This function is a kludge to reset token actors overrides not being calculated correctly on initialize
 async function toggleTokenEffect(actor:TwodsixActor): Promise<void> {
-  if (actor.isToken  && actor.isOwner) {
-    const tokenEffects = Array.from(actor.allApplicableEffects());
-    if (tokenEffects.length > 0) {
-      await tokenEffects[0].update({'disabled': !tokenEffects[0].disabled});
-      await tokenEffects[0].update({'disabled': !tokenEffects[0].disabled});
+  await toggleFirstActiveEffect(actor, true);
+}
+
+//This function is a kludge to reset linked actors overrides not being calculated correctly on initialize
+async function toggleActorEffect(actor:TwodsixActor): Promise<void> {
+  await toggleFirstActiveEffect(actor, false);
+}
+
+/**
+ * Toggles first AE on actor so that AE are correctly calculated on load.  This is a hack to fix an issue with FVTT or Twodsix that I can't find
+ * @param {TwodsixActor} actor the actor to toggle
+ * @param {boolean} isToken whether the actor is unlinked (Token actor) or not
+ * @function
+ */
+async function toggleFirstActiveEffect(actor:TwodsixActor, isToken: boolean): Promise<void> {
+  if (actor.isToken === isToken  && actor.isOwner) {
+    const actorEffects = Array.from(actor.allApplicableEffects());
+    if (actorEffects.length > 0) {
+      await actorEffects[0].update({'disabled': !actorEffects[0].disabled});
+      await actorEffects[0].update({'disabled': !actorEffects[0].disabled});
     }
   }
 }

--- a/src/module/hooks/setup.ts
+++ b/src/module/hooks/setup.ts
@@ -20,7 +20,6 @@ Hooks.once('setup', async function () {
     woundedSE.id = 'wounded';
     woundedSE.name = "EFFECT.StatusWounded";
   }
-  CONFIG.ActiveEffect.legacyTransferral = false;
 
   window["Twodsix"] = new TwodsixSystem();
 });

--- a/src/module/sheets/AbstractTwodsixItemSheet.ts
+++ b/src/module/sheets/AbstractTwodsixItemSheet.ts
@@ -16,7 +16,6 @@ export abstract class AbstractTwodsixItemSheet extends ItemSheet {
     );
   }
 
-
   public activateListeners(html:JQuery):void {
     super.activateListeners(html);
   }

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -49,6 +49,8 @@ Hooks.once('init', async function () {
     rollItemMacro
   };
 
+  CONFIG.ActiveEffect.legacyTransferral = false;
+
   // Actor
   CONFIG.Actor.documentClass = TwodsixActor;
   Actors.unregisterSheet('core', ActorSheet);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Active Effects for linked actors not active on world load


* **What is the new behavior (if this is a feature change)?**
AE that should be active are active


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
