### PR TITLE
feat: add additional equipment toggle locations

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -750,7 +750,15 @@ export const AllAnimalTypes = Object.assign({}, HerbivoreType, OmnivoreType, Car
 export const EQUIPPED_STATES = {
   backpack: "TWODSIX.Actor.Items.LocationState.backpack",
   equipped: "TWODSIX.Actor.Items.LocationState.equipped",
-  ship: "TWODSIX.Actor.Items.LocationState.ship"
+  vehicle: "TWODSIX.Actor.Items.LocationState.vehicle",
+  ship: "TWODSIX.Actor.Items.LocationState.ship",
+  base: "TWODSIX.Actor.Items.LocationState.base"
+};
+
+export const EQUIPPED_TOGGLE_OPTIONS = {
+  core: "TWODSIX.Actor.Items.LocationState.core",
+  default: "TWODSIX.Actor.Items.LocationState.default",
+  all: "TWODSIX.Actor.Items.LocationState.all",
 };
 
 export const RANGE_MODIFIERS_TYPES = {
@@ -813,6 +821,7 @@ export type TWODSIX = {
   areaTargetTypes: typeof areaTargetTypes,
   SuccessTypes: typeof SuccessTypes,
   EQUIPPED_STATES: typeof EQUIPPED_STATES,
+  EQUIPPED_TOGGLE_OPTIONS: typeof EQUIPPED_TOGGLE_OPTIONS,
   RANGE_MODIFIERS_TYPES: typeof RANGE_MODIFIERS_TYPES,
   WEAPON_RANGE_TYPES: typeof WEAPON_RANGE_TYPES
 };
@@ -845,6 +854,7 @@ export const TWODSIX = {
   areaTargetTypes: areaTargetTypes,
   SuccessTypes: SuccessTypes,
   EQUIPPED_STATES: EQUIPPED_STATES,
+  EQUIPPED_TOGGLE_OPTIONS: EQUIPPED_TOGGLE_OPTIONS,
   RANGE_MODIFIERS_TYPES: RANGE_MODIFIERS_TYPES,
   WEAPON_RANGE_TYPES: WEAPON_RANGE_TYPES
 };

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -1138,7 +1138,7 @@ async function deleteIdFromShipPositions(actorId: string) {
  */
 function getEquipmentWeight(item:TwodsixItem):number {
   if (!["skills", "spell", "trait"].includes(item.type)) {
-    if (item.system.equipped !== "ship") {
+    if (["backpack", "equipped"].includes(item.system.equipped)) {
       let q = item.system.quantity || 0;
       const w = item.system.weight || 0;
       if (item.type === "armor" && item.system.equipped === "equipped") {

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -224,6 +224,23 @@ export default function registerHandlebarsHelpers(): void {
     }
   });
 
+  Handlebars.registerHelper('twodsix_getEquippedIcon', (equipped: string) => {
+    switch (equipped) {
+      case 'backpack':
+        return "fa-solid fa-person-hiking";
+      case 'equipped':
+        return "fa-solid fa-child-reaching";
+      case 'ship':
+        return "fa-solid fa-shuttle-space";
+      case 'vehicle':
+        return "fa-solid fa-truck-plane";
+      case 'base':
+        return "fa-solid fa-house-user";
+      default:
+        return "fa-solid fa-person-hiking";
+    }
+  });
+
   Handlebars.registerHelper('twodsix_getSettingIcon', (componentType: string) => {
     switch (componentType) {
       case 'general':
@@ -289,7 +306,7 @@ export default function registerHandlebarsHelpers(): void {
   });
 
   Handlebars.registerHelper('twodsix_hideItem', (display:boolean, itemLocation:string) => {
-    return (display && (itemLocation === "ship"));
+    return (display && (["ship", "vehicle", "base"].includes(itemLocation)));
   });
 
   Handlebars.registerHelper('twodsix_getProcessingPower', (item:TwodsixItem) => {

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -1,7 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
 import AdvancedSettings from "./AdvancedSettings";
-import {booleanSetting, colorSetting} from "./settingsUtils";
+import {booleanSetting, colorSetting, stringChoiceSetting} from "./settingsUtils";
+import {TWODSIX} from "../config";
 
 export default class DisplaySettings extends AdvancedSettings {
   static create() {
@@ -56,6 +57,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.actor.push(booleanSetting('showAllCharWithTable', true));
     settings.general.push(booleanSetting('showTLonItemsTab', false, false, 'world', setDocumentPartials));
     settings.actor.push(booleanSetting('omitPSIifZero', false));
+    settings.actor.push(stringChoiceSetting('equippedToggleStates', "default", true, TWODSIX.EQUIPPED_TOGGLE_OPTIONS));
     return settings;
   }
 }

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -149,6 +149,7 @@ declare global {
       'twodsix.showTLonItemsTab': boolean;
       'twodsix.omitPSIifZero': boolean;
       'twodsix.rangeModifierType': string;
+      'twodsix.equippedToggleStates': string;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -146,7 +146,12 @@
         "LocationState": {
           "equipped": "Equipped",
           "ship": "Ship",
-          "backpack": "Backpack"
+          "backpack": "Backpack",
+          "vehicle": "Vehicle",
+          "base": "Base",
+          "core": "Core (backpack and equipped only)",
+          "default": "Default (backpack, equipped and ship)",
+          "all": "All"
         },
         "Subtype": "Type",
         "TRAITS": "TRAITS",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1695,17 +1695,6 @@ input.item-value-edit {
 }
 
 .item-controls .item-toggle i {
-  display: none;
-}
-.item-controls .item-toggle .fa-person-hiking {
-  display: inline;
-}
-.item-controls .item-toggle.ship .fa-person-hiking,
-.item-controls .item-toggle.equipped .fa-person-hiking {
-   display: none;
-}
-.item-controls .item-toggle.ship .fa-shuttle-space,
-.item-controls .item-toggle.equipped .fa-child-reaching {
   display: inline;
 }
 

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1230,12 +1230,7 @@ input.item-value-edit {
   overflow: auto;
 }
 
-.item-controls .item-toggle i { display: none; }
-.item-controls .item-toggle .fa-person-hiking { display: inline; }
-.item-controls .item-toggle.ship .fa-person-hiking,
-.item-controls .item-toggle.equipped .fa-person-hiking { display: none; }
-.item-controls .item-toggle.ship .fa-shuttle-space,
-.item-controls .item-toggle.equipped .fa-child-reaching { display: inline; }
+.item-controls .item-toggle i { display: inline; }
 
 .item-controls {
   align-self: center;

--- a/static/templates/actors/npc-sheet.html
+++ b/static/templates/actors/npc-sheet.html
@@ -71,7 +71,7 @@
             <span class="item" data-item-id="{{item.id}}">
               <span class="item-name rollable">{{item.name}} </span>
               <span class="item-controls centre">
-                <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+                <a class="item-control item-toggle" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="{{twodsix_getEquippedIcon item.system.equipped}}"></i></a>
                 <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i
                     class="fa-solid fa-pen-to-square"></i></a>
                 <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>{{#unless @last}}, {{/unless}}

--- a/static/templates/actors/parts/actor/actor-items.html
+++ b/static/templates/actors/parts/actor/actor-items.html
@@ -44,7 +44,7 @@
                 {{#unless item.system.consumableData}}
                   <a class="item-control item-fill-consumable" data-tooltip='{{localize "TWODSIX.Actor.Items.Refill"}}'><i class="fa-solid fa-battery-full"></i></a>
                 {{/unless}}{{/unless}}
-                <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+                <a class="item-control item-toggle" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="{{twodsix_getEquippedIcon item.system.equipped}}"></i></a>
                 <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
                 <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
               </span>
@@ -129,7 +129,7 @@
               <span class="item-name centre">{{item.system.weight}}</span>
               <span class="item-name centre">{{item.system.armor}}</span>
               <span class="item-controls centre">
-                <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+                <a class="item-control item-toggle" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="{{twodsix_getEquippedIcon item.system.equipped}}"></i></a>
                 <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
                 <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
               </span>
@@ -182,7 +182,7 @@
               <span class="item-name centre">{{item.system.bonus}}</span>
               <span class="item-name centre">{{item.system.auglocation}}</span>
               <span class="item-controls centre">
-                <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+                <a class="item-control item-toggle" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="{{twodsix_getEquippedIcon item.system.equipped}}"></i></a>
                 <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
                 <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
               </span>
@@ -237,7 +237,7 @@
                     <span class="item-name centre">{{item.system.shortdescr}}</span>
                   {{/iff}}
                   <span class="item-controls centre">
-                    <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+                    <a class="item-control item-toggle" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="{{twodsix_getEquippedIcon item.system.equipped}}"></i></a>
                     <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
                     <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
                   </span>
@@ -290,7 +290,7 @@
                   <span class="item-name centre">{{item.system.weight}}</span>
                   <span></span>
                   <span class="item-controls centre">
-                    {{#iff item.type "===" "junk"}}<a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>{{/iff}}
+                    {{#iff item.type "===" "junk"}}<a class="item-control item-toggle" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="{{twodsix_getEquippedIcon item.system.equipped}}"></i></a>{{/iff}}
                     <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
                     <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
                   </span>
@@ -340,7 +340,7 @@
                       <input class= "item-value-edit" type="number" min="0" step="1" value="{{item.system.quantity}}"/>
                       <span class="item-name centre">{{item.system.currentCount}}/{{item.system.max}}</span>
                       <span class="item-controls centre">
-                        <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+                        <a class="item-control item-toggle" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="{{twodsix_getEquippedIcon item.system.equipped}}"></i></a>
                         <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
                         <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
                       </span>
@@ -393,7 +393,7 @@
                 <input class= "item-value-edit" type="number" min="0" step="1" value="{{item.system.quantity}}"/>
                 <span class="item-name centre">{{item.system.techLevel}}</span>
                 <span class="item-controls centre">
-                  <a class="item-control item-toggle {{item.system.equipped}}" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="fa-solid fa-child-reaching"></i><i class="fa-solid fa-shuttle-space"></i><i class="fa-solid fa-person-hiking"></i></a>
+                  <a class="item-control item-toggle" data-tooltip='{{localize (concat "TWODSIX.Actor.Items.LocationState." item.system.equipped)}}'><i class="{{twodsix_getEquippedIcon item.system.equipped}}"></i></a>
                   <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i class="fa-solid fa-pen-to-square"></i></a>
                   <a class="item-control item-delete" data-tooltip='{{localize "TWODSIX.Actor.Items.DeleteItem"}}'><i class="fa-solid fa-trash"></i></a>
                 </span>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Only three equipment locations are available : backpack, equipped, and ship


* **What is the new behavior (if this is a feature change)?**
Add additional options of base and vehicle.  Options can be customized via setting.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
