### PR TITLE
fix: allow SkillRoll Enricher to make characteristic  checks

### DIFF
--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -378,59 +378,69 @@ export function getInitialSettingsFromFormula(parseString: string, actor: Twodsi
 
   if (parsedResult !== null) {
     const [, parsedSkills, char, diff] = parsedResult;
-    const skillOptions = parsedSkills.split("|");
-    let skill:TwodsixItem|undefined = undefined;
-    /* add qualified skill objects to an array*/
-    const skillObjects = actor?.itemTypes.skills?.filter((itm: TwodsixItem) => skillOptions.includes(itm.name));
-
-    // find the most advantageous skill to use from the collection
-    if(skillObjects?.length > 0){
-      skill = skillObjects.reduce((prev, current) => (prev.system.value > current.system.value) ? prev : current);
-    }
-
-    // If skill missing, try to use Untrained
-    if (!skill) {
-      skill = actor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
-      if (!skill) {
-        ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", actor?.name ?? "").replace("_SKILL_", parsedSkills));
-        return false;
-      }
-    }
-
-    // get characteristic key, default to skill key if none specificed in formula
-    let characteristicKey = "";
-    const charObject = actor?.system["characteristics"] ?? {};
-    //we need an array
-    const charObjectArray = Object.values(charObject);
-    if(!char) {
-      characteristicKey = getKeyByValue(TWODSIX.CHARACTERISTICS, (<Skills>skill.system).characteristic);
+    if (parsedSkills === 'None') {
+      return {
+        skill: 'None',
+        rollModifiers: {
+          characteristic: char,
+        },
+        difficulty: Object.values(difficulties).filter((difficulty: Record<string, number>) => difficulty.target === parseInt(diff, 10))[0]
+      };
     } else {
-      //find the most advantageous characteristic to use based on the displayed (custom) short label
-      const charOptions = char.split("|");
-      let candidateCharObject = undefined;
-      const candidateCharObjects = charObjectArray.filter(ch => charOptions.includes(ch.displayShortLabel));
-      if(candidateCharObjects.length > 0){
-        candidateCharObject = candidateCharObjects.reduce((prev, current) =>(prev.mod > current.mod) ? prev: current);
-      }
-      characteristicKey = candidateCharObject?.key ?? getCharacteristicFromDisplayLabel(char, actor);
-    }
+      const skillOptions = parsedSkills.split("|");
+      let skill:TwodsixItem|undefined = undefined;
+      /* add qualified skill objects to an array*/
+      const skillObjects = actor?.itemTypes.skills?.filter((itm: TwodsixItem) => skillOptions.includes(itm.name));
 
-    let shortLabel = "NONE";
-    let displayLabel = "NONE";
-    if (charObject && characteristicKey) {
-      shortLabel = charObject[characteristicKey].shortLabel;
-      displayLabel = charObject[characteristicKey].displayShortLabel;
+      // find the most advantageous skill to use from the collection
+      if(skillObjects?.length > 0){
+        skill = skillObjects.reduce((prev, current) => (prev.system.value > current.system.value) ? prev : current);
+      }
+
+      // If skill missing, try to use Untrained
+      if (!skill) {
+        skill = actor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
+        if (!skill) {
+          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", actor?.name ?? "").replace("_SKILL_", parsedSkills));
+          return false;
+        }
+      }
+
+      // get characteristic key, default to skill key if none specificed in formula
+      let characteristicKey = "";
+      const charObject = actor?.system["characteristics"] ?? {};
+      //we need an array
+      const charObjectArray = Object.values(charObject);
+      if(!char) {
+        characteristicKey = getKeyByValue(TWODSIX.CHARACTERISTICS, (<Skills>skill.system).characteristic);
+      } else {
+        //find the most advantageous characteristic to use based on the displayed (custom) short label
+        const charOptions = char.split("|");
+        let candidateCharObject = undefined;
+        const candidateCharObjects = charObjectArray.filter(ch => charOptions.includes(ch.displayShortLabel));
+        if(candidateCharObjects.length > 0){
+          candidateCharObject = candidateCharObjects.reduce((prev, current) =>(prev.mod > current.mod) ? prev: current);
+        }
+        characteristicKey = candidateCharObject?.key ?? getCharacteristicFromDisplayLabel(char, actor);
+      }
+
+      let shortLabel = "NONE";
+      let displayLabel = "NONE";
+      if (charObject && characteristicKey) {
+        shortLabel = charObject[characteristicKey].shortLabel;
+        displayLabel = charObject[characteristicKey].displayShortLabel;
+      }
+      const returnValues = {
+        skill: skill,
+        skillRoll: true,
+        displayLabel: displayLabel,
+        rollModifiers: {characteristic: shortLabel}
+      };
+      if (diff) {
+        returnValues["difficulty"] = Object.values(difficulties).filter((difficulty: Record<string, number>) => difficulty.target === parseInt(diff, 10))[0];
+      }
+      return returnValues;
     }
-    const returnValues = {
-      skill: skill,
-      skillRoll: true,
-      displayLabel: displayLabel,
-      rollModifiers: {characteristic: shortLabel}
-    };
-    if (diff) {
-      returnValues["difficulty"] = Object.values(difficulties).filter((difficulty: Record<string, number>) => difficulty.target === parseInt(diff, 10))[0];
-    }
-    return returnValues;
   } else {
     ui.notifications.error(game.i18n.localize("TWODSIX.Ship.CannotParseArgument"));
     return false;

--- a/src/module/utils/enrichers.ts
+++ b/src/module/utils/enrichers.ts
@@ -93,7 +93,7 @@ async function rollSkill (match: any, _options: any): Promise<HTMLAnchorElement>
   a.classList.add("inline-roll");
   a.classList.add("skill-roll");
   a.dataset.parseString = skillName;
-  a.innerHTML = `<i class="fas fa-dice-d20"></i> ${descrip}`;
+  a.innerHTML = `<i class="fa-solid fa-dice"></i> ${descrip}`;
   return a;
 }
 

--- a/src/module/utils/enrichers.ts
+++ b/src/module/utils/enrichers.ts
@@ -218,16 +218,20 @@ export async function handleSkillRoll(event: Event): Promise<void> {
   if (actorToUse) {
     const parsedValues:any = getInitialSettingsFromFormula(parseString, actorToUse);
     if (parsedValues) {
-      const skill:TwodsixItem = parsedValues.skill;
-      if (event.type == "click") { // left click
-        delete parsedValues.skill;
-        const settings:TwodsixRollSettings = await TwodsixRollSettings.create(true, parsedValues, skill, undefined, actorToUse);
-        if (!settings.shouldRoll) {
-          return;
+      if (parsedValues.skill === 'None') {
+        actorToUse.characteristicRoll({rollModifiers: {characteristic: parsedValues.rollModifiers.characteristic}, difficulty: parsedValues.difficulty}, true);
+      } else {
+        const skill:TwodsixItem = parsedValues.skill;
+        if (event.type == "click") { // left click
+          delete parsedValues.skill;
+          const settings:TwodsixRollSettings = await TwodsixRollSettings.create(true, parsedValues, skill, undefined, actorToUse);
+          if (!settings.shouldRoll) {
+            return;
+          }
+          await skill.skillRoll(false, settings);
+        } else { // right click
+          skill.sheet.render(true);
         }
-        await skill.skillRoll(false, settings);
-      } else { // right click
-        skill.sheet.render(true);
       }
     }
   } else {

--- a/src/module/utils/targetModifiers.ts
+++ b/src/module/utils/targetModifiers.ts
@@ -21,7 +21,7 @@ export function generateTargetDMObject():void {
     const customDMs:string[] = parseString.replace(/[\t\n\r]/gm, ' ').split(',');
     for (const modifier of customDMs) {
       // eslint-disable-next-line no-useless-escape
-      const re = new RegExp(/([^\d]*?)([-+]?\d+$)/g);
+      const re = new RegExp(/(.+?)([+-]?\d+)$/);
       const parsedResult: RegExpMatchArray | null = re.exec(modifier);
       if (parsedResult) {
         const keyValue = `key${i}`;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix


* **What is the current behavior?** (You can also link to an open issue here)
SkillRoll enricher can't make characteristic checks - must have skill


* **What is the new behavior (if this is a feature change)?**
If 'None' is entered as skill, SkillRoll makes characteristic check, instead.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
