### PR TITLE
fix: actor image on traveller sheet too small for firefox

### DIFF
--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
 import AdvancedSettings from "./AdvancedSettings";
-import {booleanSetting, colorSetting, stringChoiceSetting, stringSetting} from "./settingsUtils";
+import {booleanSetting, colorSetting, stringChoiceSetting, stringSetting, numberSetting} from "./settingsUtils";
 import {TWODSIX} from "../config";
 
 export default class DisplaySettings extends AdvancedSettings {
@@ -64,6 +64,8 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.ship.push(booleanSetting('showCost', false));
     settings.actor.push(booleanSetting('showTotalArmor', false));
     settings.general.push(booleanSetting('showItemIconsInChat', true));
+    settings.actor.push(numberSetting('defaultActorSheetWidth', 900, false, 'world', refreshWindow));
+    settings.actor.push(numberSetting('defaultActorSheetHeight', 780, false, 'world', refreshWindow));
     return settings;
   }
 }

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -127,8 +127,8 @@ export class TwodsixActorSheet extends AbstractTwodsixActorSheet {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["twodsix", "sheet", "actor"],
       template: "systems/twodsix/templates/actors/actor-sheet.html",
-      width: 862,
-      height: 720,
+      width: game.settings.get('twodsix', 'defaultActorSheetWidth'),
+      height: game.settings.get('twodsix', 'defaultActorSheetHeight'),
       resizable: true,
       tabs: [{navSelector: ".actor-sheet-tabs", contentSelector: ".sheet-body", initial: "skills"}],
       scrollY: [".skills", ".character-inventory", ".inventory", ".finances", ".info", ".effects", ".actor-notes"],

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1496,6 +1496,14 @@
       "chainBonus": {
         "hint": "The roll DM for chain rolls (or aiding another) based on the previous roll's effect.  This configuration string is formated as comma separated integers.  The sequence is based on effect values:  <=-6, -5 to -2, -1, 0 , 1 to 5, >=6.  So for Cepheus Engine, the configuration string would be '-2, -1, -1, 1, 1, 2'. Note if there are not six integers entered the chain bonus is zero.",
         "name": "Assisted/Chain Roll DM"
+      },
+      "defaultActorSheetWidth": {
+        "hint": "The initial default actor sheet width when opening after startup - in pixels.  WARNING: changing this setting will reload the world.",
+        "name": "Initial Width of Actor Sheet"
+      },
+      "defaultActorSheetHeight": {
+        "hint": "The initial default actor sheet height when opening after startup - in pixels. WARNING: changing this setting will reload the world.",
+        "name": "Initial Height of Actor Sheet"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1498,12 +1498,12 @@
         "name": "Assisted/Chain Roll DM"
       },
       "defaultActorSheetWidth": {
-        "hint": "The initial default actor sheet width when opening after startup - in pixels.  WARNING: changing this setting will reload the world.",
-        "name": "Initial Width of Actor Sheet"
+        "hint": "The default Traveller sheet width when opening after startup - in pixels.  WARNING: changing this setting will reload the world.",
+        "name": "Default Width of Traveller Sheet"
       },
       "defaultActorSheetHeight": {
-        "hint": "The initial default actor sheet height when opening after startup - in pixels. WARNING: changing this setting will reload the world.",
-        "name": "Initial Height of Actor Sheet"
+        "hint": "The default Traveller sheet height when opening after startup - in pixels. WARNING: changing this setting will reload the world.",
+        "name": "Default Height of Traveller Sheet"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -438,6 +438,8 @@ h2 {
   /* flex-wrap: nowrap; */
   justify-content: space-between;
   grid-template-rows: 4% 39% 4.6% 19.2% 22.2%;
+  width: 100%;
+  width: -moz-available;
   width: -webkit-fill-available;
 }
 

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -900,6 +900,7 @@ h2 {
   /* height: auto; */
   grid-area: character-photo;
   /* width: -webkit-fill-available; */
+  overflow: hidden;
 }
 
 .character-photo img {

--- a/static/system.json
+++ b/static/system.json
@@ -26,7 +26,7 @@
   "compatibility":
     {
       "minimum": "12",
-      "verified": "12.329"
+      "verified": "12.331"
     },
   "description": "Twodsix: A system for use with the Cepheus Engine Core Rules, Traveller (unofficial), and other similar games. <br/>This Product is derived from the Traveller System Reference Document and other Open Gaming Content made available by the Open Gaming License, and does not contain closed content from products published by either Mongoose Publishing or Far Future Enterprises. This Product is not affiliated with either Mongoose Publishing or Far Future Enterprises, and it makes no claim to or challenge to any trademarks held by either entity. The use of the Traveller System Reference Document does not convey the endorsement of this Product by either Mongoose Publishing or Far Future Enterprises as a product of either of their product lines.<br/>Cepheus Engine and Samardan Press™ are the trademarks of Jason \"Flynn\" Kemp; we are not affiliated with Jason \"Flynn\" Kemp or Samardan Press™.<br/> See the files OpenGameLicense.md and LICENSE for license details.<br/>",
   "esmodules": ["twodsix.bundle.js"],

--- a/static/system.json
+++ b/static/system.json
@@ -336,9 +336,6 @@
   ],
   "primaryTokenAttribute": "hits",
   "styles": [],
-  "templateVersion": 2,
-  "manifestPlusVersion": "1.0.0",
-  "allowBugReporter": true,
   "bugs": "https://github.com/xdy/twodsix-foundryvtt/issues",
   "media": [
     {
@@ -360,6 +357,8 @@
     "hotReload": {
       "extensions": ["css", "html", "hbs", "json"],
       "paths": ["twodsix.css", "templates", "lang", "styles"]
-    }
+    },
+    "manifestPlusVersion": "1.0.0",
+    "allowBugReporter": true
   }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fixes


* **What is the current behavior?** (You can also link to an open issue here)
Small image disrupt alignment of Traveller sheet for Firefox
System manifest contains legacy items
User can't adjust default sizes for Traveller sheets

* **What is the new behavior (if this is a feature change)?**
Set a width so that small images display correctly for Firefox
Move legacy items into flags or delete unnecessary ones.
Add setting for default traveller sheet width and height

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
