### PR TITLE
fix: missing melee range modifier on flat sheets

### DIFF
--- a/static/templates/items/parts/weapon-sheet-flat.html
+++ b/static/templates/items/parts/weapon-sheet-flat.html
@@ -5,15 +5,23 @@
     <label class="resource-label" for="system.handlingModifiers">{{localize "TWODSIX.Items.Weapon.HandlingModifiers"}}</label>
     <input class="form-input" id="system.handlingModifiers" type="text" placeholder="{{localize 'TWODSIX.Items.Weapon.HandlingExample'}}" name="system.handlingModifiers" value="{{system.handlingModifiers}}">
   </div>
-  <div class="item-range">
-    {{#if settings.ShowRangeBandAndHideRange}}
+  {{#if settings.ShowRangeBandAndHideRange}}
+    <div class="item-range">
       <label class="resource-label" for="system.rangeBand">{{localize "TWODSIX.Items.Weapon.rangeBand"}}</label>
       <select id="system.rangeBand" name="system.rangeBand">{{selectOptions settings.rangeTypes selected=system.rangeBand localize=true}}</select>
-    {{else}}
+    </div>
+  {{else}}
+    <div class="item-range">
       <label class="resource-label" for="system.range">{{localize "TWODSIX.Items.Weapon.Range"}}</label>
       <input class="form-input" id="system.range" type="text" name="system.range" value="{{system.range}}">
-    {{/if}}
-  </div>
+    </div>
+    {{#unless disableMeleeRangeDM}}
+    <div class="item-range">
+      <label class="resource-label" for="system.meleeRangeModifier">{{localize "TWODSIX.Items.Weapon.MeleeRangeModifier"}}</label>
+      <input class="form-input" id="system.meleeRangeModifier" type="number" name="system.meleeRangeModifier" value="{{system.meleeRangeModifier}}">
+    </div>
+    {{/unless}}
+  {{/if}}
   {{> "systems/twodsix/templates/items/parts/weapon-parts/weapon-attack.html"}}
   {{> "systems/twodsix/templates/items/parts/weapon-parts/weapon-magazine.html"}}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
melee range modifier does not appear on flat weapon sheets


* **What is the new behavior (if this is a feature change)?**
Modifier now appears


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
