### PR TITLE
feat: add setting to omit alt characteristics that are zero

### DIFF
--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -58,6 +58,7 @@ export default class DisplaySettings extends AdvancedSettings {
     settings.actor.push(booleanSetting('showAllCharWithTable', true));
     settings.general.push(booleanSetting('showTLonItemsTab', false, false, 'world', setDocumentPartials));
     settings.actor.push(booleanSetting('omitPSIifZero', false));
+    settings.actor.push(booleanSetting('omitALTifZero', false));
     settings.actor.push(stringChoiceSetting('equippedToggleStates', "default", true, TWODSIX.EQUIPPED_TOGGLE_OPTIONS));
     settings.actor.push(booleanSetting('showSkillGroups', false));
     settings.ship.push(stringSetting('jDriveLabel', "TWODSIX.Ship.JDrive", false, "world", updateJDrive, true));

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -390,15 +390,14 @@ export function getDisplayOrder(returnData: any): string[] {
       const altList = ['alternative1', 'alternative2', 'alternative3'];
       if (charMode === 'alternate') {
         altList.pop();
+      } else {
+        altList.push('psionicStrength');
       }
+
       for (const key of altList) {
-        if (returnData.system.characteristics[key].value !== 0 || !game.settings.get('twodsix', 'omitALTifZero')) {
+        const displaySetting = key === 'psionicStrength' ? game.settings.get('twodsix', 'omitPSIifZero') : game.settings.get('twodsix', 'omitALTifZero');
+        if (returnData.system.characteristics[key].value !== 0 || !displaySetting) {
           returnValue.push(key);
-        }
-      }
-      if (charMode === 'all') {
-        if (returnData.system.characteristics.psionicStrength.value !== 0 || !game.settings.get('twodsix', 'omitPSIifZero')) {
-          returnValue.push('psionicStrength');
         }
       }
       break;

--- a/src/module/sheets/TwodsixActorSheet.ts
+++ b/src/module/sheets/TwodsixActorSheet.ts
@@ -354,9 +354,12 @@ export class TwodsixNPCSheet extends TwodsixActorSheet {
 
 export function setCharacteristicDisplay(returnData: object): void {
   const charMode = game.settings.get('twodsix', 'showAlternativeCharacteristics');
-  returnData.system.characteristics.alternative1.displayChar = ['alternate', 'all'].includes(charMode);
-  returnData.system.characteristics.alternative2.displayChar = ['alternate', 'all'].includes(charMode);
-  returnData.system.characteristics.alternative3.displayChar = ['all'].includes(charMode);
+  returnData.system.characteristics.alternative1.displayChar = ['alternate', 'all'].includes(charMode) &&
+        (returnData.system.characteristics.alternative1.value !== 0 || !game.settings.get('twodsix', 'omitALTifZero'));
+  returnData.system.characteristics.alternative2.displayChar = ['alternate', 'all'].includes(charMode) &&
+        (returnData.system.characteristics.alternative2.value !== 0 || !game.settings.get('twodsix', 'omitALTifZero'));
+  returnData.system.characteristics.alternative3.displayChar = ['all'].includes(charMode) &&
+        (returnData.system.characteristics.alternative3.value !== 0 || !game.settings.get('twodsix', 'omitALTifZero'));
   returnData.system.characteristics.dexterity.displayChar = true;
   returnData.system.characteristics.education.displayChar = true;
   returnData.system.characteristics.endurance.displayChar = true;
@@ -382,14 +385,24 @@ export function getDisplayOrder(returnData: any): string[] {
       }
       break;
     case 'alternate':
-      returnValue.push('alternative1', 'alternative2');
-      break;
     case 'all':
-      returnValue.push('alternative1', 'alternative2', 'alternative3');
-      if (returnData.system.characteristics.psionicStrength.value !== 0 || !game.settings.get('twodsix', 'omitPSIifZero')) {
-        returnValue.push('psionicStrength');
+    {
+      const altList = ['alternative1', 'alternative2', 'alternative3'];
+      if (charMode === 'alternate') {
+        altList.pop();
+      }
+      for (const key of altList) {
+        if (returnData.system.characteristics[key].value !== 0 || !game.settings.get('twodsix', 'omitALTifZero')) {
+          returnValue.push(key);
+        }
+      }
+      if (charMode === 'all') {
+        if (returnData.system.characteristics.psionicStrength.value !== 0 || !game.settings.get('twodsix', 'omitPSIifZero')) {
+          returnValue.push('psionicStrength');
+        }
       }
       break;
+    }
     default:
       break;
   }

--- a/src/types/twodsix.d.ts
+++ b/src/types/twodsix.d.ts
@@ -150,6 +150,7 @@ declare global {
       'twodsix.defaultCompendiumPartial': string;
       'twodsix.showTLonItemsTab': boolean;
       'twodsix.omitPSIifZero': boolean;
+      'twodsix.omitALTifZero': boolean;
       'twodsix.rangeModifierType': string;
       'twodsix.equippedToggleStates': string;
       'twodsix.targetDMList': string;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1459,12 +1459,12 @@
         "name": "Display Tech Level in Compendium and Item Tab lists"
       },
       "omitPSIifZero": {
-        "hint": "Does not display PSI characteristic if value set to zero.",
-        "name": "Omit PSI from actor sheets if value zero"
+        "hint": "Hides psionic strength characteristic if value set to zero.",
+        "name": "Omit PSI characteristic from actor sheets if value zero"
       },
       "omitALTifZero": {
-        "hint": "Does not display ALT characteristic if value set to zero.",
-        "name": "Omit Alternative from actor sheets if value zero"
+        "hint": "Hides alternative characteristics if value set to zero.",
+        "name": "Omit ALT characteristics from actor sheets if value zero"
       },
       "rangeModifierType": {
         "hint": "Type of modifier to use for ranged weapons. Single Range Value (e.g. XX, for MgT2). Double Range Value (e.g. XX/YY for CD, CDEE, CQ, etc.). Range Bands by weapon type (e.g. 'Shotgun' for CE and MgT1).",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1462,6 +1462,10 @@
         "hint": "Does not display PSI characteristic if value set to zero.",
         "name": "Omit PSI from actor sheets if value zero"
       },
+      "omitALTifZero": {
+        "hint": "Does not display ALT characteristic if value set to zero.",
+        "name": "Omit Alternative from actor sheets if value zero"
+      },
       "rangeModifierType": {
         "hint": "Type of modifier to use for ranged weapons. Single Range Value (e.g. XX, for MgT2). Double Range Value (e.g. XX/YY for CD, CDEE, CQ, etc.). Range Bands by weapon type (e.g. 'Shotgun' for CE and MgT1).",
         "name": "Range Modifier Types for Weapons"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
ALT characteristics are always displayed when enabled


* **What is the new behavior (if this is a feature change)?**
Setting to hide ALT characteristics when value is zero


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
