### PR TITLE
fix: make item macros more robust

### DIFF
--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -47,6 +47,7 @@ export const registerSettings = function ():void {
   booleanSetting('invertSkillRollShiftClick', false, true);
   booleanSetting('transferDroppedItems', false, true);
   booleanSetting('autoAddUnarmed', false, true);
+  booleanSetting('NoDuplicatesOnHotbar', false, true, "client");
   //Store default partials for items and compendium tab - hidden
   stringSetting('defaultItemPartial', ItemDirectory.entryPartial, false, "client");
   stringSetting('defaultCompendiumPartial', Compendium.entryPartial, false, "client");

--- a/src/module/utils/createItemMacro.ts
+++ b/src/module/utils/createItemMacro.ts
@@ -60,8 +60,16 @@ async function addItemMacro(dropData:object, slot:number): Promise<void> {
         }, { renderSheet: false }) as Macro;
       } else {
         if (macro.command !== command) {
-          ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.MacroNameExists"));
-          await macro.update({command: command});
+          await Dialog.confirm({
+            title: game.i18n.localize("TWODSIX.Dialogs.ReplaceMacroCommand"),
+            content: game.i18n.localize("TWODSIX.Warnings.MacroNameExists"),
+            yes: async () => {
+              await macro.update({command: command});
+            },
+            no: () => {
+              //Nothing
+            },
+          });
         }
         if (Object.values(game.user.hotbar).includes(macro.id) && game.settings.get('twodsix', 'NoDuplicatesOnHotbar')) {
           return;

--- a/src/module/utils/createItemMacro.ts
+++ b/src/module/utils/createItemMacro.ts
@@ -25,8 +25,8 @@ async function addItemMacro(dropData:object, slot:number): Promise<void> {
       let img = "";
       let command = "";
       if (dropData.type === "Item") {
-        command = `game.twodsix.rollItemMacro("${item.id ? item.id : item._id}");`;
         itemName = item.name || "";
+        command = `game.twodsix.rollItemMacro("${item.id ? item.id : item._id}", "${itemName}");`;
         img = item.img || foundry.documents.BaseMacro.DEFAULT_ICON;
 
         //handle case for unattached item
@@ -58,6 +58,14 @@ async function addItemMacro(dropData:object, slot:number): Promise<void> {
           img: img,
           flags: { 'twodsix.itemMacro': true },
         }, { renderSheet: false }) as Macro;
+      } else {
+        if (macro.command !== command) {
+          ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.MacroNameExists"));
+          await macro.update({command: command});
+        }
+        if (Object.values(game.user.hotbar).includes(macro.id)) {
+          return;
+        }
       }
       await game.user?.assignHotbarMacro(macro, slot);
     }

--- a/src/module/utils/createItemMacro.ts
+++ b/src/module/utils/createItemMacro.ts
@@ -63,7 +63,7 @@ async function addItemMacro(dropData:object, slot:number): Promise<void> {
           ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.MacroNameExists"));
           await macro.update({command: command});
         }
-        if (Object.values(game.user.hotbar).includes(macro.id)) {
+        if (Object.values(game.user.hotbar).includes(macro.id) && game.settings.get('twodsix', 'NoDuplicatesOnHotbar')) {
           return;
         }
       }

--- a/src/module/utils/rollItemMacro.ts
+++ b/src/module/utils/rollItemMacro.ts
@@ -5,21 +5,22 @@ import TwodsixItem from "../entities/TwodsixItem";
 
 /**
  * Use a previously created macro.
- * @param {string} itemId
+ * @param {string} itemId Item's id
+ * @param {string}  itemName Item's name
  * @return {Promise}
  */
-export async function rollItemMacro(itemId: string): Promise<void> {
+export async function rollItemMacro(itemId: string, itemName?:string): Promise<void> {
   const speaker = ChatMessage.getSpeaker();
   let actor;
   if (speaker.token) {
-    actor = game.actors?.tokens[speaker.token];
+    actor = game.actors.tokens[speaker.token];
   }
   if (!actor && speaker.actor) {
-    actor = game.actors?.get(speaker.actor);
+    actor = game.actors.get(speaker.actor);
   }
-  const item:TwodsixItem = actor ? actor.items.find((i) => i.id === itemId) : null;
+  const item:TwodsixItem = actor ? (actor.items.get(itemId) ?? actor.items.getName(itemName)) : undefined;
   if (!item) {
-    const unattachedItem = game.items?.get(itemId);
+    const unattachedItem = game.items.get(itemId) ?? game.items.getName(itemName);
     if (unattachedItem?.type != "weapon" && !actor && unattachedItem) {
       await (<TwodsixItem><unknown>unattachedItem).skillRoll(true);
     } else {

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -152,6 +152,7 @@ declare global {
       'twodsix.equippedToggleStates': string;
       'twodsix.targetDMList': string;
       'twodsix.showSkillGroups': boolean;
+      'twodsix.NoDuplicatesOnHotbar': boolean;
     }
   }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -52,7 +52,8 @@
       "ROFSingle": "Single Fire",
       "ROFBurst": "Burst Fire",
       "ROFFull": "Full Auto",
-      "ROFDoubleTap": "Double Tap"
+      "ROFDoubleTap": "Double Tap",
+      "ReplaceMacroCommand": "Update Macro Command"
     },
     "Actor": {
       "Age": "Age",
@@ -1460,7 +1461,7 @@
       "ResetEffectForManualDamage": "Effects not included in damage rolls.  Resetting effects in manual rolls to false.",
       "tableNotFound": "Cannot find RollTable in Journal Entry Link.",
       "typeMismatch": "RollTable link/UUID in Journal Entry is not a RollTable.",
-      "MacroNameExists": "Macro by that name exists, but command is different.  Updating command."
+      "MacroNameExists": "Macro by that name exists, but command is different.  Update to the new command?"
     }
   },
   "TYPES": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1455,7 +1455,8 @@
       "WearingMultipleLayers": "Multiple armor layers equipped while wearing non-stackable armor.",
       "ResetEffectForManualDamage": "Effects not included in damage rolls.  Resetting effects in manual rolls to false.",
       "tableNotFound": "Cannot find RollTable in Journal Entry Link.",
-      "typeMismatch": "RollTable link/UUID in Journal Entry is not a RollTable."
+      "typeMismatch": "RollTable link/UUID in Journal Entry is not a RollTable.",
+      "MacroNameExists": "Macro by that name exists, but command is different.  Updating command."
     }
   },
   "TYPES": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1373,6 +1373,10 @@
       "showSkillGroups": {
         "hint": "Group skills on actor sheet by group labels.",
         "name": "Group skills by labels"
+      },
+      "NoDuplicatesOnHotbar": {
+        "hint": "Prevent duplicate item macros when drag-dropping items onto hotbar",
+        "name": "No duplicate item macros on hotbar"
       }
     },
     "CloseAndCreateNew": "Close and create new",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
drop item macro on hotbar not robust (uses item.id only, does not update macro if macro by that name exists, duplicates macro on dropbar,


* **What is the new behavior (if this is a feature change)?**
Add optional item.name field as backup lookup, update command if changed, don't add macro to hot bar if already there.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
