### PR TITLE
feat: add melee range modifier as boon-bane

### DIFF
--- a/src/migrations/2023_12_30_10_32_refactor_rangeModifier.ts
+++ b/src/migrations/2023_12_30_10_32_refactor_rangeModifier.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
+import { applyToAllItems, applyToAllActors } from "../module/utils/migration-utils";
+
+async function refactorMeleeRangeModifier(item: TwodsixItem): Promise<void> {
+  if (item.type === 'weapon') {
+    if (typeof item.system.meleeRangeModifier === 'number') {
+      const newString = item.system.meleeRangeModifier.toString();
+      item.update({'system.meleeRangeModifier': newString});
+    }
+  }
+}
+
+async function refactorWeapons (actor:TwodsixActor): Promise<void> {
+  for (const weapon of actor.itemTypes.weapon) {
+    refactorMeleeRangeModifier(weapon);
+  }
+}
+
+export async function migrate(): Promise<void> {
+  await applyToAllItems(refactorMeleeRangeModifier);
+  await applyToAllActors(refactorWeapons);
+  console.log("Range Modifier Migration Complete");
+  return Promise.resolve();
+}

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -275,11 +275,11 @@ export default class TwodsixItem extends Item {
       if (range > game.settings.get('twodsix', 'meleeRange')) {
         rangeModifier = INFEASIBLE;
       }
+    } else if (isNaN(rangeValues[0]) /*|| (rangeValues[0] === 0 && range === 0)*/) {
+      //rangeModifier = 0;
     } else if (range <= game.settings.get('twodsix', 'meleeRange')) {
       // Handle within melee range
-      if (isNaN(rangeValues[0]) /*|| (rangeValues[0] === 0 && range === 0)*/) {
-        //rangeModifier = 0;
-      } else if (range > (rangeModifierType === 'singleBand' ? rangeValues[0] : rangeValues[1] ?? rangeValues[0])) {
+      if (range > (rangeModifierType === 'singleBand' ? rangeValues[0] : rangeValues[1] ?? rangeValues[0])) {
         rangeModifier = INFEASIBLE;
       } else if (game.settings.get('twodsix', 'termForAdvantage').toLowerCase() === this.system.meleeRangeModifier.toLowerCase()){
         rollType = 'Advantage';

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -263,12 +263,19 @@ export default class TwodsixItem extends Item {
     let rollType = 'Normal';
     const rangeModifierType = game.settings.get('twodsix', 'rangeModifierType');
     const rangeValues = this.system.range?.split('/', 2).map((s:string) => parseFloat(s));
-    if (!['CE_Bands', 'none'].includes(rangeModifierType) && this.system.range?.toLowerCase().includes('melee')) {
+    if (rangeModifierType === 'none') {
+      //rangeModifier = 0;
+    } else if (rangeModifierType === 'CE_Bands') {
+      const targetBand:string = getRangeBand(range);
+      if (targetBand !== "unknown") {
+        rangeModifier =  getRangeBandModifier(this.system.rangeBand, targetBand);
+      }
+    } else if (this.system.range?.toLowerCase().includes('melee')) {
       // Handle special case of melee weapon
       if (range > game.settings.get('twodsix', 'meleeRange')) {
         rangeModifier = INFEASIBLE;
       }
-    } else if (!['CE_Bands', 'none'].includes(rangeModifierType) && range <= game.settings.get('twodsix', 'meleeRange')) {
+    } else if (range <= game.settings.get('twodsix', 'meleeRange')) {
       // Handle within melee range
       if (isNaN(rangeValues[0]) /*|| (rangeValues[0] === 0 && range === 0)*/) {
         //rangeModifier = 0;
@@ -281,48 +288,27 @@ export default class TwodsixItem extends Item {
       } else {
         rangeModifier = parseInt(this.system.meleeRangeModifier) || 0;
       }
-    } else {
-      switch (rangeModifierType) {
-        case 'none': {
-          //rangeModifier = 0;
-          break;
-        }
-        case 'singleBand': {
-          if (range <= rangeValues[0] * 0.25) {
-            rangeModifier = 1;
-          } else if (range <= rangeValues[0]) {
-            //rangeModifier = 0;
-          } else if (range <= rangeValues[0] * 2) {
-            rangeModifier = -2;
-          } else if (range <= rangeValues[0] * 4) {
-            rangeModifier = -4;
-          } else {
-            rangeModifier = INFEASIBLE;
-          }
-          break;
-        }
-        case 'doubleBand': {
-          if (rangeValues[0] > rangeValues[1]) {
-            //rangeModifier = 0;
-          } else if (range <= rangeValues[0]) {
-            //rangeModifier = 0;
-          } else if (range <= rangeValues[1]) {
-            rangeModifier = -2;
-          } else {
-            rangeModifier = INFEASIBLE;
-          }
-          break;
-        }
-        case 'CE_Bands': {
-          const targetBand:string = getRangeBand(range);
-          if (targetBand !== "unknown") {
-            rangeModifier =  getRangeBandModifier(this.system.rangeBand, targetBand);
-          }
-          break;
-        }
-        default: {
-          //rangeModifier = 0;
-        }
+    } else if (rangeModifierType === 'singleBand') {
+      if (range <= rangeValues[0] * 0.25) {
+        rangeModifier = 1;
+      } else if (range <= rangeValues[0]) {
+        //rangeModifier = 0;
+      } else if (range <= rangeValues[0] * 2) {
+        rangeModifier = -2;
+      } else if (range <= rangeValues[0] * 4) {
+        rangeModifier = -4;
+      } else {
+        rangeModifier = INFEASIBLE;
+      }
+    } else if (rangeModifierType === 'doubleBand') {
+      if (rangeValues[0] > rangeValues[1]) {
+        //rangeModifier = 0;
+      } else if (range <= rangeValues[0]) {
+        //rangeModifier = 0;
+      } else if (range <= rangeValues[1]) {
+        rangeModifier = -2;
+      } else {
+        rangeModifier = INFEASIBLE;
       }
     }
     return {rangeModifier: rangeModifier, rollType: rollType};

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -335,7 +335,7 @@ export default class TwodsixItem extends Item {
       const weaponSkill = this.actor?.items.get(this.system.skill);
       skillName = weaponSkill?.getFlag("twodsix", "untrainedSkill") ? this.system.associatedSkillName : weaponSkill?.name;
       const targetMatchingSkill = target.actor?.itemTypes.skills?.find(sk => sk.name === skillName);
-      dodgeParryModifier = targetMatchingSkill?.system.value || 0;
+      dodgeParryModifier = -targetMatchingSkill?.system.value || 0;
     }
     return {dodgeParry: dodgeParryModifier, dodgeParryLabel: skillName};
   }

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -189,16 +189,20 @@ export default class TwodsixItem extends Item {
     if (controlledTokens?.length === 1) {
       let rangeLabel = "";
       let rangeModifier = 0;
+      let rollType = 'Normal';
       const isCEBands =  game.settings.get('twodsix', 'rangeModifierType') === 'CE_Bands';
       const localizePrefix = "TWODSIX.Chat.Roll.RangeBandTypes.";
       if (targetTokens.length === 1) {
         const targetRange = canvas.grid.measureDistance(controlledTokens[0], targetTokens[0], {gridSpaces: true});
-        rangeModifier = this.getRangeModifier(targetRange);
+        const rangeData = this.getRangeModifier(targetRange);
+        rangeModifier = rangeData.rangeModifier;
+        rollType = rangeData.rollType;
         rangeLabel = isCEBands ? (this.system.rangeBand === 'none' ? game.i18n.localize(localizePrefix + "none") : `${game.i18n.localize(localizePrefix + getRangeBand(targetRange))}`) : `${targetRange.toLocaleString(game.i18n.lang, {maximumFractionDigits: 2})} ${canvas.scene.grid.units}`;
       } else if (targetTokens.length === 0) {
         rangeLabel = isCEBands && this.system.rangeBand === 'none' ? game.i18n.localize(localizePrefix + "none") : game.i18n.localize("TWODSIX.Ship.Unknown");
       }
       Object.assign(tmpSettings.rollModifiers, {weaponsRange: rangeModifier, rangeLabel: rangeLabel});
+      Object.assign(tmpSettings, {rollType: rollType});
     }
 
     const settings:TwodsixRollSettings = await TwodsixRollSettings.create(showThrowDialog, tmpSettings, skill, this, <TwodsixActor>this.actor);
@@ -234,7 +238,9 @@ export default class TwodsixItem extends Item {
         Object.assign(settings.rollModifiers, dodgeParryInfo);
         if (controlledTokens.length === 1) {
           const targetRange = canvas.grid.measureDistance(controlledTokens[0], targetTokens[i%targetTokens.length], {gridSpaces: true});
-          settings.rollModifiers.weaponsRange = this.getRangeModifier(targetRange);
+          const rangeData = this.getRangeModifier(targetRange);
+          Object.assign(settings.rollModifiers, {weaponsRange: rangeData.rangeModifier});
+          Object.assign(settings, {rollType: rangeData.rollType});
         }
       }
       const roll = await this.skillRoll(false, settings, showInChat);
@@ -252,63 +258,74 @@ export default class TwodsixItem extends Item {
     }
   }
 
-  public getRangeModifier(range:number): number {
+  public getRangeModifier(range:number): any {
+    let rangeModifier = 0;
+    let rollType = 'Normal';
     const rangeModifierType = game.settings.get('twodsix', 'rangeModifierType');
-    //Handle special case of melee weapon
-    if (!['CE_Bands', 'none'].includes(rangeModifierType) && this.system.range?.toLowerCase().includes('melee')) {
-      if (range <= game.settings.get('twodsix', 'meleeRange')) {
-        return 0;
-      } else {
-        return INFEASIBLE;
-      }
-    }
     const rangeValues = this.system.range?.split('/', 2).map((s:string) => parseFloat(s));
-    switch (rangeModifierType) {
-      case 'none': {
-        return 0;
+    if (!['CE_Bands', 'none'].includes(rangeModifierType) && this.system.range?.toLowerCase().includes('melee')) {
+      // Handle special case of melee weapon
+      if (range > game.settings.get('twodsix', 'meleeRange')) {
+        rangeModifier = INFEASIBLE;
       }
-      case 'singleBand': {
-        if (isNaN(rangeValues[0]) || (rangeValues[0] === 0 && range === 0)) {
-          return 0;
-        } else if (range <= game.settings.get('twodsix', 'meleeRange')) {
-          return this.system.meleeRangeModifier ?? 0;
-        } else if (range <= rangeValues[0] * 0.25) {
-          return 1;
-        } else if (range <= rangeValues[0]) {
-          return 0;
-        } else if (range <= rangeValues[0] * 2) {
-          return -2;
-        } else if (range <= rangeValues[0] * 4) {
-          return -4;
-        } else {
-          return INFEASIBLE;
+    } else if (!['CE_Bands', 'none'].includes(rangeModifierType) && range <= game.settings.get('twodsix', 'meleeRange')) {
+      // Handle within melee range
+      if (isNaN(rangeValues[0]) /*|| (rangeValues[0] === 0 && range === 0)*/) {
+        //rangeModifier = 0;
+      } else if (range > (rangeModifierType === 'singleBand' ? rangeValues[0] : rangeValues[1] ?? rangeValues[0])) {
+        rangeModifier = INFEASIBLE;
+      } else if (game.settings.get('twodsix', 'termForAdvantage').toLowerCase() === this.system.meleeRangeModifier.toLowerCase()){
+        rollType = 'Advantage';
+      } else if (game.settings.get('twodsix', 'termForDisadvantage').toLowerCase() === this.system.meleeRangeModifier.toLowerCase()) {
+        rollType = 'Disadvantage';
+      } else {
+        rangeModifier = parseInt(this.system.meleeRangeModifier) ?? 0;
+      }
+    } else {
+      switch (rangeModifierType) {
+        case 'none': {
+          //rangeModifier = 0;
+          break;
         }
-      }
-      case 'doubleBand': {
-        if (isNaN(rangeValues[0]) || rangeValues[0] > rangeValues[1] || (rangeValues[0] === 0 && range === 0)) {
-          return 0;
-        } else if (range <= game.settings.get('twodsix', 'meleeRange')) {
-          return this.system.meleeRangeModifier ?? 0;
-        } else if (range <= rangeValues[0]) {
-          return 0;
-        } else if (range <= rangeValues[1]) {
-          return -2;
-        } else {
-          return INFEASIBLE;
+        case 'singleBand': {
+          if (range <= rangeValues[0] * 0.25) {
+            rangeModifier = 1;
+          } else if (range <= rangeValues[0]) {
+            //rangeModifier = 0;
+          } else if (range <= rangeValues[0] * 2) {
+            rangeModifier = -2;
+          } else if (range <= rangeValues[0] * 4) {
+            rangeModifier = -4;
+          } else {
+            rangeModifier = INFEASIBLE;
+          }
+          break;
         }
-      }
-      case 'CE_Bands': {
-        const targetBand:string = getRangeBand(range);
-        if (targetBand === "unknown") {
-          return 0;
-        } else {
-          return getRangeBandModifier(this.system.rangeBand, targetBand);
+        case 'doubleBand': {
+          if (rangeValues[0] > rangeValues[1]) {
+            //rangeModifier = 0;
+          } else if (range <= rangeValues[0]) {
+            //rangeModifier = 0;
+          } else if (range <= rangeValues[1]) {
+            rangeModifier = -2;
+          } else {
+            rangeModifier = INFEASIBLE;
+          }
+          break;
         }
-      }
-      default: {
-        return 0;
+        case 'CE_Bands': {
+          const targetBand:string = getRangeBand(range);
+          if (targetBand !== "unknown") {
+            rangeModifier =  getRangeBandModifier(this.system.rangeBand, targetBand);
+          }
+          break;
+        }
+        default: {
+          //rangeModifier = 0;
+        }
       }
     }
+    return {rangeModifier: rangeModifier, rollType: rollType};
   }
 
   public getDodgeParryValues(target: Token): object {

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -279,7 +279,7 @@ export default class TwodsixItem extends Item {
       } else if (game.settings.get('twodsix', 'termForDisadvantage').toLowerCase() === this.system.meleeRangeModifier.toLowerCase()) {
         rollType = 'Disadvantage';
       } else {
-        rangeModifier = parseInt(this.system.meleeRangeModifier) ?? 0;
+        rangeModifier = parseInt(this.system.meleeRangeModifier) || 0;
       }
     } else {
       switch (rangeModifierType) {

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -719,7 +719,7 @@ export interface Weapon extends GearTemplate, LinkTemplate, TargetTemplate {
   armorPiercing:number;
   doubleTap:boolean;
   handlingModifier:string;
-  meleeRangeModifier:number;
+  meleeRangeModifier:string;
 }
 
 export interface Computer extends GearTemplate, LinkTemplate {

--- a/static/template.json
+++ b/static/template.json
@@ -501,7 +501,7 @@
       "features": "",
       "armorPiercing": 0,
       "handlingModifiers": "",
-      "meleeRangeModifier": 0
+      "meleeRangeModifier": "0"
     },
     "armor": {
       "templates": ["gearTemplate", "referenceTemplateItem"],

--- a/static/templates/items/parts/weapon-parts/weapon-modifiers.html
+++ b/static/templates/items/parts/weapon-parts/weapon-modifiers.html
@@ -43,7 +43,7 @@
   {{#unless disableMeleeRangeDM}}
   <div class="item-range">
     <label class="resource-label" for="system.meleeRangeModifier">{{localize "TWODSIX.Items.Weapon.MeleeRangeModifier"}}</label>
-    <input class="form-input" id="system.meleeRangeModifier" type="number" name="system.meleeRangeModifier" value="{{system.meleeRangeModifier}}">
+    <input class="form-input" id="system.meleeRangeModifier" type="text" name="system.meleeRangeModifier" value="{{system.meleeRangeModifier}}">
   </div>
   {{/unless}}
 {{/if}}

--- a/static/templates/items/parts/weapon-sheet-flat.html
+++ b/static/templates/items/parts/weapon-sheet-flat.html
@@ -18,7 +18,7 @@
     {{#unless disableMeleeRangeDM}}
     <div class="item-range">
       <label class="resource-label" for="system.meleeRangeModifier">{{localize "TWODSIX.Items.Weapon.MeleeRangeModifier"}}</label>
-      <input class="form-input" id="system.meleeRangeModifier" type="number" name="system.meleeRangeModifier" value="{{system.meleeRangeModifier}}">
+      <input class="form-input" id="system.meleeRangeModifier" type="text" name="system.meleeRangeModifier" value="{{system.meleeRangeModifier}}">
     </div>
     {{/unless}}
   {{/if}}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature, bug fix


* **What is the current behavior?** (You can also link to an open issue here)
can only specify integer as melee range modifier
dodge / parry values are positive modifiers

* **What is the new behavior (if this is a feature change)?**
can also specify adv/dis (per settings)
dodge/parry modifiers are negative values

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Requires a migration of meleeRangeModifier from int to string on weapons


* **Other information**:
