### PR TITLE
fix: missing ship-cargo weights and vehicle-shipping size

### DIFF
--- a/src/module/data/vehicles.ts
+++ b/src/module/data/vehicles.ts
@@ -155,7 +155,7 @@ export class VehicleData extends TwodsixVehicleBaseData {
     schema.openVehicle = new fields.BooleanField({required: true, initial: false});
     schema.traits = new fields.StringField({...requiredBlankString});
     schema.weight = new fields.StringField({...requiredBlankString});
-
+    schema.shippingSize = new fields.StringField({...requiredBlankString});
     return schema;
   }
 }

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -129,7 +129,7 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
       width: 862,
       height: 720,
       resizable: true,
-      tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "skills"}],
+      tabs: [{navSelector: ".actor-sheet-tabs", contentSelector: ".sheet-body", initial: "skills"}],
       scrollY: [".skills", ".inventory", ".finances", ".info", ".effects", ".actor-notes"],
       dragDrop: [{dragSelector: ".item", dropSelector: null}]
     });

--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -75,7 +75,7 @@ export class TwodsixShipSheet extends AbstractTwodsixActorSheet {
       width: 825,
       height: 686,
       resizable: true,
-      tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "ship-positions"}],
+      tabs: [{navSelector: ".actor-sheet-tabs", contentSelector: ".sheet-body", initial: "ship-positions"}],
       scrollY: [".ship-positions", ".ship-crew", ".ship-component", ".ship-storage", ".storage-wrapper", ".finances", ".ship-notes"],
       dragDrop: [
         //{dropSelector: ".ship-positions-list", dragSelector: ".drag"}, UNKNOWN NEED

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2848,6 +2848,10 @@ a.ship-crew-tab.active, a.ship-positions-tab.active , a.ship-storage-tab.active,
   justify-content: space-evenly;
 }
 
+.cargo-weight span.ship-stat.centre {
+  margin-top: 0;
+}
+
 .cargo-list {
   /*margin-top: 1.1em;*/
   /* overflow-y: auto; */

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -276,7 +276,7 @@ table tr:nth-child(even) {
   margin: 8px 2%;
   width: 96%;
 }
-.sheet nav.sheet-tabs {
+.sheet nav.actor-sheet-tabs {
   height: 100%;
   /* flex: 0 0 23px !important; */
   margin: 0 !important;
@@ -308,7 +308,7 @@ table tr:nth-child(even) {
   overflow: hidden;
 }
 
-.sheet nav.sheet-tabs .item {
+.sheet nav.actor-sheet-tabs .item {
   padding: 2px;
   /* border: none; */
   /* border: solid 2px var(--s2d6-default-color); */
@@ -3689,14 +3689,14 @@ div.app.window-app.minimized.twodsix.ship.actor header a.close {
 
 /* TOKEN SHEET */
 
-.token-sheet .sheet-tabs {
+.token-sheet .actor-sheet-tabs {
   flex: 0 0 32px;
   border-bottom: 1px solid var(--s2d6-form-light);
   line-height: 10px;
   /*width: 32.5em;*/
 }
 
-.sheet-tabs {
+.actor-sheet-tabs {
   justify-content: space-around;
   font-size: 2ch;
   text-align: center;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -1042,7 +1042,7 @@ svg:hover {
   align-items: center;
 }
 
-.sheet nav.sheet-tabs{
+.sheet nav.actor-sheet-tabs{
   height: auto !important;
   /* line-height: 100%; */
   text-align: center;
@@ -1054,7 +1054,7 @@ svg:hover {
   /* overflow: hidden; */
 }
 
-.sheet nav.sheet-tabs .item {
+.sheet nav.actor-sheet-tabs .item {
   padding: 2px;
 }
 
@@ -2927,7 +2927,7 @@ div.app.window-app.twodsix.ship.actor header a.close {
 */
 /* TOKEN SHEET */
 /*
-.token-sheet .sheet-tabs {
+.token-sheet .actor-sheet-tabs {
   flex: 0 0 32px;
   border-bottom: 1px solid var(--form-light);
   line-height: 28px !important;

--- a/static/templates/actors/actor-sheet.html
+++ b/static/templates/actors/actor-sheet.html
@@ -67,7 +67,7 @@
     {{#unless limited}}
     {{!-- Sheet Tab Navigation --}}
       <div class="character-tabs">
-        <nav class="sheet-tabs tabs" data-group="primary">
+        <nav class="actor-sheet-tabs tabs" data-group="primary">
           <a class="skill-tab" data-tab="skills" data-tooltip="{{localize 'TWODSIX.Actor.Tabs.SkillsTabTooltip'}}">{{localize "TWODSIX.Actor.Tabs.Skills"}}</a>
           <a class="item-tab" data-tab="inventory" data-tooltip="{{localize 'TWODSIX.Actor.Tabs.InventoryTabTooltip'}}">{{localize "TWODSIX.Actor.Tabs.Inventory"}}</a>
           <a class="finances-tab" data-tab="finances" data-tooltip="{{localize 'TWODSIX.Actor.Tabs.FinancesTabTooltip'}}">{{localize "TWODSIX.Actor.Tabs.Finances"}}</a>

--- a/static/templates/actors/ship-sheet.html
+++ b/static/templates/actors/ship-sheet.html
@@ -68,7 +68,7 @@
     {{/unless}}
     {{!-- Sheet Tab Navigation --}}
       <div class="ship-tabs">
-        <nav class="sheet-tabs tabs" data-group="primary">
+        <nav class="actor-sheet-tabs tabs" data-group="primary">
           <a class="ship-positions-tab" data-tab="ship-positions"><i class="fa-solid fa-street-view"></i><br>{{localize "TWODSIX.Ship.Tabs.ShipPositions"}}</a>
           <a class="ship-crew-tab" data-tab="ship-crew"><i class="fa-solid fa-users"></i><br>{{localize "TWODSIX.Ship.Tabs.Crew"}}</a>
           <a class="ship-component-tab" data-tab="ship-component"><i class="fa-solid fa-gears"></i><br>{{localize "TWODSIX.Ship.Tabs.Components"}}</a>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
cargo weights aren't visible on ship sheet cargo tab
vehicle shipping size can't be saved
AE edit window tabs mis-aligned
* **What is the new behavior (if this is a feature change)?**
cargo weights are visible
vehicle shipping size in schema
align AE window tabs

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
