### PR TITLE
fix: double tap not correct for CD, CLU, CEL

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -433,7 +433,7 @@ const RULESETS = Object.freeze({
       difficultyListUsed: "CE",
       difficultiesAsTargetNumber: true,
       autofireRulesUsed: "CEL",
-      ShowDoubleTap: true,
+      ShowDoubleTap: false,
       modifierForZeroCharacteristic: -2,
       termForAdvantage: "advantage",
       termForDisadvantage: "disadvantage",

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -368,6 +368,7 @@ export default class TwodsixItem extends Item {
    * @returns {any} { weaponType, isAutoFull, usedAmmo, numberOfAttacks }
    */
   private getFireModeParams( rateOfFireCE: number, attackType: string, tmpSettings: any): any {
+    const ruleSet = game.settings.get("twodsix", "ruleset");
     const weapon:Weapon = <Weapon>this.system;
     let numberOfAttacks = 1;
     let bonusDamage = "0";
@@ -399,12 +400,12 @@ export default class TwodsixItem extends Item {
         if (autoFireRules === 'CEL') {
           usedAmmo = 3 * rateOfFire;
         }
-        skillLevelMax = game.settings.get("twodsix", "ruleset") === "CDEE" ? 1 : undefined; //special rule for CD-EE
+        skillLevelMax = ruleSet === "CDEE" ? 1 : undefined; //special rule for CD-EE
         isAutoFull = true;
         break;
       case "auto-burst":
         if (autoFireRules !== 'CT') {
-          bonusDamage = game.settings.get("twodsix", "ruleset") === "CDEE" ? `${rateOfFire}d6kh` : rateOfFire.toString(); //special rule for CD-EE
+          bonusDamage = ruleSet === "CDEE" ? `${rateOfFire}d6kh` : rateOfFire.toString(); //special rule for CD-EE
         }
         break;
       case "burst-attack-dm":
@@ -414,7 +415,14 @@ export default class TwodsixItem extends Item {
         bonusDamage = TwodsixItem.burstBonusDamage(rateOfFire);
         break;
       case "double-tap":
-        Object.assign(tmpSettings.rollModifiers, { rof: 1 });
+        //Need to assign as bonus damage or rof bonus depending on rules
+        if ( ['CD', 'CLU'].includes(ruleSet)) {
+          bonusDamage = "1d6";
+        } else if (['AC', 'CEL'].includes(ruleSet)) {
+          bonusDamage = "1";
+        } else {
+          Object.assign(tmpSettings.rollModifiers, { rof: 1 });
+        }
         usedAmmo = 2;
         break;
     }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fixes


* **What is the current behavior?** (You can also link to an open issue here)
double tap adds bonus to attack roll and not damage


* **What is the new behavior (if this is a feature change)?**
have double tap apply correct bonuses


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
