### PR TITLE
fix: make @SkillRoll always use the displayed char label

### DIFF
--- a/src/module/utils/enrichers.ts
+++ b/src/module/utils/enrichers.ts
@@ -219,7 +219,7 @@ export async function handleSkillRoll(event: Event): Promise<void> {
     const parsedValues:any = getInitialSettingsFromFormula(parseString, actorToUse);
     if (parsedValues) {
       if (parsedValues.skill === 'None') {
-        actorToUse.characteristicRoll({rollModifiers: {characteristic: parsedValues.rollModifiers.characteristic, other: parsedValues.rollModifiers.other}, difficulty: parsedValues.difficulty}, true);
+        actorToUse.characteristicRoll({rollModifiers: parsedValues.rollModifiers, difficulty: parsedValues.difficulty}, true);
       } else {
         const skill:TwodsixItem = parsedValues.skill;
         if (event.type == "click") { // left click


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
@SkillRoll[None/???] requires the logical short name, not the custom/displayed one.  Also, logical or does not work.


* **What is the new behavior (if this is a feature change)?**
Have @SkillRoll[None/???] work with displayed short label.
The logical or now works with CHR rolls, e.g. @SkillRoll[None/DEX|STR]


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
