### PR TITLE
fix: enable button in DisplayTable for chat messages

### DIFF
--- a/src/module/hooks/chatCard.ts
+++ b/src/module/hooks/chatCard.ts
@@ -7,17 +7,19 @@ import TwodsixActor from "../entities/TwodsixActor";
 import { TwodsixDiceRoll } from "../utils/TwodsixDiceRoll";
 import { TwodsixRollSettings } from "../utils/TwodsixRollSettings";
 import { TWODSIX } from "../config";
-import { handleSkillRoll } from "../utils/enrichers";
+import { handleSkillRoll, handleTableRoll } from "../utils/enrichers";
 
 Hooks.on("renderChatLog", (_app, html, _data) => {
   html.on("click", ".card-buttons button", onChatCardAction);
   html.on("click", ".item-name", onChatCardToggleContent);
   html.on("click", ".skill-roll", handleSkillRoll);
+  html.on("click", ".table-roll", handleTableRoll);
 });
 Hooks.on("renderChatPopout", (_app, html, _data) => {
   html.on("click", ".card-buttons button", onChatCardAction);
   html.on("click", ".item-name", onChatCardToggleContent);
   html.on("click", ".skill-roll", handleSkillRoll);
+  html.on("click", ".table-roll", handleTableRoll);
 });
 
 /* -------------------------------------------- */


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Button using `@DisplayTable` in chat doesn't work


* **What is the new behavior (if this is a feature change)?**
Button now executes code from chat.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
