### PR TITLE
feat: add third alternate characteristic

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -640,10 +640,10 @@ export const HullPricingOptions = {
  * The valid choices for characteristic displays in the game system.
  */
 export const CharacteristicDisplayTypes = {
-  core: "Core",
-  base: "Base",
-  alternate: "Alternate",
-  all: "All"
+  core: "TWODSIX.Actor.CharDisplay.Core",
+  base: "TWODSIX.Actor.CharDisplay.Base",
+  alternate: "TWODSIX.Actor.CharDisplay.Alternate",
+  all: "TWODSIX.Actor.CharDisplay.All"
 };
 
 /**

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -12,7 +12,8 @@ const CHARACTERISTICS = Object.freeze({
   "stamina": "STA",
   "lifeblood": "LFB",
   "alternative1": "ALT1",
-  "alternative2": "ALT2"
+  "alternative2": "ALT2",
+  "alternative3": "ALT3"
 });
 
 /**

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -13,7 +13,7 @@ import {Component, Consumable, Gear, Skills, UsesConsumables, Weapon} from "../.
 import { confirmRollFormula } from "../utils/sheetUtils";
 import { getCharacteristicFromDisplayLabel } from "../utils/utils";
 import ItemTemplate from "../utils/ItemTemplate";
-import { getDamageTypes } from "../sheets/TwodsixItemSheet";
+import { getDamageTypes } from "../utils/sheetUtils";
 import { TWODSIX } from "../config";
 
 export default class TwodsixItem extends Item {

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -167,6 +167,10 @@ export default function registerHandlebarsHelpers(): void {
     return game.settings.get('twodsix', 'alternativeShort2');
   });
 
+  Handlebars.registerHelper('alternativeShort3', () => {
+    return game.settings.get('twodsix', 'alternativeShort3');
+  });
+
   Handlebars.registerHelper('skillName', (skillName) => {
     return simplifySkillName(skillName);
   });

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -7,7 +7,7 @@ import { TWODSIX } from "./config";
 import TwodsixItem from "./entities/TwodsixItem";
 import {Skills} from "../types/template";
 import TwodsixActor, { getPower, getWeight } from "./entities/TwodsixActor";
-import { _getTranslatedCharacteristicList, _genUntranslatedCharacteristicList } from "./utils/TwodsixRollSettings";
+import { getCharacteristicList } from "./utils/TwodsixRollSettings";
 import { simplifySkillName } from "./utils/utils";
 
 export default function registerHandlebarsHelpers(): void {
@@ -409,13 +409,7 @@ export default function registerHandlebarsHelpers(): void {
   });
 
   Handlebars.registerHelper('getCharacteristicList', (actor: TwodsixActor) => {
-    let returnValue = {};
-    if (actor) {
-      returnValue = _getTranslatedCharacteristicList(actor);
-    } else {
-      returnValue = _genUntranslatedCharacteristicList();
-    }
-    return returnValue;
+    return getCharacteristicList(actor);
   });
 
   Handlebars.registerHelper('makePieImage', (text: string) => {

--- a/src/module/hooks/diceTrayIntegration.ts
+++ b/src/module/hooks/diceTrayIntegration.ts
@@ -51,13 +51,16 @@ Hooks.on('dcCalcWhitelist', (whitelist, actor) => {
         delete whitelist.twodsix.custom.attributes.psionicStrength;
         delete whitelist.twodsix.custom.attributes.alternative1;
         delete whitelist.twodsix.custom.attributes.alternative2;
+        delete whitelist.twodsix.custom.attributes.alternative3;
         break;
       case 'base':
         delete whitelist.twodsix.custom.attributes.alternative1;
         delete whitelist.twodsix.custom.attributes.alternative2;
+        delete whitelist.twodsix.custom.attributes.alternative3;
         break;
       case 'alternate':
         delete whitelist.twodsix.custom.attributes.psionicStrength;
+        delete whitelist.twodsix.custom.attributes.alternative3;
         break;
       case 'all':
         break;

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -79,6 +79,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.characteristics.push(stringSetting("shortPSI", "TWODSIX.Items.Skills.PSI", false, "world", updatePSIShortLabel, true));
     settings.characteristics.push(stringSetting("alternativeShort1", "ALT1"));
     settings.characteristics.push(stringSetting("alternativeShort2", "ALT2"));
+    settings.characteristics.push(stringSetting("alternativeShort3", "ALT3"));
     settings.ship.push(numberSetting('maxComponentHits', 3));
     settings.ship.push(numberSetting('mortgagePayment', 240, false));
     settings.ship.push(stringSetting('massProductionDiscount', "0.10", false)); //Should be a number setting, but FVTT unhappy with values other than 0.5

--- a/src/module/settings/RulsetSettings.ts
+++ b/src/module/settings/RulsetSettings.ts
@@ -69,7 +69,7 @@ export default class RulesetSettings extends AdvancedSettings {
     settings.characteristics.push(booleanSetting('lifebloodInsteadOfCharacteristics', false));
     settings.characteristics.push(booleanSetting('showContaminationBelowLifeblood', true));
     settings.characteristics.push(booleanSetting('showHeroPoints', false));
-    settings.characteristics.push(stringChoiceSetting('showAlternativeCharacteristics', "base", false, TWODSIX.CharacteristicDisplayTypes));
+    settings.characteristics.push(stringChoiceSetting('showAlternativeCharacteristics', "base", true, TWODSIX.CharacteristicDisplayTypes));
     settings.characteristics.push(stringSetting("shortSTR", "TWODSIX.Items.Skills.STR", false, "world", updateSTRShortLabel, true));
     settings.characteristics.push(stringSetting("shortDEX", "TWODSIX.Items.Skills.DEX", false, "world", updateDEXShortLabel, true));
     settings.characteristics.push(stringSetting("shortEND", "TWODSIX.Items.Skills.END", false, "world", updateENDShortLabel, true));

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -339,7 +339,7 @@ export function setCharacteristicDisplay(returnData: object): void {
   const charMode = game.settings.get('twodsix', 'showAlternativeCharacteristics');
   returnData.system.characteristics.alternative1.displayChar = ['alternate', 'all'].includes(charMode);
   returnData.system.characteristics.alternative2.displayChar = ['alternate', 'all'].includes(charMode);
-  returnData.system.characteristics.alternative3.displayChar = ['alternate', 'all'].includes(charMode);
+  returnData.system.characteristics.alternative3.displayChar = ['all'].includes(charMode);
   returnData.system.characteristics.dexterity.displayChar = true;
   returnData.system.characteristics.education.displayChar = true;
   returnData.system.characteristics.endurance.displayChar = true;

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -339,6 +339,7 @@ export function setCharacteristicDisplay(returnData: object): void {
   const charMode = game.settings.get('twodsix', 'showAlternativeCharacteristics');
   returnData.system.characteristics.alternative1.displayChar = ['alternate', 'all'].includes(charMode);
   returnData.system.characteristics.alternative2.displayChar = ['alternate', 'all'].includes(charMode);
+  returnData.system.characteristics.alternative3.displayChar = ['alternate', 'all'].includes(charMode);
   returnData.system.characteristics.dexterity.displayChar = true;
   returnData.system.characteristics.education.displayChar = true;
   returnData.system.characteristics.endurance.displayChar = true;
@@ -367,7 +368,7 @@ export function getDisplayOrder(returnData: any): string[] {
       returnValue.push('alternative1', 'alternative2');
       break;
     case 'all':
-      returnValue.push('alternative1', 'alternative2');
+      returnValue.push('alternative1', 'alternative2', 'alternative3');
       if (returnData.system.characteristics.psionicStrength.value !== 0 || !game.settings.get('twodsix', 'omitPSIifZero')) {
         returnValue.push('psionicStrength');
       }

--- a/src/module/sheets/TwodsixAnimalSheet.ts
+++ b/src/module/sheets/TwodsixAnimalSheet.ts
@@ -5,7 +5,7 @@ import { AbstractTwodsixActorSheet } from "./AbstractTwodsixActorSheet";
 import { TWODSIX } from "../config";
 import TwodsixActor from "../entities/TwodsixActor";
 import { Animal } from "src/types/template";
-import { getDamageTypes } from "../sheets/TwodsixItemSheet";
+import { getDamageTypes } from "../utils/sheetUtils";
 import { setCharacteristicDisplay } from "./TwodsixActorSheet";
 export class TwodsixAnimalSheet extends AbstractTwodsixActorSheet {
 

--- a/src/module/sheets/TwodsixRobotSheet.ts
+++ b/src/module/sheets/TwodsixRobotSheet.ts
@@ -4,7 +4,7 @@
 import { AbstractTwodsixActorSheet } from "./AbstractTwodsixActorSheet";
 import { TWODSIX } from "../config";
 import TwodsixActor from "../entities/TwodsixActor";
-import { getDamageTypes } from "../sheets/TwodsixItemSheet";
+import { getDamageTypes } from "../utils/sheetUtils";
 import { setCharacteristicDisplay } from "./TwodsixActorSheet";
 
 export class TwodsixRobotSheet extends AbstractTwodsixActorSheet {

--- a/src/module/sheets/TwodsixSpaceObjectSheet.ts
+++ b/src/module/sheets/TwodsixSpaceObjectSheet.ts
@@ -9,7 +9,7 @@ import TwodsixActor from "../entities/TwodsixActor";
 import { TWODSIX } from "../config";
 import { simplifyRollFormula } from "../utils/dice";
 import { getDiceResults } from "../entities/TwodsixItem";
-import { getDamageTypes } from "../sheets/TwodsixItemSheet";
+import { getDamageTypes } from "../utils/sheetUtils";
 
 export class TwodsixSpaceObjectSheet extends AbstractTwodsixActorSheet {
   /** @override */

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -357,6 +357,16 @@ export function _genUntranslatedCharacteristicList(): object {
   return returnValue;
 }
 
+export function getCharacteristicList(actor?:TwodsixActor|undefined): any {
+  let returnValue = {};
+  if (actor) {
+    returnValue = _getTranslatedCharacteristicList(actor);
+  } else {
+    returnValue = _genUntranslatedCharacteristicList();
+  }
+  return returnValue;
+}
+
 export async function getCustomModifiers(selectedActor:TwodsixActor, characteristic:string, skill?:Skills): Promise<any> {
   const characteristicKey = getKeyByValue(TWODSIX.CHARACTERISTICS, characteristic);
   const simpleSkillRef = skill ? `system.skills.` + simplifySkillName(skill.name) : ``;

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -317,6 +317,8 @@ export function _getTranslatedCharacteristicList(actor:TwodsixActor):object {
     if (!['base', 'core'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {
       returnValue["ALT1"] = getCharacteristicLabelWithMod(actor, "alternative1");
       returnValue["ALT2"] =  getCharacteristicLabelWithMod(actor, "alternative2");
+    }
+    if (['all'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {
       returnValue["ALT3"] =  getCharacteristicLabelWithMod(actor, "alternative3");
     }
     if (!['alternate', 'core'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {
@@ -344,6 +346,8 @@ export function _genUntranslatedCharacteristicList(): object {
   if (!['base', 'core'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {
     returnValue["ALT1"] = game.settings.get('twodsix', 'alternativeShort1');
     returnValue["ALT2"] = game.settings.get('twodsix', 'alternativeShort2');
+  }
+  if (['all'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {
     returnValue["ALT3"] = game.settings.get('twodsix', 'alternativeShort3');
   }
   if (!['alternate', 'core'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -317,6 +317,7 @@ export function _getTranslatedCharacteristicList(actor:TwodsixActor):object {
     if (!['base', 'core'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {
       returnValue["ALT1"] = getCharacteristicLabelWithMod(actor, "alternative1");
       returnValue["ALT2"] =  getCharacteristicLabelWithMod(actor, "alternative2");
+      returnValue["ALT3"] =  getCharacteristicLabelWithMod(actor, "alternative3");
     }
     if (!['alternate', 'core'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {
       returnValue["PSI"] =  getCharacteristicLabelWithMod(actor, "psionicStrength");
@@ -343,6 +344,7 @@ export function _genUntranslatedCharacteristicList(): object {
   if (!['base', 'core'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {
     returnValue["ALT1"] = game.settings.get('twodsix', 'alternativeShort1');
     returnValue["ALT2"] = game.settings.get('twodsix', 'alternativeShort2');
+    returnValue["ALT3"] = game.settings.get('twodsix', 'alternativeShort3');
   }
   if (!['alternate', 'core'].includes(game.settings.get('twodsix', 'showAlternativeCharacteristics'))) {
     returnValue["PSI"] = game.i18n.localize("TWODSIX.Items.Skills.PSI");

--- a/src/module/utils/actorDamage.ts
+++ b/src/module/utils/actorDamage.ts
@@ -4,7 +4,7 @@
 import TwodsixActor from "../entities/TwodsixActor";
 import { calcModFor } from "./sheetUtils";
 import {Traveller} from "../../types/template";
-import { getDamageTypes } from "../sheets/TwodsixItemSheet";
+import { getDamageTypes } from "./sheetUtils";
 
 /**
  * This class handles an individual attribute, such as strength and dexterity

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
 //Assorted utility functions likely to be helpful when displaying characters
+import { camelCase } from "../settings/settingsUtils";
 
 // export function pseudoHex(value:number):string {
 //   switch (value) {
@@ -325,4 +326,26 @@ export async function wait(ms) {
   return new Promise(resolve => {
     setTimeout(resolve, ms);
   });
+}
+
+/**
+ * Function to return an object of the damage types from setting: 'damageTypeOptions'
+ * @param {boolean} isWeapon  Whether the item is a weapon. If so, add {NONE: "---"} to list.
+ * @returns {object} An object with the damage type key, label pairs
+ * @export
+ */
+export function getDamageTypes(isWeapon:boolean): object {
+  const returnObject = {};
+  const damageTypeOptions:string = game.settings.get('twodsix', 'damageTypeOptions');
+  if (damageTypeOptions !== "") {
+    let protectionTypeLabels:string[] = damageTypeOptions.split(',');
+    protectionTypeLabels = protectionTypeLabels.map((s:string) => s.trim());
+    for (const type of protectionTypeLabels) {
+      Object.assign(returnObject, {[camelCase(type)]: type});
+    }
+  }
+  if (isWeapon) {
+    Object.assign(returnObject, {"NONE": "---"});
+  }
+  return returnObject;
 }

--- a/src/module/utils/utils.ts
+++ b/src/module/utils/utils.ts
@@ -52,6 +52,8 @@ export function getCharShortName(char: string): string {
       return game.settings.get('twodsix', 'alternativeShort1');
     case "ALT2":
       return game.settings.get('twodsix', 'alternativeShort2');
+    case "ALT3":
+      return game.settings.get('twodsix', 'alternativeShort3');
     case "LFB":
     case "STA":
     case "HIT":

--- a/src/types/template.d.ts
+++ b/src/types/template.d.ts
@@ -395,6 +395,7 @@ export interface Characteristics {
   lifeblood:Characteristic;
   alternative1:Characteristic;
   alternative2:Characteristic;
+  alternative3:Characteristic;
 }
 
 export interface Characteristic {

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -84,6 +84,7 @@ declare global {
       'twodsix.ruleset': string; //TODO Should be more specific, really
       'twodsix.alternativeShort1': string;
       'twodsix.alternativeShort2': string;
+      'twodsix.alternativeShort3': string;
       'twodsix.maxComponentHits': number;
       'twodsix.initiativeFormula': string;
       'twodsix.armorDamageFormula': string;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -896,6 +896,10 @@
         "hint": "Short name for second alternative characteristic. It should be four characters or fewer.",
         "name": "Short name for alternative characteristic 2"
       },
+      "alternativeShort3": {
+        "hint": "Short name for third alternative characteristic. It should be four characters or fewer.",
+        "name": "Short name for alternative characteristic 3"
+      },
       "autofireRulesUsed": {
         "hint": "Select which variant's auto/burst fire rules should be used.",
         "name": "Select which variant's auto/burst fire rules should be used."

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -233,6 +233,7 @@
         "MovementRate": "Movement Rate"
       },
       "CharDisplay": {
+        "Core": "Core",
         "Base": "Base",
         "Alternate": "Alternate",
         "All": "All"
@@ -996,7 +997,7 @@
         "name": "Ship Initiative Formula"
       },
       "showAlternativeCharacteristics": {
-        "hint": " Core: six basic chararcteristics (STR, DEX, END, INT, EDU, and SOC).  Base: core six plus PSI. Alternative: core six plus Alternative characteristics. All: core six plus PSI plus Alternative characteristics.",
+        "hint": " Core: six basic chararcteristics (STR, DEX, END, INT, EDU, and SOC).  Base: core six plus PSI. Alternative: core six plus two Alternative characteristics. All: core six plus PSI plus three Alternative characteristics.",
         "name": "Select characteristics to display"
       },
       "showContaminationBelowLifeblood": {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1195,9 +1195,9 @@ span.stat-name-table, input.stat-name-table {
   display: block;
   cursor: pointer;
   text-align: center;
-  width: 3ch;
+  width: 4ch;
   height: 2ch;
-  transform: rotate(-45deg);
+  transform: rotate(-50deg);
   margin: 0;
   padding: 0;
 }
@@ -1330,7 +1330,7 @@ span.stat-damage-table input {
   border: solid;
   border-width: thin;
   border-radius: 15%;
-  width: 3ch;
+  width: 4ch;
   height: 3.5ch;
   border-color: var(--s2d6-default-color);
 }

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1166,9 +1166,10 @@ span.bgi-charEdit {
 .stat-table-small {
   background-color: var(--s2d6-nav-background);
   font-size: 11px;
-  margin-left: 39px;
+  margin-left: 37px;
   margin-top: 0px;
-  width: 82%;
+  margin-right: 14px;
+  width: -webkit-fill-available;
 }
 .table-header-row {
   height: 5ch;
@@ -1194,7 +1195,7 @@ span.stat-name-table, input.stat-name-table {
   display: block;
   cursor: pointer;
   text-align: center;
-  width: 4ch;
+  width: 3ch;
   height: 2ch;
   transform: rotate(-45deg);
   margin: 0;
@@ -1308,7 +1309,7 @@ span.stat-modifier-table {
 }
 
 span.stat-ability-table input, span.stat-modifier-table input {
-  width: 4ch;
+  width: 3ch;
   height: 3.5ch;
   color: var(--s2d6-stat-input);
 }
@@ -1329,7 +1330,7 @@ span.stat-damage-table input {
   border: solid;
   border-width: thin;
   border-radius: 15%;
-  width: 4ch;
+  width: 3ch;
   height: 3.5ch;
   border-color: var(--s2d6-default-color);
 }

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -994,7 +994,7 @@ h2 {
 }
 
 .bgi-species input {
-  width: 8em;
+  width: 7em;
   border: none;
 }
 

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -1309,7 +1309,7 @@ span.stat-modifier-table {
 }
 
 span.stat-ability-table input, span.stat-modifier-table input {
-  width: 3ch;
+  width: 4ch;
   height: 3.5ch;
   color: var(--s2d6-stat-input);
 }

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -186,7 +186,7 @@ label.checkbox > input[type="checkbox"] {
 .animal-content-container {
   display: grid;
   grid-template-columns: 15em 22em 18em;
-  grid-template-rows: 23em 0.5fr 0.5fr;
+  grid-template-rows: 22em 0.5fr 0.5fr;
   gap: 16px 16px;
   position: relative;
   grid-template-areas:
@@ -626,7 +626,7 @@ img.character-info-mask {
 }
 
 .bgi-species input {
-  width: 8em;
+  width: 7em;
   border: none;
 }
 

--- a/static/template.json
+++ b/static/template.json
@@ -91,6 +91,14 @@
             "label": "Alternative 2",
             "shortLabel": "ALT2",
             "displayShortLabel": ""
+          },
+          "alternative3": {
+            "key": "alternative3",
+            "value": 7,
+            "damage": 0,
+            "label": "Alternative 3",
+            "shortLabel": "ALT3",
+            "displayShortLabel": ""
           }
         },
         "characteristicEdit": false

--- a/static/templates/actors/parts/actor/actor-characteristics-table.html
+++ b/static/templates/actors/parts/actor/actor-characteristics-table.html
@@ -16,7 +16,6 @@
   </thead>
   <tbody>
       <tr>
-        {{log this}}
         <td {{#iff this.actor.type "===" "traveller"}} style="font-size: smaller;"{{/iff}}>{{localize "TWODSIX.Damage.Max"}}</td>
         {{#each system.characteristics as |char key|}}
           {{#if char.displayChar}}

--- a/static/templates/actors/parts/actor/actor-characteristics-table.html
+++ b/static/templates/actors/parts/actor/actor-characteristics-table.html
@@ -16,7 +16,7 @@
   </thead>
   <tbody>
       <tr>
-        <td>{{localize "TWODSIX.Damage.Max"}}:</td>
+        <td>{{localize "TWODSIX.Damage.Max"}}</td>
         {{#each system.characteristics as |char key|}}
           {{#if char.displayChar}}
             <td><span class="stat-ability-table"><input type="number" min="0" name="system.characteristics.{{key}}.value"
@@ -27,7 +27,7 @@
       </tr>
 
       <tr>
-        <td>{{localize "TWODSIX.Damage.Mod"}}:</td>
+        <td>{{localize "TWODSIX.Damage.Mod"}}</td>
         {{#each system.characteristics as |char key|}}
           {{#if char.displayChar}}
           <td><span class="stat-modifier-table"><input readonly type="text" data-tooltip="{{twodsix_getTooltip ../actor (concat 'system.characteristics.' key '.mod')}}"
@@ -37,7 +37,7 @@
       </tr>
 
      <tr>
-        <td>{{localize "TWODSIX.Damage.Dmg"}}:</td>
+        <td>{{localize "TWODSIX.Damage.Dmg"}}</td>
         {{#each system.characteristics as |char key|}}
           {{#if char.displayChar}}
             <td><span class="stat-damage-table"><input type="number" max="{{char.value}}" min="0"

--- a/static/templates/actors/parts/actor/actor-characteristics-table.html
+++ b/static/templates/actors/parts/actor/actor-characteristics-table.html
@@ -16,7 +16,8 @@
   </thead>
   <tbody>
       <tr>
-        <td>{{localize "TWODSIX.Damage.Max"}}</td>
+        {{log this}}
+        <td {{#iff this.actor.type "===" "traveller"}} style="font-size: smaller;"{{/iff}}>{{localize "TWODSIX.Damage.Max"}}</td>
         {{#each system.characteristics as |char key|}}
           {{#if char.displayChar}}
             <td><span class="stat-ability-table"><input type="number" min="0" name="system.characteristics.{{key}}.value"
@@ -27,7 +28,7 @@
       </tr>
 
       <tr>
-        <td>{{localize "TWODSIX.Damage.Mod"}}</td>
+        <td {{#iff this.actor.type "===" "traveller"}} style="font-size: smaller;"{{/iff}}>{{localize "TWODSIX.Damage.Mod"}}</td>
         {{#each system.characteristics as |char key|}}
           {{#if char.displayChar}}
           <td><span class="stat-modifier-table"><input readonly type="text" data-tooltip="{{twodsix_getTooltip ../actor (concat 'system.characteristics.' key '.mod')}}"
@@ -37,7 +38,7 @@
       </tr>
 
      <tr>
-        <td>{{localize "TWODSIX.Damage.Dmg"}}</td>
+        <td {{#iff this.actor.type "===" "traveller"}} style="font-size: smaller;"{{/iff}}>{{localize "TWODSIX.Damage.Dmg"}}</td>
         {{#each system.characteristics as |char key|}}
           {{#if char.displayChar}}
             <td><span class="stat-damage-table"><input type="number" max="{{char.value}}" min="0"

--- a/static/templates/actors/parts/actor/actor-characteristics-table.html
+++ b/static/templates/actors/parts/actor/actor-characteristics-table.html
@@ -5,7 +5,7 @@
         {{#if char.displayChar}}
           {{#if ../system.characteristicEdit}}
             <td><input type = "text" name= "system.characteristics.{{key}}.displayShortLabel" data-label = "system.characteristics.{{key}}.displayShortLabel"
-              class="stat-name-table" value="{{char.displayShortLabel}}" maxlength="3"/></td>
+              class="stat-name-table" value="{{char.displayShortLabel}}" maxlength="4"/></td>
           {{else}}
             <td><span class="stat-name-table rollable-characteristic" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-roll="2d6+{{char.mod}}" data-label="{{char.shortLabel}}">
               {{char.displayShortLabel}}</span></td>

--- a/static/templates/items/skills-sheet.html
+++ b/static/templates/items/skills-sheet.html
@@ -43,7 +43,7 @@
       <div class="item-type">
         <label for="system.characteristic" class="resource-label">{{localize "TWODSIX.Items.Skills.Modifier"}}</label>
         <select class="form-input" name="system.characteristic" value={{characteristic}}>
-          {{selectOptions (getCharacteristicList owner) selected=system.characteristic }}
+          {{selectOptions settings.characteristicsList selected=system.initialCharacteristic }}
         </select>
       </div>
       <div class="item-rollDifficulty">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature and refactor


* **What is the current behavior?** (You can also link to an open issue here)
Only 2 alternative char
getDamageTypes can cause circular references 


* **What is the new behavior (if this is a feature change)?**
Add third alt char - visible only with display ALL
move getDamageTypes to sheetUtils


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No?


* **Other information**:
