### PR TITLE
feat: New Enhancer Buttons for Journal pages

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -11,7 +11,7 @@ import TwodsixActor from "./TwodsixActor";
 import {DICE_ROLL_MODES} from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs";
 import {Component, Consumable, Gear, Skills, UsesConsumables, Weapon} from "../../types/template";
 import { confirmRollFormula } from "../utils/sheetUtils";
-import { getCharacteristicFromDisplayLabel } from "../utils/TwodsixShipActions";
+import { getCharacteristicFromDisplayLabel } from "../utils/utils";
 import ItemTemplate from "../utils/ItemTemplate";
 import { getDamageTypes } from "../sheets/TwodsixItemSheet";
 import { TWODSIX } from "../config";

--- a/src/module/hooks/tableRolls.ts
+++ b/src/module/hooks/tableRolls.ts
@@ -1,10 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
 
-import { handleTableRoll } from "../utils/enrichers";
-
+import { handleTableRoll, handleSkillRoll } from "../utils/enrichers";
+// Add hooks when clicking on rollable table link
 for (const sheet of ["JournalPageSheet"]) {
   Hooks.on(`render${sheet}`, (_app, html, _options) => {
     html.on('click contextmenu', '.table-roll', handleTableRoll.bind());
+    html.on('click contextmenu', '.skill-roll', handleSkillRoll.bind());
   });
 }

--- a/src/module/hooks/tableRolls.ts
+++ b/src/module/hooks/tableRolls.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+
+import { handleTableRoll } from "../utils/enrichers";
+
+for (const sheet of ["JournalPageSheet"]) {
+  Hooks.on(`render${sheet}`, (_app, html, _options) => {
+    html.on('click contextmenu', '.table-roll', handleTableRoll.bind());
+  });
+}

--- a/src/module/utils/enrichers.ts
+++ b/src/module/utils/enrichers.ts
@@ -1,0 +1,163 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+
+//Adapted from https://github.com/pafvel/dragonbane/blob/master/modules/journal.js
+
+export function addCustomEnrichers() {
+  CONFIG.TextEditor.enrichers.push(
+    {
+      pattern: /@DisplayTable\[(.+?)\](?:{(.+?)})?/gm,
+      enricher: enrichDisplayTable
+    },
+    {
+      pattern: /@Table\[(.+?)\](?:{(.+?)})?/gm,
+      enricher: rollTable
+    }
+  );
+}
+
+async function enrichDisplayTable (match, options) {
+  const table = findTable(match[1], options);
+  const tableName = match[2] ?? table?.name;
+  const a = document.createElement("div");
+  if (table) {
+    a.classList.add("display-table");
+    const html = displayTable(match[1], table, tableName);
+    a.innerHTML = await TextEditor.enrichHTML(html, {async: true});
+  } else {
+    a.dataset.tableId = match[1];
+    if (match[2]) {
+      a.dataset.tableName = match[2];
+    }
+    a.classList.add("content-link");
+    a.classList.add("broken");
+    a.innerHTML = `<i class="fas fa-unlink"></i> ${tableName}`;
+  }
+  return a;
+}
+
+async function rollTable (match, options) {
+  const table = findTable(match[1], options);
+  const tableName = match[2] ?? table?.name;
+  const a = document.createElement("a");
+  if (table) {
+    a.classList.add("inline-roll");
+    a.classList.add("table-roll");
+    a.dataset.tableId = table.uuid;
+    a.dataset.tableName = table.name;
+    a.innerHTML = `<i class="fas fa-dice-d20"></i><i class="fas fa-th-list"></i> ${tableName}`;
+  } else {
+    a.dataset.tableId = match[1];
+    if (match[2]) {
+      a.dataset.tableName = match[2];
+    }
+    a.classList.add("content-link");
+    a.classList.add("broken");
+    a.innerHTML = `<i class="fas fa-unlink"></i> ${tableName}`;
+  }
+  return a;
+}
+
+function displayTable(uuid, table, tableName) {
+  if (!table) {
+    return "";
+  }
+
+  /*
+  // Rollable table in caption
+  let html = `
+  <table>
+      <caption>@Table[${uuid}]{${tableName}}</caption>
+      <tr>
+          <th>[[/roll ${table.formula}]]</th>
+          <th>${game.i18n.localize("DoD.journal.tableResult")}</th>
+      </tr>`;
+  */
+
+  // Rollable table in roll column header
+  let html = `
+  <table>
+      <caption class="table-caption">${tableName}</caption>
+      <tr>
+          <th style="text-transform: uppercase;">@Table[${uuid}]{${table.formula}}</th>
+          <th>${game.i18n.localize("Table Result")}</th>
+      </tr>`;
+
+  for (const result of table.results) {
+    html += `
+      <tr>
+          <td>${result.range[0]}`;
+    if (result.range[1] != result.range[0]) {
+      html += ` - ${result.range[1]}`;
+    }
+    if (result.documentCollection == "RollTable") {
+      const subTable = findTable(result.text);
+      if (subTable?.uuid != table.uuid) {
+        let subTableName = result.text;
+        if(subTableName.startsWith(table.name)) {
+          subTableName = subTableName.slice(table.name.length);
+          if (subTableName.startsWith(" - ")) {
+            subTableName = subTableName.slice(3);
+          }
+        }
+        html += `</td>
+                  <td>${subTable?.description} @DisplayTable[RollTable.${result.documentId}]{${subTableName}}</td>
+              </tr>`;
+      } else {
+        html += `</td>
+                  <td>${result.text}</td>
+              </tr>`;
+      }
+    } else if (result.documentCollection == "Item") {
+      html += `</td>
+              <td>@UUID[Item.${result.documentId}]{${result.text}}</td>
+          </tr>`;
+    } else {
+      html += `</td>
+              <td>${result.text}</td>
+          </tr>`;
+    }
+  }
+  html += `</table>`;
+  return html;
+}
+
+function findTable(tableName:string, options?:any) {
+  const table = game.tables.find(i => i.name.toLowerCase() == tableName.toLowerCase()) || fromUuidSync(tableName);
+  if (!table) {
+    if (!options?.noWarnings){
+      sendWarning("WARNING.tableNotFound", {id: tableName});
+    }
+    return null;
+  }
+  if (!(table instanceof RollTable)) {
+    if (!options?.noWarning){
+      sendWarning("WARNING.typeMismatch", {id: tableName});
+    }
+    return null;
+  }
+  return table;
+}
+
+function sendWarning(msg, params) {
+  if (!params) {
+    return ui.notifications.warn(game.i18n.localize(msg));
+  } else {
+    return ui.notifications.warn(game.i18n.format(game.i18n.localize(msg), params));
+  }
+}
+
+export async function handleTableRoll(event) {
+  const tableId = event.currentTarget.dataset.tableId;
+  const tableName = event.currentTarget.dataset.tableName;
+  const table = fromUuidSync(tableId) || this.findTable(tableName);
+  if (table) {
+    if (event.type == "click") { // left click
+      table.draw();
+    } else { // right click
+      table.sheet.render(true);
+    }
+  }
+  event.preventDefault();
+  event.stopPropagation();
+}

--- a/src/module/utils/enrichers.ts
+++ b/src/module/utils/enrichers.ts
@@ -18,7 +18,7 @@ export function addCustomEnrichers() {
       enricher: rollTable
     },
     {
-      pattern: /@SkillRoll(?:{(.+?)})?/gm,
+      pattern: /@SkillRoll(?:\[(.*?)\])?(?:{(.*?)})?/gm,
       enricher: rollSkill
     }
   );
@@ -85,12 +85,13 @@ async function rollTable (match: any, options: any): Promise<HTMLAnchorElement> 
  * @returns {HTMLAnchorElement} The rolltable in an html format
  */
 async function rollSkill (match: any, _options: any): Promise<HTMLAnchorElement> {
-  const skillName = match[1] ?? match[2];
+  const skillName = match[1] || match[2];
+  const descrip = match[2] || match[1];
   const a = document.createElement("a");
   a.classList.add("inline-roll");
   a.classList.add("skill-roll");
   a.dataset.skillName = skillName;
-  a.innerHTML = `<i class="fas fa-dice-d20"></i> ${skillName}`;
+  a.innerHTML = `<i class="fas fa-dice-d20"></i> ${descrip}`;
   return a;
 }
 

--- a/src/module/utils/enrichers.ts
+++ b/src/module/utils/enrichers.ts
@@ -241,7 +241,7 @@ export async function handleSkillRoll(event: Event): Promise<void> {
  * @param {any} options The optional find strings
  * @returns {TwodsixItem} The RollTable document
  */
-function findSkill(skillName:string): TwodsixItem {
+/*function findSkill(skillName:string): TwodsixItem {
   const actorToUse = getControlledTraveller();
   if (actorToUse) {
     let skill = actorToUse.itemTypes.skills?.find(i => i.name.toLowerCase() == skillName.toLowerCase()) || fromUuidSync(skillName);
@@ -252,4 +252,4 @@ function findSkill(skillName:string): TwodsixItem {
   } else {
     ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoActorSelected"));
   }
-}
+}*/

--- a/src/module/utils/enrichers.ts
+++ b/src/module/utils/enrichers.ts
@@ -227,7 +227,7 @@ export async function handleSkillRoll(event: Event): Promise<void> {
  * @param {any} options The optional find strings
  * @returns {TwodsixItem} The RollTable document
  */
-function findSkill(skillName:string, _options?:any): TwodsixItem {
+function findSkill(skillName:string): TwodsixItem {
   const actorToUse = getControlledTraveller();
   if (actorToUse) {
     let skill = actorToUse.itemTypes.skills?.find(i => i.name.toLowerCase() == skillName.toLowerCase()) || fromUuidSync(skillName);

--- a/src/module/utils/utils.ts
+++ b/src/module/utils/utils.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+import { getKeyByValue } from "./sheetUtils";
 
 // https://stackoverflow.com/a/34749873
 /**
@@ -120,4 +121,24 @@ export function capitalizeFirstLetter(inputString:string):string {
   } else {
     return "";
   }
+}
+
+/**
+ * A function for getting the full characteristic key from the displayed short label.
+ * @param {string} char           The displayed characteristic short label.
+ * @param {TwodsixActor} actor    The Actor in question.
+ * @returns {string}              Full logical name (key) of the characteristic.
+ */
+export function getCharacteristicFromDisplayLabel(char:string, actor?:TwodsixActor):string {
+  let tempObject = {};
+  let charObject= {};
+  if (actor) {
+    charObject = actor.system["characteristics"];
+    for (const key in charObject) {
+      tempObject[key] = charObject[key].displayShortLabel;
+    }
+  } else {
+    tempObject = TWODSIX.CHARACTERISTICS;
+  }
+  return getKeyByValue(tempObject, char);
 }

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -28,6 +28,7 @@ import { TwodsixRobotSheet } from "./module/sheets/TwodsixRobotSheet";
 import { TwodsixSpaceObjectSheet } from "./module/sheets/TwodsixSpaceObjectSheet";
 import { TwodsixDiceRoll } from "./module/utils/TwodsixDiceRoll";
 import { TwodsixRollSettings } from "./module/utils/TwodsixRollSettings";
+import { addCustomEnrichers } from "./module/utils/enrichers";
 
 // @ts-ignore
 hookScriptFiles.forEach((hookFile:string) => import(`./module/hooks/${hookFile}.ts`));
@@ -112,8 +113,12 @@ Hooks.once('init', async function () {
   registerHandlebarsHelpers();
 
   registerSettings();
+
   //Dice Rolls
   CONFIG.Dice.rolls.push(TwodsixDiceRoll);
+
+  //Add custom Enrichers
+  addCustomEnrichers();
 
   /* add fonts */
   // @ts-ignore

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -380,6 +380,9 @@
         }
       }
     },
+    "Table": {
+      "TableResults": "Table Results"
+    },
     "Create": "Create",
     "Handlebars": {
       "CantShowCharacteristic": "You need to reselect the characteristic for all skills marked with XXX. Sorry..."
@@ -1406,7 +1409,9 @@
       "MissingUntrainedSkill": "Actor is missing untrained skill. Reload application to fix.",
       "TooManyTargets": "More targets than the number of attacks, targets will be chosen in order selected.",
       "WearingMultipleLayers": "Multiple armor layers equipped while wearing non-stackable armor.",
-      "ResetEffectForManualDamage": "Effects not included in damage rolls.  Resetting effects in manual rolls to false."
+      "ResetEffectForManualDamage": "Effects not included in damage rolls.  Resetting effects in manual rolls to false.",
+      "tableNotFound": "Cannot find RollTable in Journal Entry Link.",
+      "typeMismatch": "RollTable link/UUID in Journal Entry is not a RollTable."
     }
   },
   "TYPES": {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -3071,6 +3071,12 @@ select.form-input, input.form-input, span.form-input {
   color: var(--s2d6-stat-input);
 }
 
+.table-caption {
+  color: var(--s2d6-stat-input);
+  font-size: 1.5em;
+  font-style: italic;
+}
+
 .chat-message .table-draw .table-results .table-result .result-text {
   color: var(--s2d6-dialog-color);
 }

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2543,6 +2543,12 @@ background: var(--sidebar-background);
   word-break: break-all;
   font-size: inherit;
 }*/
+
+.table-caption {
+  font-size: 1.5em;
+  font-style: italic;
+}
+
 .dice-total {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
No direct ability to display roll table in Journal Entry
Can't make complex skill rolls without macro


* **What is the new behavior (if this is a feature change)?**
Add @DisplayRollTable enricher. 
Add @SkillRoll enricher. 
Described here: https://github.com/xdy/twodsix-foundryvtt/wiki/Custom-Journal-Page-Enhancers

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Refactored ship position skill roll code to use parsing across both code bases