### PR TITLE
fix: add option to change the damage-stat-color style

### DIFF
--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -51,6 +51,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.general.push(booleanSetting('showFeaturesInChat', false));
     settings.general.push(colorSetting('defaultColor', "#29aae1", "Color", false, 'world', changeDefaultColor));
     settings.general.push(colorSetting('lightColor', "#00e5ff", "Color", false, 'world', changeLightColor));
+    settings.general.push(colorSetting('damageStatColor', "#b52c2c", "Color", false, 'world', changeDamageColor));
     settings.general.push(booleanSetting('showHitsChangesInChat', false));
     settings.token.push(booleanSetting('reduceStatusIcons', false, false, "world", updateStatusIcons));
     settings.general.push(booleanSetting('useTabbedViews', false));
@@ -83,6 +84,13 @@ export const changeLightColor = function () {
     game.settings.set('twodsix', 'lightColor', "#00e5ff");
   }
   document.documentElement.style.setProperty('--s2d6-light-color', game.settings.get('twodsix', 'lightColor'));
+};
+
+export const changeDamageColor = function () {
+  if (game.settings.get('twodsix', 'damageStatColor') === "") {
+    game.settings.set('twodsix', 'damageStatColor', "#b52c2c");
+  }
+  document.documentElement.style.setProperty('--s2d6-damage-stat-color', game.settings.get('twodsix', 'damageStatColor'));
 };
 
 export const updateStatusIcons = function () {

--- a/src/twodsix.ts
+++ b/src/twodsix.ts
@@ -184,6 +184,7 @@ Hooks.once('init', async function () {
     document.documentElement.style.setProperty('--s2d6-default-color',  game.settings.get('twodsix', 'defaultColor'));
     document.documentElement.style.setProperty('--s2d6-light-color', game.settings.get('twodsix', 'lightColor'));
   }
+  document.documentElement.style.setProperty('--s2d6-damage-stat-color', game.settings.get('twodsix', 'damageStatColor'));
 
   if (game.settings.get('twodsix', 'useModuleFixStyle') && !game.settings.get('twodsix', 'useFoundryStandardStyle')) {
     switchCss("systems/twodsix/styles/twodsix_moduleFix.css");

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1355,6 +1355,10 @@
         "hint": "Change the theme highlight color. Delete value to reset.",
         "name": "Set Highlight Color"
       },
+      "damageStatColor": {
+        "hint": "Change the color of characteristic damage on the actor sheet. Delete value to reset.",
+        "name": "Set Characteristic Damage Color"
+      },
       "useItemActiveEffects": {
         "hint": "Use Item Active Effects.  WARNING: may result is odd system behavior.",
         "name": "Use Item Active Effects"

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -27,65 +27,35 @@
 }
 
 :root {
-  --s2d6-default-color:
-  rgba(41, 170, 225, 1);
-  --s2d6-light-color:
-  rgba(0, 229, 255, 1);
-  --s2d6-window-color:
-  rgba(86, 148, 175, 1);
-  --s2d6-background-transparent:
-  rgba(0, 0, 0, 0);
-  --s2d6-background-nearly-transparent:
-  rgba(0, 0, 0, 0.25);
-  --s2d6-background-semi-opaque:
-  rgba(0, 0, 0, 0.5);
-  --s2d6-background-nearly-opaque:
-  rgba(0, 0, 0, 0.75);
-  --s2d6-background-opaque:
-  rgba(0, 0, 0, 1);
-  --s2d6-nav-background:
-  rgb(64 63 63 / 95%);
-  --s2d6-dark-hover:
-  var(--s2d6-background-nearly-opaque);
-  --s2d6-light-background-transparent:
-  rgba(255, 255, 255, 0.09);
-  --s2d6-stat-input:
-  rgb(146 172 213);
-  --s2d6-item-active:
-  var(--s2d6-background-opaque);
-  --s2d6-header-border:
-  rgba(34, 80, 120, 1);
-  --s2d6-form-light:
-  rgb(175, 173, 160, 1);
-  --s2d6-item-border:
-  var(--s2d6-stat-input);
-  --s2d6-skill-list-even:
-  var(--s2d6-light-background-transparent);
-  --s2d6-sidebar-background:
-  var(--s2d6-form-light); /*rgba(130, 129, 125, 1)*/
-  --s2d6-crit-fail:
-  rgba(170, 2, 0, 1);
-  --s2d6-crit-success:
-  rgba(47, 120, 34, 1);
-  --s2d6-dialog-color:
-  rgba(168, 184, 208, 1); /*rgba(162, 188, 228, 1)*/
-  --s2d6-app-color:
-  rgba(240, 240, 224, 1);
-  --s2d6-item-hover:
-  var(--s2d6-app-color); /*rgba(255, 255, 255, 1)*/
-  --s2d6-select-light:
-  var(--s2d6-item-hover);
-  --s2d6-damage-red:
-  rgba(255, 0, 0, 1);
-  --s2d6-damage-stat-color:
-  rgba(181, 44, 44, 1);
-  --s2d6-damage-orange:
-  rgba(255, 153, 0, 1);
-  --s2d6-pie-color:
-  var(--s2d6-default-color);
-  --s2d6-pie-background-color:
-  var(--s2d6-background-opaque);
-  /*--sidebar-width: 318px;*/
+  --s2d6-default-color: rgba(41, 170, 225, 1);
+  --s2d6-light-color: rgba(0, 229, 255, 1);
+  --s2d6-window-color: rgba(86, 148, 175, 1);
+  --s2d6-background-transparent: rgba(0, 0, 0, 0);
+  --s2d6-background-nearly-transparent:rgba(0, 0, 0, 0.25);
+  --s2d6-background-semi-opaque: rgba(0, 0, 0, 0.5);
+  --s2d6-background-nearly-opaque: rgba(0, 0, 0, 0.75);
+  --s2d6-background-opaque: rgba(0, 0, 0, 1);
+  --s2d6-nav-background: rgb(64 63 63 / 95%);
+  --s2d6-dark-hover: var(--s2d6-background-nearly-opaque);
+  --s2d6-light-background-transparent: rgba(255, 255, 255, 0.09);
+  --s2d6-stat-input: rgb(146 172 213);
+  --s2d6-item-active: var(--s2d6-background-opaque);
+  --s2d6-header-border: rgba(34, 80, 120, 1);
+  --s2d6-form-light: rgb(175, 173, 160, 1);
+  --s2d6-item-border: var(--s2d6-stat-input);
+  --s2d6-skill-list-even: var(--s2d6-light-background-transparent);
+  --s2d6-sidebar-background: var(--s2d6-form-light); /*rgba(130, 129, 125, 1)*/
+  --s2d6-damage-stat-color: rgba(181, 44, 44, 1);
+  --s2d6-crit-fail: rgba(170, 2, 0, 1);
+  --s2d6-crit-success: rgba(47, 120, 34, 1);
+  --s2d6-dialog-color: rgba(168, 184, 208, 1); /*rgba(162, 188, 228, 1)*/
+  --s2d6-app-color: rgba(240, 240, 224, 1);
+  --s2d6-item-hover: var(--s2d6-app-color); /*rgba(255, 255, 255, 1)*/
+  --s2d6-select-light: var(--s2d6-item-hover);
+  --s2d6-damage-red: rgba(255, 0, 0, 1);
+  --s2d6-damage-orange: rgba(255, 153, 0, 1);
+  --s2d6-pie-color: var(--s2d6-default-color);
+  --s2d6-pie-background-color: var(--s2d6-background-opaque);
 }
 
 body {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix


* **What is the current behavior?** (You can also link to an open issue here)
Color of the damage fields on actor sheet isn't easily changes and not suited to folks with color issues/


* **What is the new behavior (if this is a feature change)?**
New setting to change the value of these fields.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
