### PR TITLE
feat: add melee range modifier

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -254,9 +254,9 @@ export default class TwodsixItem extends Item {
 
   public getRangeModifier(range:number): number {
     const rangeModifierType = game.settings.get('twodsix', 'rangeModifierType');
-    //Handle special case of melee
+    //Handle special case of melee weapon
     if (!['CE_Bands', 'none'].includes(rangeModifierType) && this.system.range?.toLowerCase().includes('melee')) {
-      if (range <= canvas.scene.grid.distance) {
+      if (range <= game.settings.get('twodsix', 'meleeRange')) {
         return 0;
       } else {
         return INFEASIBLE;
@@ -270,6 +270,8 @@ export default class TwodsixItem extends Item {
       case 'singleBand': {
         if (isNaN(rangeValues[0]) || (rangeValues[0] === 0 && range === 0)) {
           return 0;
+        } else if (range <= game.settings.get('twodsix', 'meleeRange')) {
+          return this.system.meleeRangeModifier ?? 0;
         } else if (range <= rangeValues[0] * 0.25) {
           return 1;
         } else if (range <= rangeValues[0]) {
@@ -283,7 +285,11 @@ export default class TwodsixItem extends Item {
         }
       }
       case 'doubleBand': {
-        if (isNaN(rangeValues[0]) || rangeValues[0] > rangeValues[1] || range <= rangeValues[0]) {
+        if (isNaN(rangeValues[0]) || rangeValues[0] > rangeValues[1] || (rangeValues[0] === 0 && range === 0)) {
+          return 0;
+        } else if (range <= game.settings.get('twodsix', 'meleeRange')) {
+          return this.system.meleeRangeModifier ?? 0;
+        } else if (range <= rangeValues[0]) {
           return 0;
         } else if (range <= rangeValues[1]) {
           return -2;

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -103,6 +103,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.roll.push(stringChoiceSetting('useDegreesOfSuccess', "none", true, TWODSIX.SuccessTypes));
     settings.roll.push(booleanSetting("overrideSuccessWithNaturalCrit", false));
     settings.general.push(stringChoiceSetting('rangeModifierType', "none", true, TWODSIX.RANGE_MODIFIERS_TYPES));
+    settings.general.push(numberSetting("meleeRange", 2, false, "world"));
     settings.roll.push(largeStringSetting('targetDMList', "", false, "world", generateTargetDMObject));
     return settings;
   }

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -65,13 +65,18 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       damageTypes: getDamageTypes(["weapon", "consumable"].includes(this.item.type)),
       rangeTypes: TWODSIX.WEAPON_RANGE_TYPES.long
     };
-    //prevent processor attachemetns to software
+    //prevent processor attachements to software
     returnData.config = duplicate(TWODSIX);
     if (this.actor && this.item.type === "consumable" ) {
       const onComputer = this.actor.items.find(it => it.type === "computer" && it.system.consumables.includes(this.item.id));
       if(onComputer) {
         delete returnData.config.CONSUMABLES.processor;
       }
+    }
+
+    // Disable Melee Range DM if designated as Melee weapon
+    if (this.item.type === 'weapon') {
+      returnData.disableMeleeRangeDM = this.item.system.range.toLowerCase() === 'melee';
     }
     return returnData;
   }

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -718,6 +718,8 @@ export interface Weapon extends GearTemplate, LinkTemplate, TargetTemplate {
   features:string;
   armorPiercing:number;
   doubleTap:boolean;
+  handlingModifier:string;
+  meleeRangeModifier:number;
 }
 
 export interface Computer extends GearTemplate, LinkTemplate {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -609,7 +609,8 @@
         "Attack": "Attack",
         "Consumables": "Consumables",
         "DefaultMagazine": "Default Magazine Size",
-        "HandlingExample": "e.g., DEX 6/-3 10/+4"
+        "HandlingExample": "e.g., DEX 6/-3 10/+4",
+        "MeleeRangeModifier": "Melee Range DM"
       },
       "Spells": {
         "CircleSchool": "Spell Circle/School",
@@ -1334,6 +1335,10 @@
       "targetDMList": {
         "hint": "A comma separated list of target difficulty modifiers.  The list has the format of 'label1 number1, label2 number2...'.  For example, 'Obscure -1, Prone (melee) +1, Prone (Ranged) -1'.",
         "name": "List of target modifiers"
+      },
+      "meleeRange": {
+        "hint": "The distance where combat is in melee range.  Typically on grid unit or less (e.g. 1.5m).",
+        "name": "Melee combat range"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/template.json
+++ b/static/template.json
@@ -500,7 +500,8 @@
       "recoil": false,
       "features": "",
       "armorPiercing": 0,
-      "handlingModifiers": ""
+      "handlingModifiers": "",
+      "meleeRangeModifier": 0
     },
     "armor": {
       "templates": ["gearTemplate", "referenceTemplateItem"],

--- a/static/templates/items/parts/weapon-parts/weapon-modifiers.html
+++ b/static/templates/items/parts/weapon-parts/weapon-modifiers.html
@@ -40,8 +40,10 @@
     <label class="resource-label" for="system.range">{{localize "TWODSIX.Items.Weapon.Range"}}</label>
     <input class="form-input" id="system.range" type="text" name="system.range" value="{{system.range}}">
   </div>
+  {{#unless disableMeleeRangeDM}}
   <div class="item-range">
     <label class="resource-label" for="system.meleeRangeModifier">{{localize "TWODSIX.Items.Weapon.MeleeRangeModifier"}}</label>
     <input class="form-input" id="system.meleeRangeModifier" type="number" name="system.meleeRangeModifier" value="{{system.meleeRangeModifier}}">
   </div>
+  {{/unless}}
 {{/if}}

--- a/static/templates/items/parts/weapon-parts/weapon-modifiers.html
+++ b/static/templates/items/parts/weapon-parts/weapon-modifiers.html
@@ -30,12 +30,18 @@
   <input class="form-input" id="system.handlingModifiers" type="text" placeholder="{{localize 'TWODSIX.Items.Weapon.HandlingExample'}}" name="system.handlingModifiers" value="{{system.handlingModifiers}}">
 </div>
 
-<div class="item-range">
-  {{#if settings.ShowRangeBandAndHideRange}}
+{{#if settings.ShowRangeBandAndHideRange}}
+  <div class="item-range">
     <label class="resource-label" for="system.rangeBand">{{localize "TWODSIX.Items.Weapon.rangeBand"}}</label>
     <select id="system.rangeBand" name="system.rangeBand">{{selectOptions settings.rangeTypes selected=system.rangeBand localize=true}}</select>
-  {{else}}
+  </div>
+{{else}}
+  <div class="item-range">
     <label class="resource-label" for="system.range">{{localize "TWODSIX.Items.Weapon.Range"}}</label>
     <input class="form-input" id="system.range" type="text" name="system.range" value="{{system.range}}">
-  {{/if}}
-</div>
+  </div>
+  <div class="item-range">
+    <label class="resource-label" for="system.meleeRangeModifier">{{localize "TWODSIX.Items.Weapon.MeleeRangeModifier"}}</label>
+    <input class="form-input" id="system.meleeRangeModifier" type="number" name="system.meleeRangeModifier" value="{{system.meleeRangeModifier}}">
+  </div>
+{{/if}}

--- a/static/templates/misc/setting-partial.html
+++ b/static/templates/misc/setting-partial.html
@@ -3,7 +3,7 @@
     <label>{{{localize setting.name}}}</label>
       <div class="form-fields">
         {{#iff setting.htmlType "===" "Number"}}
-        <input type="number" name="{{key}}" value="{{setting.value}}" data-dtype="Number">
+        <input type="number" name="{{key}}" value="{{setting.value}}" data-dtype="Number" step="0.01">
         {{/iff}}
         {{#iff setting.htmlType "===" "String"}}
         <input type="text" name="{{key}}" value="{{setting.value}}" data-dtype="String">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
No modifier is applied to ranged weapons used within melee combat range


* **What is the new behavior (if this is a feature change)?**
Add a melee modifier field to weapons and a rules setting to set melee range.
Apply modifier to weapons if within melee range


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Using the melee value for range checks against rules setting. It is no longer one adjacent grid unit


* **Other information**:
