### PR TITLE
fix: can not edit or save  traveller biography field

### DIFF
--- a/src/module/data/character-base.ts
+++ b/src/module/data/character-base.ts
@@ -86,6 +86,7 @@ export class TwodsixActorBaseData extends foundry.abstract.TypeDataModel {
     /* Descriptions */
     schema.description = new fields.HTMLField({...requiredBlankString});
     schema.notes = new fields.HTMLField({...requiredBlankString});
+    schema.bio = new fields.HTMLField({...requiredBlankString});
 
     return schema;
   }

--- a/static/template.json
+++ b/static/template.json
@@ -1,7 +1,7 @@
 {
   "Actor": {
     "types": ["traveller", "ship", "vehicle", "animal", "robot", "space-object"],
-    "htmlFields": ["descriptions", "notes", "contacts", "xpNotes", "cargo"],
+    "htmlFields": ["descriptions", "notes", "bio", "contacts", "xpNotes", "cargo"],
     "traveller": {},
     "animal": {},
     "robot": {},


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Unable to edit/save traveller biography field


* **What is the new behavior (if this is a feature change)?**
Can edit and save Traveller biography


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO


* **Other information**:
