### PR TITLE
fix: allow zero value for Active Effect Custom

### DIFF
--- a/src/module/hooks/activeEffects.ts
+++ b/src/module/hooks/activeEffects.ts
@@ -13,7 +13,7 @@ import TwodsixActor from "../entities/TwodsixActor";
 //This hook applies CUSTOM active effects values as a formula that is evaluated and not a static
 Hooks.on('applyActiveEffect', (actor:TwodsixActor, change:any, current: any, _delta: any) => {
   //return if current doesn't exist (probably derived value)
-  if (!current) {
+  if (current == undefined) {
     return;
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Custom mode for Active effects don't calculate if initial value zero.


* **What is the new behavior (if this is a feature change)?**
Custom mode for Active effects work correctly if initial value is zero.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
