### PR TITLE
feat: add active effects custom mode

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -961,7 +961,7 @@ export default class TwodsixActor extends Actor {
       this.statuses.clear();
     }
 
-    // Organize non-disabled effects by their application priority
+    // Organize non-disabled effects by their application priority and add CUSTOM to derivedData
     const changes = [];
     for ( const effect of this.appliedEffects ) {
       changes.push(...effect.changes.map(change => {
@@ -972,6 +972,13 @@ export default class TwodsixActor extends Actor {
       }));
       for ( const statusId of effect.statuses ) {
         this.statuses.add(statusId);
+      }
+      //Add custom effects to the derivedData array
+      const customChanges = effect.changes.filter( change => change.mode === CONST.ACTIVE_EFFECT_MODES.CUSTOM);
+      for ( const change of customChanges) {
+        if(!derivedData.includes(change.key)) {
+          derivedData.push(change.key);
+        }
       }
     }
     changes.sort((a, b) => a.priority - b.priority);

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -176,7 +176,7 @@ export default class TwodsixActor extends Actor {
     let maxEncumbrance = 0;
     const encumbFormula = game.settings.get('twodsix', 'maxEncumbrance');
     if (Roll.validate(encumbFormula)) {
-      maxEncumbrance = new Roll(encumbFormula, this.system).evaluate({async: false}).total;
+      maxEncumbrance = Roll.safeEval(Roll.replaceFormulaData(encumbFormula, this.system));
     }
     return maxEncumbrance;
   }

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -723,14 +723,14 @@ export function getDiceResults(inputRoll:Roll) {
 /**
  * A function for getting a value from a roll string.
  *
- * @param {string} rollFormula    The original roll.
+ * @param {string} rollFormula    The original roll. It must be deterministic
  * @param {TwodsixItem } item     Item making the roll
  * @returns {number}              The resulting roll value.
  */
 export function getValueFromRollFormula(rollFormula:string, item:TwodsixItem): number {
   let returnValue = 0;
   if (Roll.validate(rollFormula)) {
-    returnValue = new Roll(rollFormula, item.actor?.getRollData()).evaluate({async: false}).total;
+    returnValue = Roll.safeEval(Roll.replaceFormulaData(rollFormula, item.actor?.getRollData())) ?? 0;
   }
   return returnValue;
 }

--- a/src/module/hooks/applyActiveEffects.ts
+++ b/src/module/hooks/applyActiveEffects.ts
@@ -4,24 +4,24 @@
 import TwodsixActor from "../entities/TwodsixActor";
 //This hook applies CUSTOM active effects values as a formula that is evaluated and not a static
 Hooks.on('applyActiveEffect', (actor:TwodsixActor, change:any, current: any, delta: any) => {
-  //const r = new Roll(delta, actor);
-  //r.evaluate({async: false});
-  const r = Roll.safeEval(Roll.replaceFormulaData(delta, actor));
-  const ct = foundry.utils.getType(current);
   let update = 0;
-  switch ( ct ) {
-    case "string": {
-      if (Number.isInteger(Number.parseFloat(current))) {
-        update = (parseInt(current) + parseInt(r));
-      } else {
-        update = Number.parseFloat(current) + r;
+  if (Roll.validate(delta)) {
+    const r = Roll.safeEval(Roll.replaceFormulaData(delta, actor));
+    const ct = foundry.utils.getType(current);
+    switch ( ct ) {
+      case "string": {
+        if (Number.isInteger(Number.parseFloat(current))) {
+          update = (parseInt(current) + parseInt(r));
+        } else {
+          update = Number.parseFloat(current) + r;
+        }
+        break;
       }
-      break;
-    }
-    case "number":
-    {
-      update = current + r;
-      break;
+      case "number":
+      {
+        update = current + r;
+        break;
+      }
     }
   }
   foundry.utils.setProperty(actor, change.key, update);

--- a/src/module/hooks/applyActiveEffects.ts
+++ b/src/module/hooks/applyActiveEffects.ts
@@ -3,10 +3,14 @@
 
 import TwodsixActor from "../entities/TwodsixActor";
 //This hook applies CUSTOM active effects values as a formula that is evaluated and not a static
-Hooks.on('applyActiveEffect', (actor:TwodsixActor, change:any, current: any, delta: any) => {
+Hooks.on('applyActiveEffect', (actor:TwodsixActor, change:any, current: any, _delta: any) => {
   let update = 0;
-  if (Roll.validate(delta)) {
-    const r = Roll.safeEval(Roll.replaceFormulaData(delta, actor));
+  let changeFormula = change.value;
+  if (foundry.utils.getType(changeFormula) !== 'string') {
+    changeFormula = changeFormula.toString();
+  }
+  if (Roll.validate(changeFormula)) {
+    const r = Roll.safeEval(Roll.replaceFormulaData(changeFormula, actor));
     const ct = foundry.utils.getType(current);
     switch ( ct ) {
       case "string": {

--- a/src/module/hooks/applyActiveEffects.ts
+++ b/src/module/hooks/applyActiveEffects.ts
@@ -1,0 +1,28 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+
+import TwodsixActor from "../entities/TwodsixActor";
+//This hook applies CUSTOM active effects values as a formula that is evaluated and not a static
+Hooks.on('applyActiveEffect', (actor:TwodsixActor, change:any, current: any, delta: any) => {
+  //const r = new Roll(delta, actor);
+  //r.evaluate({async: false});
+  const r = Roll.safeEval(Roll.replaceFormulaData(delta, actor));
+  const ct = foundry.utils.getType(current);
+  let update = 0;
+  switch ( ct ) {
+    case "string": {
+      if (Number.isInteger(Number.parseFloat(current))) {
+        update = (parseInt(current) + parseInt(r));
+      } else {
+        update = Number.parseFloat(current) + r;
+      }
+      break;
+    }
+    case "number":
+    {
+      update = current + r;
+      break;
+    }
+  }
+  foundry.utils.setProperty(actor, change.key, update);
+});

--- a/src/module/hooks/applyActiveEffects.ts
+++ b/src/module/hooks/applyActiveEffects.ts
@@ -30,3 +30,7 @@ Hooks.on('applyActiveEffect', (actor:TwodsixActor, change:any, current: any, _de
   }
   foundry.utils.setProperty(actor, change.key, update);
 });
+
+Hooks.on(`renderActiveEffectConfig`, (app, _html, _data) => {
+  app.setPosition({width: 700});
+});

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -3760,3 +3760,7 @@ input[type="text"].color {
   justify-content: space-between;
   padding-right: 1ch;
 }
+
+.active-effect-sheet .effect-change .value {
+  flex: 3;
+}

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -3030,3 +3030,7 @@ Monk's Enhanced Journals
   justify-content: space-between;
   padding-right: 1ch;
 }
+
+.active-effect-sheet .effect-change .value {
+  flex: 3;
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature and bug fixes


* **What is the current behavior?** (You can also link to an open issue here)
CUSTOM mode for active effects does nothing
Deterministic rolls done with Roll({async: false})

* **What is the new behavior (if this is a feature change)?**
CUSTOM mode now allows for formula effect values
Deterministic rolls done with Roll.safeEval()

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
