### PR TITLE
fix: finance edit box size

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -456,7 +456,7 @@ export default class TwodsixActor extends Actor {
     let maxEncumbrance = 0;
     const encumbFormula = game.settings.get('twodsix', 'maxEncumbrance');
     if (Roll.validate(encumbFormula)) {
-      maxEncumbrance = Roll.safeEval(Roll.replaceFormulaData(encumbFormula, this.getRollData()));
+      maxEncumbrance = Roll.safeEval(Roll.replaceFormulaData(encumbFormula, this.getRollData(), {missing: "0", warn: false}));
     }
     return Math.max(maxEncumbrance, 0);
   }

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -183,6 +183,11 @@ export default class TwodsixActor extends Actor {
       if (deltaHits !== 0) {
         //console.log ('need to update wounded status');
         Object.assign(options, {deltaHits: deltaHits});
+        if (game.modules.get('splatter')?.active) {
+          //A hack to get splatter to work correctly - it doesn't respect derived data
+          const newHits = Math.clamp((this.system.hits.value - deltaHits), 0, this.system.hits.max);
+          foundry.utils.mergeObject(data, {'system.hits.value': newHits});
+        }
       }
     }
 

--- a/src/module/hooks/diceTrayIntegration.ts
+++ b/src/module/hooks/diceTrayIntegration.ts
@@ -1,6 +1,7 @@
+// DICE TRAY no longer supports custom buttons through a simple API as of V12
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
-import { getKeyByValue } from "../utils/sheetUtils";
+/*import { getKeyByValue } from "../utils/sheetUtils";
 import { simplifySkillName } from "../utils/utils";
 import {TWODSIX} from "../config";
 
@@ -70,4 +71,4 @@ Hooks.on('dice-calculator.calculator', (calculators, Template) => {
     }
   }
   calculators.twodsix = twodsixDiceCalculator;
-});
+});*/

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2963,10 +2963,10 @@ div.ship-value {
   height: 74%;
 }
 
-.ship-financial-notes {
+/*.ship-financial-notes {
   display: grid;
   grid-template-rows: 4fr 1fr;
-}
+}*/
 
 .ship-commonFunds input[type="number"] {
   border: 1px solid var(--s2d6-default-color);
@@ -2976,10 +2976,14 @@ div.ship-value {
 .ship-financial-notes div[contenteditable], .ship-financial-notes .editor {
   border: 1px solid var(--s2d6-default-color);
   /* width: 107%; */
-  min-height: min-content;
+  height: 31ch;
   border-radius: 0;
   overflow-y: auto;
   padding: 0.2em;
+}
+
+.ship-common-funds {
+  margin-top: 3ch;
 }
 
 /*-------------------------------------------------*/

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2428,11 +2428,11 @@ div.ship-value {
   height: 63%;
 }
 
-.ship-financial-notes {
+/*.ship-financial-notes {
   display: grid;
   grid-template-rows: 4fr 1fr;
   gap: 2ch;
-}
+}*/
 
 .ship-commonFunds input[type="number"] {
   border: 1px solid;
@@ -2442,13 +2442,16 @@ div.ship-value {
 .ship-financial-notes div[contenteditable], .ship-financial-notes .editor {
   border: 1px solid var(--color-border-light-tertiary);
   background-color: var(--s2d6-input-background) !important;
-  width: 60ch;
-  height: 33ch;
+  width: 75ch;
+  height: 35ch;
   border-radius: 0 3px 3px;
   overflow-y: auto;
   padding: 0.2em;
 }
 
+.ship-common-funds {
+  margin-top: 3ch;
+}
 
 /*-------------------------------------------------*/
 

--- a/static/templates/actors/parts/ship/ship-finance.html
+++ b/static/templates/actors/parts/ship/ship-finance.html
@@ -1,6 +1,6 @@
 <div class="ship-finances-container">
-  <div class="ship-financial-notes">
-    <div>
+  <div>
+    <div class="ship-financial-notes">
       <span class="item-title">{{localize "TWODSIX.Ship.FINANCENOTES"}}</span>
       {{#if settings.useProseMirror}}
       {{editor richText.finances target="system.finances" button=true owner=owner editable=editable async=true engine="prosemirror" collaborate=true}}
@@ -8,7 +8,7 @@
         <div contenteditable="true" data-edit="system.finances">{{#if actor.system.finances}}{{{actor.system.finances}}}{{/if}}</div>
       {{/if}}
     </div>
-    <div>
+    <div class="ship-common-funds">
       <span class="item-title">{{localize "TWODSIX.Ship.COMMONFUNDS"}}</span>
       <span class="ship-commonFunds"><input type="number" value="{{actor.system.commonFunds}}" name="system.commonFunds" /> {{localize "TWODSIX.Ship.MCr"}}</span>
     </div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
If not using prosemirror, finance notes area a single line in height.


* **What is the new behavior (if this is a feature change)?**
Fix box height to a set number of characters


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
