### PR TITLE
feat: allow associated skill to list multiple skills

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -360,10 +360,9 @@ export default class TwodsixItem extends Item {
       skill = this;
       item = undefined;
     } else if (this.type === "spell") {
-      skill =  <TwodsixItem>(workingActor?.itemTypes.skills.find(sk => sk.name === this.system?.associatedSkillName) ?? workingActor?.itemTypes.skills.find(sk => sk.name === game.settings.get("twodsix", "sorcerySkill")));
-      if (skill === undefined  && workingActor) {
-        skill = workingActor.getUntrainedSkill();
-      }
+      const skillList = `${game.settings.get("twodsix", "sorcerySkill")}|` + this.system?.associatedSkillName;
+      skill =  <TwodsixItem>(workingActor.getBestSkill(skillList, false));
+
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       item = this;
     } else if (this.type === "component") {

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -402,7 +402,7 @@ export function getInitialSettingsFromFormula(parseString: string, actor: Twodsi
     if (parsedSkills !== "" && parsedSkills !== 'None') {
       skill = getBestSkill(parsedSkills, actor, !char);
       if (!skill) {
-        ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", actor?.name ?? "").replace("_SKILL_", parsedSkills));
+        ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", actor.name ?? "").replace("_SKILL_", parsedSkills));
         return false;
       }
     }
@@ -466,14 +466,14 @@ export function getBestSkill(skillList: string, actor:TwodsixActor, includeChar:
   // find the most advantageous skill to use from the collection
   if(skillObjects?.length > 0){
     skill = skillObjects.reduce((prev, current) => {
-      const prevValue = prev.system.value + includeChar ? getCharMoD(actor, prev.system.characteristic) : 0;
-      const currentValue = current.system.value + includeChar ? getCharMoD(actor, current.system.characteristic) : 0;
+      const prevValue = prev.system.value + (includeChar ? getCharMoD(actor, prev.system.characteristic) : 0);
+      const currentValue = current.system.value + (includeChar ? getCharMoD(actor, current.system.characteristic) : 0);
       return (prevValue > currentValue) ? prev : current;
     });
   }
   // If skill missing, try to use Untrained
   if (!skill) {
-    skill = actor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
+    skill = actor.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
   }
   return skill;
 }

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -370,7 +370,14 @@ export async function getCustomModifiers(selectedActor:TwodsixActor, characteris
   return returnObject;
 }
 
-export function getInitialSettingsFromFormula(parseString: string, actor: TwodsixActor): any {
+/**
+ * Returns initial roll settings based on a coded string for a roll formula
+ * @param {string} parseString A string of roll parameters.  It has the format 'Skill 1 | Skill 2/Char1 | Char 2 Difficulty+ =Item Id'
+ * e.g. 'Engineering|Mechanic/INT|EDU 6+'.  For a characteristic Roll, use 'None' instead of a skill name.
+ * @param {TwodsixActor} actor The actor that posesses the skill
+ * @returns {TwodsixRollSettings | any} an object of the initial RollSettings
+ */
+export function getInitialSettingsFromFormula(parseString: string, actor: TwodsixActor): TwodsixRollSettings|any {
   const difficulties = TWODSIX.DIFFICULTIES[(<number>game.settings.get('twodsix', 'difficultyListUsed'))];
   // eslint-disable-next-line no-useless-escape
   const re = new RegExp(/^(.[^\/\+=]*?) ?(?:\/([\S]+))? ?(?:(\d{0,2})\+)? ?(?:=(\w*))? ?$/);
@@ -392,21 +399,11 @@ export function getInitialSettingsFromFormula(parseString: string, actor: Twodsi
 
     // Select Skill if required
     let skill:TwodsixItem|undefined = undefined;
-    if (parsedSkills !== "") {
-      const skillOptions = parsedSkills.split("|");
-      /* add qualified skill objects to an array*/
-      const skillObjects = actor?.itemTypes.skills?.filter((itm: TwodsixItem) => skillOptions.includes(itm.name));
-      // find the most advantageous skill to use from the collection
-      if(skillObjects?.length > 0){
-        skill = skillObjects.reduce((prev, current) => (prev.system.value > current.system.value) ? prev : current);
-      }
-      // If skill missing, try to use Untrained
+    if (parsedSkills !== "" && parsedSkills !== 'None') {
+      skill = getBestSkill(parsedSkills, actor, !char);
       if (!skill) {
-        skill = actor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
-        if (!skill) {
-          ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", actor?.name ?? "").replace("_SKILL_", parsedSkills));
-          return false;
-        }
+        ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", actor?.name ?? "").replace("_SKILL_", parsedSkills));
+        return false;
       }
     }
 
@@ -420,7 +417,7 @@ export function getInitialSettingsFromFormula(parseString: string, actor: Twodsi
       characteristicKey = getKeyByValue(TWODSIX.CHARACTERISTICS, (<Skills>skill.system).characteristic);
     } else if (char) {
       //find the most advantageous characteristic to use based on the displayed (custom) short label
-      const charOptions = char.split("|");
+      const charOptions = char.split("|").map(str => str.trim());
       let candidateCharObject = undefined;
       const candidateCharObjects = charObjectArray.filter(ch => charOptions.includes(ch.displayShortLabel));
       if(candidateCharObjects.length > 0){
@@ -437,8 +434,8 @@ export function getInitialSettingsFromFormula(parseString: string, actor: Twodsi
     }
 
     const returnValues = {
-      skill: parsedSkills === 'None' ? 'None': skill,
-      skillRoll: !!skill,
+      skill: skill,
+      skillRoll: parsedSkills === 'None' ? false : !!skill,
       displayLabel: displayLabel,
       rollModifiers: {
         characteristic: shortLabel,
@@ -451,5 +448,40 @@ export function getInitialSettingsFromFormula(parseString: string, actor: Twodsi
   } else {
     ui.notifications.error(game.i18n.localize("TWODSIX.Ship.CannotParseArgument"));
     return false;
+  }
+}
+
+/**
+ * Returns skill with highest value from an actor based on a list of skills
+ * @param {string} skillList A string of skills separated by pipe, e.g. "Admin | Combat"
+ * @param {TwodsixActor} actor The actor that posesses the skill
+ * @param {boolean} includeChar Whether to include default charactrisic in selection
+ * @returns {TwodsixItem|undefined} the skill document selected
+ */
+export function getBestSkill(skillList: string, actor:TwodsixActor, includeChar: boolean): TwodsixItem|undefined {
+  let skill:TwodsixItem|undefined = undefined;
+  const skillOptions = skillList.split("|").map(str => str.trim());
+  /* add qualified skill objects to an array*/
+  const skillObjects = actor.itemTypes.skills?.filter((itm: TwodsixItem) => skillOptions.includes(itm.name));
+  // find the most advantageous skill to use from the collection
+  if(skillObjects?.length > 0){
+    skill = skillObjects.reduce((prev, current) => {
+      const prevValue = prev.system.value + includeChar ? getCharMoD(actor, prev.system.characteristic) : 0;
+      const currentValue = current.system.value + includeChar ? getCharMoD(actor, current.system.characteristic) : 0;
+      return (prevValue > currentValue) ? prev : current;
+    });
+  }
+  // If skill missing, try to use Untrained
+  if (!skill) {
+    skill = actor?.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
+  }
+  return skill;
+}
+
+function getCharMoD(actor:TwodsixActor, charShort: string):number {
+  if (charShort !== 'NONE' && charShort) {
+    return actor.system.characteristics[getKeyByValue(TWODSIX.CHARACTERISTICS, charShort)].mod;
+  } else {
+    return 0;
   }
 }

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -400,7 +400,7 @@ export function getInitialSettingsFromFormula(parseString: string, actor: Twodsi
     // Select Skill if required
     let skill:TwodsixItem|undefined = undefined;
     if (parsedSkills !== "" && parsedSkills !== 'None') {
-      skill = getBestSkill(parsedSkills, actor, !char);
+      skill = actor.getBestSkill(parsedSkills, !char);
       if (!skill) {
         ui.notifications.error(game.i18n.localize("TWODSIX.Ship.ActorLacksSkill").replace("_ACTOR_NAME_", actor.name ?? "").replace("_SKILL_", parsedSkills));
         return false;
@@ -448,40 +448,5 @@ export function getInitialSettingsFromFormula(parseString: string, actor: Twodsi
   } else {
     ui.notifications.error(game.i18n.localize("TWODSIX.Ship.CannotParseArgument"));
     return false;
-  }
-}
-
-/**
- * Returns skill with highest value from an actor based on a list of skills
- * @param {string} skillList A string of skills separated by pipe, e.g. "Admin | Combat"
- * @param {TwodsixActor} actor The actor that posesses the skill
- * @param {boolean} includeChar Whether to include default charactrisic in selection
- * @returns {TwodsixItem|undefined} the skill document selected
- */
-export function getBestSkill(skillList: string, actor:TwodsixActor, includeChar: boolean): TwodsixItem|undefined {
-  let skill:TwodsixItem|undefined = undefined;
-  const skillOptions = skillList.split("|").map(str => str.trim());
-  /* add qualified skill objects to an array*/
-  const skillObjects = actor.itemTypes.skills?.filter((itm: TwodsixItem) => skillOptions.includes(itm.name));
-  // find the most advantageous skill to use from the collection
-  if(skillObjects?.length > 0){
-    skill = skillObjects.reduce((prev, current) => {
-      const prevValue = prev.system.value + (includeChar ? getCharMoD(actor, prev.system.characteristic) : 0);
-      const currentValue = current.system.value + (includeChar ? getCharMoD(actor, current.system.characteristic) : 0);
-      return (prevValue > currentValue) ? prev : current;
-    });
-  }
-  // If skill missing, try to use Untrained
-  if (!skill) {
-    skill = actor.itemTypes.skills.find((itm: TwodsixItem) => itm.name === game.i18n.localize("TWODSIX.Actor.Skills.Untrained")) as TwodsixItem;
-  }
-  return skill;
-}
-
-function getCharMoD(actor:TwodsixActor, charShort: string):number {
-  if (charShort !== 'NONE' && charShort) {
-    return actor.system.characteristics[getKeyByValue(TWODSIX.CHARACTERISTICS, charShort)].mod;
-  } else {
-    return 0;
   }
 }

--- a/src/module/utils/TwodsixShipActions.ts
+++ b/src/module/utils/TwodsixShipActions.ts
@@ -68,19 +68,27 @@ export class TwodsixShipActions {
         flags: {tokenUUID: extra.ship?.uuid}
       });
       Object.assign(settings.rollModifiers, {item: extra.diceModifier ? parseInt(extra.diceModifier) : 0});
-      const skill:TwodsixItem = settings.skill;
+      const skill:TwodsixItem|undefined = settings.skill;
       delete settings.skill;
-      const options = await TwodsixRollSettings.create(showTrowDiag, settings, skill, <TwodsixItem>extra.component, extra.actor);
-      if (!options.shouldRoll) {
-        return false;
-      }
-
-      if (extra.component) {
-        return extra.component.skillRoll(false, options);
+      if (!settings.skillRoll) {
+        // Special case of characteristic roll
+        if (settings.rollModifiers.characteristic) {
+          extra.actor.characteristicRoll({rollModifiers: settings.rollModifiers, difficulty: settings.difficulty}, true);
+        } else {
+          return false;
+        }
       } else {
-        return skill.skillRoll(false, options);
-      }
+        const options = await TwodsixRollSettings.create(showTrowDiag, settings, skill, <TwodsixItem>extra.component, extra.actor);
+        if (!options.shouldRoll) {
+          return false;
+        }
 
+        if (extra.component) {
+          return extra.component.skillRoll(false, options);
+        } else {
+          return skill.skillRoll(false, options);
+        }
+      }
     } else {
       ui.notifications.error(game.i18n.localize("TWODSIX.Ship.CannotParseArgument"));
       return false;

--- a/src/module/utils/enrichers.ts
+++ b/src/module/utils/enrichers.ts
@@ -218,7 +218,7 @@ export async function handleSkillRoll(event: Event): Promise<void> {
   if (actorToUse) {
     const parsedValues:any = getInitialSettingsFromFormula(parseString, actorToUse);
     if (parsedValues) {
-      if (parsedValues.skill === 'None') {
+      if (!parsedValues.skillRoll) {
         actorToUse.characteristicRoll({rollModifiers: parsedValues.rollModifiers, difficulty: parsedValues.difficulty}, true);
       } else {
         const skill:TwodsixItem = parsedValues.skill;

--- a/src/module/utils/migration-utils.ts
+++ b/src/module/utils/migration-utils.ts
@@ -37,10 +37,9 @@ export async function applyToAllItems(fn: ((item:TwodsixItem) => Promise<void>))
 
 async function applyToAllPacks(fn: ((doc: TwodsixActor | TwodsixItem) => Promise<void>), packs:Compendium[]): Promise<void> {
   for (const pack of packs) {
-    let wasLocked = false;
+    const wasLocked = pack.locked;
     if (pack.locked) {
       await pack.configure({locked: false});
-      wasLocked = true;
     }
     for (const doc of await pack.getDocuments()) {
       await fn(doc);

--- a/src/module/utils/utils.ts
+++ b/src/module/utils/utils.ts
@@ -39,6 +39,13 @@ export function mergeDeep(target:Record<string, any>, ...sources:Record<string, 
   return mergeDeep(target, ...sources);
 }
 
+/**
+ * Returns the localized, default short label based on logical shortLabel
+ * @param {string} char the logical, characteristic shortLabel (not the display label)
+ * @return {string} the value from the object
+ * @public
+ * @function
+ */
 export function getCharShortName(char: string): string {
   switch (char) {
     case "ALT1":
@@ -54,10 +61,25 @@ export function getCharShortName(char: string): string {
   }
 }
 
+/**
+ * Returns the simplified skill name by removing white space from the skill's full name
+ * @param {string} skillName the skill's full name
+ * @return {string} the skill's name with whitespace removed
+ * @public
+ * @function
+ */
 export function simplifySkillName(skillName:string): string {
   return skillName.replace(/\W/g, "");
 }
 
+/**
+ * Returns the value for an object based on the keys in the key string
+ * @param {object} o the object
+ * @param {string} s they key(s) as a string path with each lower sub key separated by dots, e.g. "key.subKey.subsubKey"
+ * @return {any} the value form the object
+ * @public
+ * @function
+ */
 export function ObjectbyString(o, s) {
   //https://stackoverflow.com/questions/6491463/accessing-nested-javascript-objects-and-arrays-by-string-path
   s = s.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -493,7 +493,7 @@
       },
       "Equipment": {
         "AssignSkill": "Assign Skill",
-        "AssociatedSkillName": "Associated Skill Name",
+        "AssociatedSkillName": "Associated Skill Name(s)",
         "Description": "Description",
         "ItemName": "Item Name",
         "Location": "Location",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature, refactor


* **What is the current behavior?** (You can also link to an open issue here)
Associated skill field for items can only list a single skill name


* **What is the new behavior (if this is a feature change)?**
Allow multiple skills to be listed, separated by pipe.  System selects the best one.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
