### PR TITLE
fix: missing range field on flat weapons sheet

### DIFF
--- a/static/templates/items/parts/weapon-sheet-flat.html
+++ b/static/templates/items/parts/weapon-sheet-flat.html
@@ -5,6 +5,15 @@
     <label class="resource-label" for="system.handlingModifiers">{{localize "TWODSIX.Items.Weapon.HandlingModifiers"}}</label>
     <input class="form-input" id="system.handlingModifiers" type="text" placeholder="{{localize 'TWODSIX.Items.Weapon.HandlingExample'}}" name="system.handlingModifiers" value="{{system.handlingModifiers}}">
   </div>
+  <div class="item-range">
+    {{#if settings.ShowRangeBandAndHideRange}}
+      <label class="resource-label" for="system.rangeBand">{{localize "TWODSIX.Items.Weapon.rangeBand"}}</label>
+      <select id="system.rangeBand" name="system.rangeBand">{{selectOptions settings.rangeTypes selected=system.rangeBand localize=true}}</select>
+    {{else}}
+      <label class="resource-label" for="system.range">{{localize "TWODSIX.Items.Weapon.Range"}}</label>
+      <input class="form-input" id="system.range" type="text" name="system.range" value="{{system.range}}">
+    {{/if}}
+  </div>
   {{> "systems/twodsix/templates/items/parts/weapon-parts/weapon-attack.html"}}
   {{> "systems/twodsix/templates/items/parts/weapon-parts/weapon-magazine.html"}}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
range field not visible on flat weapons sheet


* **What is the new behavior (if this is a feature change)?**
field is visible


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
