### PR TITLE
fix: Try to streamline encumbrance calcs

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -212,7 +212,7 @@ export default class TwodsixActor extends Actor {
     if (Roll.validate(encumbFormula)) {
       maxEncumbrance = Roll.safeEval(Roll.replaceFormulaData(encumbFormula, this.system));
     }
-    return maxEncumbrance;
+    return Math.max(maxEncumbrance, 0);
   }
 
   getActorEncumbrance():number {

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -217,9 +217,9 @@ export default class TwodsixActor extends Actor {
 
   getActorEncumbrance():number {
     let encumbrance = 0;
-    const actorItems = this.items.filter( i => !["skills", "trait", "ship_position", "storage"].includes(i.type));
+    const actorItems = this.items.filter( i => !["skills", "trait", "ship_position", "storage", "spell"].includes(i.type));
     for (const item of actorItems) {
-      encumbrance += getEquipmentWeight(<TwodsixItem>item);
+      encumbrance += getEquipmentWeight(item);
     }
     return encumbrance;
   }

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -728,9 +728,10 @@ export default class TwodsixItem extends Item {
    * A method to change the suspened state of an Actor Active effect linked to item
    *
    * @param {boolean} newSuspendedState    The new Active Effect suspended state for the actor
+   * @param {any} options An object to pass to update hook (only {dontSync: true/false} for encumbrance checks is coded)
    * @returns {Promise<void>}
    */
-  public async toggleActiveEffectStatus(newSuspendedState:boolean, options = {}): Promise<void> {
+  public async toggleActiveEffectStatus(newSuspendedState:boolean, options: any = {}): Promise<void> {
     const changes = [];
     for (const effect of this.effects) {
       if (effect.disabled !== newSuspendedState) {

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -730,11 +730,15 @@ export default class TwodsixItem extends Item {
    * @param {boolean} newSuspendedState    The new Active Effect suspended state for the actor
    * @returns {Promise<void>}
    */
-  public async toggleActiveEffectStatus(newSuspendedState:boolean): Promise<void> {
+  public async toggleActiveEffectStatus(newSuspendedState:boolean, options = {}): Promise<void> {
+    const changes = [];
     for (const effect of this.effects) {
       if (effect.disabled !== newSuspendedState) {
-        await effect.update({disabled: newSuspendedState});
+        changes.push({_id: effect.id, disabled: newSuspendedState});
       }
+    }
+    if (changes.length > 0 ) {
+      await this.updateEmbeddedDocuments("ActiveEffect", changes, options);
     }
   }
 

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -27,8 +27,8 @@ Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>,
 Hooks.on("updateItem", async (item: TwodsixItem, update: Record<string, any>, options: any, userId:string) => {
   if (game.user?.id === userId) {
     const owningActor: TwodsixActor = item.actor;
-    if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') && owningActor && !options.dontSync) {
-      if ((owningActor.type === 'traveller') && !["skills", "trait", "spell"].includes(item.type) && update.system) {
+    if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') && owningActor?.type === 'traveller' && !options.dontSync) {
+      if (!["skills", "trait", "spell"].includes(item.type) && update.system) {
         if ((Object.hasOwn(update.system, "weight") || Object.hasOwn(update.system, "quantity") || (Object.hasOwn(update.system, "equipped")) && item.system.weight > 0)) {
           await applyEncumberedEffect(owningActor);
         }

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -149,9 +149,9 @@ export async function applyEncumberedEffect(selectedActor: TwodsixActor): Promis
 
   // Delete encumbered AE's if uneeded or more than one
   if (isCurrentlyEncumbered.length > 0) {
-    const idList = await isCurrentlyEncumbered.map(i => i.id);
+    const idList = isCurrentlyEncumbered.map(i => i.id);
     if (state === true) {
-      idToKeep = await idList.pop();
+      idToKeep = idList.pop();
     }
     if(idList.length > 0) {
       await selectedActor.deleteEmbeddedDocuments("ActiveEffect", idList);

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -194,8 +194,9 @@ export async function applyEncumberedEffect(selectedActor: TwodsixActor): Promis
         statuses: ["encumbered"]
       }]);
     } else {
-      if (changeData[0].value !== selectedActor.effects.get(idToKeep)?.changes[0].value  && !!idToKeep) {
-        selectedActor.updateEmbeddedDocuments('ActiveEffect', [{ _id: idToKeep, changes: changeData }]);
+      const encumberedEffect = await selectedActor.effects.get(idToKeep);
+      if (changeData[0].value !== encumberedEffect?.changes[0].value  && encumberedEffect) {
+        encumberedEffect.update({changes: changeData });
       }
     }
   }

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -28,8 +28,8 @@ Hooks.on("updateItem", (item: TwodsixItem, update: Record<string, any>, options:
   if (game.user?.id === userId) {
     const owningActor = <TwodsixActor> item.actor;
     if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') && owningActor) {
-      if ((owningActor.type === 'traveller') && !["skills", "trait", "spell"].includes(item.type) ) {
-        if (update.system?.weight && !options.dontSync) {
+      if ((owningActor.type === 'traveller') && !["skills", "trait", "spell"].includes(item.type) && update.system) {
+        if ((Object.hasOwn(update.system, "weight") || Object.hasOwn(update.system, "quantity") || Object.hasOwn(update.system, "equipped")) && !options.dontSync) {
           applyEncumberedEffect(owningActor);
         }
       }

--- a/src/module/hooks/showStatusIcons.ts
+++ b/src/module/hooks/showStatusIcons.ts
@@ -26,10 +26,10 @@ Hooks.on('updateActor', async (actor: TwodsixActor, update: Record<string, any>,
 
 Hooks.on("updateItem", async (item: TwodsixItem, update: Record<string, any>, options: any, userId:string) => {
   if (game.user?.id === userId) {
-    const owningActor = <TwodsixActor> item.actor;
-    if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') && owningActor) {
+    const owningActor: TwodsixActor = item.actor;
+    if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') && owningActor && !options.dontSync) {
       if ((owningActor.type === 'traveller') && !["skills", "trait", "spell"].includes(item.type) && update.system) {
-        if ((Object.hasOwn(update.system, "weight") || Object.hasOwn(update.system, "quantity") || (Object.hasOwn(update.system, "equipped")) && item.system.weight > 0) && !options.dontSync) {
+        if ((Object.hasOwn(update.system, "weight") || Object.hasOwn(update.system, "quantity") || (Object.hasOwn(update.system, "equipped")) && item.system.weight > 0)) {
           await applyEncumberedEffect(owningActor);
         }
       }
@@ -37,7 +37,7 @@ Hooks.on("updateItem", async (item: TwodsixItem, update: Record<string, any>, op
     //Needed - for active effects changing damage stats
     if (game.settings.get('twodsix', 'useWoundedStatusIndicators') && owningActor) {
       if (checkForDamageStat(update, owningActor.type) && ["traveller", "animal", "robot"].includes(owningActor.type)) {
-        await applyWoundedEffect(<TwodsixActor>item.actor);
+        await applyWoundedEffect(owningActor);
       }
     }
   }
@@ -361,7 +361,7 @@ export function getIconTint(selectedActor: TwodsixActor): string {
   }
 }
 
-export function getHitsTint(selectedTraveller: Traveller): string {
+export function getHitsTint(selectedTraveller: TwodsixActor): string {
   let returnVal = '';
   if (selectedTraveller.characteristics.lifeblood.current <= 0) {
     returnVal = DAMAGECOLORS.deadTint;
@@ -373,7 +373,7 @@ export function getHitsTint(selectedTraveller: Traveller): string {
   return returnVal;
 }
 
-export function getCDWoundTint(selectedTraveller: Traveller): string {
+export function getCDWoundTint(selectedTraveller: TwodsixActor): string {
   let returnVal = '';
   if (selectedTraveller.characteristics.lifeblood.current <= 0) {
     returnVal = DAMAGECOLORS.deadTint;
@@ -385,7 +385,7 @@ export function getCDWoundTint(selectedTraveller: Traveller): string {
   return returnVal;
 }
 
-export function getCELWoundTint(selectedTraveller: Traveller): string {
+export function getCELWoundTint(selectedTraveller: TwodsixActor): string {
   let returnVal = '';
   const testArray = [selectedTraveller.characteristics.strength, selectedTraveller.characteristics.dexterity, selectedTraveller.characteristics.endurance];
   const maxNonZero = testArray.filter(chr => chr.value !== 0).length;
@@ -402,7 +402,7 @@ export function getCELWoundTint(selectedTraveller: Traveller): string {
   return returnVal;
 }
 
-export function getCEWoundTint(selectedTraveller: Traveller): string {
+export function getCEWoundTint(selectedTraveller: TwodsixActor): string {
   let returnVal = '';
   const testArray = [selectedTraveller.characteristics.strength, selectedTraveller.characteristics.dexterity, selectedTraveller.characteristics.endurance];
   const maxNonZero = testArray.filter(chr => chr.value !== 0).length;
@@ -428,12 +428,12 @@ export function getCEWoundTint(selectedTraveller: Traveller): string {
   return returnVal;
 }
 
-export function isUnconsciousCE(selectedTraveller: Traveller): boolean {
+export function isUnconsciousCE(selectedTraveller: TwodsixActor): boolean {
   const testArray = [selectedTraveller.characteristics.strength, selectedTraveller.characteristics.dexterity, selectedTraveller.characteristics.endurance];
   return (testArray.filter(chr => chr.current <= 0 && chr.value !== 0).length === 2);
 }
 
-export function getCEAWoundTint(selectedTraveller: Traveller): string {
+export function getCEAWoundTint(selectedTraveller: TwodsixActor): string {
   let returnVal = '';
   const lfbCharacteristic: string = game.settings.get('twodsix', 'lifebloodInsteadOfCharacteristics') ? 'strength' : 'lifeblood';
   const endCharacteristic: string = game.settings.get('twodsix', 'lifebloodInsteadOfCharacteristics') ? 'endurance' : 'stamina';

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -6,6 +6,7 @@ import { TWODSIX } from "../config";
 import TwodsixActor from "../entities/TwodsixActor";
 import { Consumable, Skills } from "../../types/template";
 import TwodsixItem  from "../entities/TwodsixItem";
+import { applyEncumberedEffect } from "../hooks/showStatusIcons";
 //import { wait } from "../utils/sheetUtils";
 
 export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
@@ -267,7 +268,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
       const li = $(event.currentTarget).parents(".item");
       const itemSelected = <TwodsixItem>this.actor.items.get(li.data("itemId"));
       const newState = getNewEquippedState(itemSelected);
-      await itemSelected.toggleActiveEffectStatus(newState !== "equipped");
+      itemSelected.toggleActiveEffectStatus(newState !== "equipped");
 
       //change equipped state after toggling active effects so that encumbrance calcs correctly
       const itemUpdates = [];
@@ -280,9 +281,11 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
           itemUpdates.push({_id: consumableSelected.id, "system.equipped": newState});
         }
       }
-      await this.actor.updateEmbeddedDocuments("Item", itemUpdates, {dontSync: itemSelected.type !== "consumable"});
+      await this.actor.updateEmbeddedDocuments("Item", itemUpdates, {dontSync: true});
       //await wait(100); ///try adding delay to lessen the db error of clicking to fast
-
+      if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators')) {
+        applyEncumberedEffect(this.actor);
+      }
       //check for equipping more than one armor with nonstackable
       if (this.actor.system.layersWorn > 1 && this.actor.system.wearingNonstackable && itemSelected.type === 'armor') {
         ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.WearingMultipleLayers"));

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -284,7 +284,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
       await this.actor.updateEmbeddedDocuments("Item", itemUpdates, {dontSync: true});
       //await wait(100); ///try adding delay to lessen the db error of clicking to fast
       if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators')) {
-        applyEncumberedEffect(this.actor);
+        await applyEncumberedEffect(this.actor);
       }
       //check for equipping more than one armor with nonstackable
       if (this.actor.system.layersWorn > 1 && this.actor.system.wearingNonstackable && itemSelected.type === 'armor') {

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -268,7 +268,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
       const li = $(event.currentTarget).parents(".item");
       const itemSelected = <TwodsixItem>this.actor.items.get(li.data("itemId"));
       const newState = getNewEquippedState(itemSelected);
-      itemSelected.toggleActiveEffectStatus(newState !== "equipped");
+      await itemSelected.toggleActiveEffectStatus(newState !== "equipped", {dontSync: true});
 
       //change equipped state after toggling active effects so that encumbrance calcs correctly
       const itemUpdates = [];

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -221,7 +221,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
 
   private _changeEquipped(event) {
     if (this.item.isEmbedded) {
-      const newDiabledState = $(event.currentTarget).val() !== 'equipped';
+      const newDiabledState = event.currentTarget.value !== 'equipped';
       const updates = [];
       for (const effect of this.item.effects) {
         if (effect.disabled !== newDiabledState) {

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -221,7 +221,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
 
   private _changeEquipped(event) {
     if (this.item.isEmbedded) {
-      const newDiabledState = $(event.currentTarget).val() !== 'equipped' ?? true;
+      const newDiabledState = $(event.currentTarget).val() !== 'equipped';
       for (const effect of this.item.effects) {
         if (effect.disabled !== newDiabledState) {
           effect.update({disabled: newDiabledState});

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -222,10 +222,14 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
   private _changeEquipped(event) {
     if (this.item.isEmbedded) {
       const newDiabledState = $(event.currentTarget).val() !== 'equipped';
+      const updates = [];
       for (const effect of this.item.effects) {
         if (effect.disabled !== newDiabledState) {
-          effect.update({disabled: newDiabledState});
+          updates.push({_id: effect.id, disabled: newDiabledState});
         }
+      }
+      if (updates.length > 0) {
+        this.item.updateEmbeddedDocuments('ActiveEffect', updates);
       }
     }
   }

--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -133,6 +133,7 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
     html.find(`[name="system.isBaseHull"]`).on('change', this._changeIsBaseHull.bind(this));
     html.find(`[name="type"]`).on('change', this._changeType.bind(this));
     html.find(`[name="system.nonstackable"]`).on('change', this._changeNonstackable.bind(this));
+    html.find(`[name="system.equipped"]`).on('change', this._changeEquipped.bind(this));
   }
   private async _changeSubtype(event) {
     event.preventDefault(); //Needed?
@@ -214,6 +215,17 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
       //check for having more than one equipped armor when changing to nonstackable
       if (this.item.actor.system.layersWorn > 1 && newValue && this.item.system.equipped === 'equipped') {
         ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.WearingMultipleLayers"));
+      }
+    }
+  }
+
+  private _changeEquipped(event) {
+    if (this.item.isEmbedded) {
+      const newDiabledState = $(event.currentTarget).val() !== 'equipped' ?? true;
+      for (const effect of this.item.effects) {
+        if (effect.disabled !== newDiabledState) {
+          effect.update({disabled: newDiabledState});
+        }
       }
     }
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)
- Encumbrance isn't checked when directly changing equipped state on item sheet
- Encumbrance check fires too often


* **What is the new behavior (if this is a feature change)?**
- Check encumbrance state when changing equipped state on item sheet
- Try to reduce the number of encumbrance checks


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
