### PR TITLE
fix: allow item-piles module to work with damage drop

### DIFF
--- a/src/module/hooks/dropItemOnToken.ts
+++ b/src/module/hooks/dropItemOnToken.ts
@@ -6,7 +6,7 @@
 import TwodsixActor from "../entities/TwodsixActor";
 import { getItemDataFromDropData } from "../utils/sheetUtils";
 Hooks.on('dropCanvasData', (canvasObject, dropData) => {
-  if ((dropData.type === 'damageItem' || dropData.type === "Item") && game.settings.get("twodsix", "allowDropOnIcon")) {
+  if ((dropData.type === 'damageItem' || (dropData.type === "Item" && !game.modules.get("item-piles")?.active)) && game.settings.get("twodsix", "allowDropOnIcon")) {
     catchDrop(canvasObject, dropData).then();
     return false;
   }

--- a/src/module/hooks/itemPilesIntegration.ts
+++ b/src/module/hooks/itemPilesIntegration.ts
@@ -61,10 +61,4 @@ Hooks.once("item-piles-ready", async function() {
       "odd-color": "#00000000",
     }*/
   });
-
-  // Item piles conflict with drag drop on icon
-  if (game.settings.get('twodsix', 'allowDropOnIcon')) {
-    await game.settings.set('twodsix', 'allowDropOnIcon', false);
-    ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.DragDropOnIconsDisabled"));
-  }
 });

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1483,8 +1483,7 @@
       "ResetEffectForManualDamage": "Effects not included in damage rolls.  Resetting effects in manual rolls to false.",
       "tableNotFound": "Cannot find RollTable in Journal Entry Link.",
       "typeMismatch": "RollTable link/UUID in Journal Entry is not a RollTable.",
-      "MacroNameExists": "Macro by that name exists, but command is different.  Update to the new command?",
-      "DragDropOnIconsDisabled": "The system setting for dragging and dropping items on tokens has been disabled as it conflicts with the Item Piles module."
+      "MacroNameExists": "Macro by that name exists, but command is different.  Update to the new command?"
     }
   },
   "TYPES": {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When using item piles module, can't use drop of damage on token.


* **What is the new behavior (if this is a feature change)?**
Allow exception for damageItem drop


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users will need to enable Drag-drop on tokens again if using item piles.


* **Other information**:
