### PR TITLE
fix:  encumbrance indicator doubling on status change

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -423,7 +423,8 @@ const RULESETS = Object.freeze({
       armorDamageFormula: "@damage - @effectiveArmor",
       addEffectToDamage: true,
       weightModifierForWornArmor: "1",
-      chainBonus: "0, 0, 0, 1, 1, 1"
+      chainBonus: "0, 0, 0, 1, 1, 1",
+      reverseHealingOrder: true
     }
   },
   CDEE: {
@@ -476,7 +477,8 @@ const RULESETS = Object.freeze({
       armorDamageFormula: "@damage - @effectiveArmor",
       addEffectToDamage: true,
       weightModifierForWornArmor: "1",
-      chainBonus: "0, 0, 0, 1, 1, 1"
+      chainBonus: "0, 0, 0, 1, 1, 1",
+      reverseHealingOrder: true
     }
   },
   CLU: {
@@ -529,7 +531,8 @@ const RULESETS = Object.freeze({
       armorDamageFormula: "@damage - @effectiveArmor",
       addEffectToDamage: true,
       weightModifierForWornArmor: "1",
-      chainBonus: "0, 0, 0, 1, 1, 1"
+      chainBonus: "0, 0, 0, 1, 1, 1",
+      reverseHealingOrder: true
     }
   },
   SOC: {

--- a/src/module/entities/TwodsixActiveEffect.ts
+++ b/src/module/entities/TwodsixActiveEffect.ts
@@ -35,7 +35,7 @@ export class TwodsixActiveEffect extends ActiveEffect {
    * @see {Document#_onCreate}
    * @override
    */
-  async _onCreate(data: object, options: object, userId: string): void {
+  async _onCreate(data: object, options: object, userId: string):void {
     await super._onCreate(data, options, userId);
     if(game.userId === userId  && this.parent?.type === 'traveller') {
       await checkEncumbranceStatus(this);
@@ -51,7 +51,7 @@ export class TwodsixActiveEffect extends ActiveEffect {
    * @see {Document#_onUpdate}
    * @override
    */
-  async _onUpdate(changed: object, options: object, userId: string) {
+  async _onUpdate(changed: object, options: object, userId: string):void {
     await super._onUpdate(changed, options, userId);
     if(game.userId === userId  && this.parent?.type === 'traveller') {
       await checkEncumbranceStatus(this);
@@ -66,7 +66,7 @@ export class TwodsixActiveEffect extends ActiveEffect {
    * @see {Document#_onDelete}
    * @override
    */
-  async _onDelete(options: object, userId: string): void {
+  async _onDelete(options: object, userId: string):void {
     await super._onDelete(options, userId);
     if(game.userId === userId && this.parent?.type === 'traveller') {
       await checkEncumbranceStatus(this);
@@ -99,7 +99,7 @@ async function checkEncumbranceStatus (activeEffect:TwodsixActiveEffect):void {
  * @returns {boolean} Whether the effect could change encumbrance status
  */
 function changesEncumbranceStat(activeEffect:TwodsixActiveEffect):boolean {
-  if (activeEffect.changes.length > 0){
+  if (activeEffect.changes.length > 0) {
     for (const change of activeEffect.changes) {
       if (change.key.includes('system.characteristics.strength.value')  ||
           change.key.includes('system.characteristics.strength.current') ||

--- a/src/module/entities/TwodsixActiveEffect.ts
+++ b/src/module/entities/TwodsixActiveEffect.ts
@@ -80,14 +80,13 @@ export class TwodsixActiveEffect extends ActiveEffect {
  * @returns {void}
  */
 async function checkEncumbranceStatus (activeEffect:TwodsixActiveEffect):void {
-  if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') && changesEncumbranceStat(activeEffect)) {
+  if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') && (changesEncumbranceStat(activeEffect) || activeEffect.statuses.has('dead'))) {
     if (activeEffect.statuses.size === 0 ) {
       await applyEncumberedEffect(activeEffect.parent);
     } else {
       const notEncumbered = !activeEffect.statuses.has('encumbered');
       const notUnc = !activeEffect.statuses.has('unconscious');
-      const notDead = !activeEffect.statuses.has('dead');
-      if (notEncumbered && notUnc && notDead) {
+      if (notEncumbered && notUnc) {
         await applyEncumberedEffect(activeEffect.parent);
       }
     }

--- a/src/module/entities/TwodsixActiveEffect.ts
+++ b/src/module/entities/TwodsixActiveEffect.ts
@@ -58,17 +58,20 @@ export class TwodsixActiveEffect extends ActiveEffect {
 
   }
 }
-
+/**
+ * Calls applyEncumberedEffect if active effect could change encumbered status
+ * @param {TwodsixActiveEffect} activeEffect  The active effect being changed
+ * @returns {void}
+ */
 async function checkEncumbranceStatus (activeEffect:TwodsixActiveEffect):void {
   if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') && changesEncumbranceStat(activeEffect)) {
     if (activeEffect.statuses.size === 0 ) {
       await applyEncumberedEffect(activeEffect.parent);
     } else {
-      const notEncumbered= !activeEffect.statuses.has('encumbered');
-      const notWounded = !activeEffect.statuses.has('wounded');
+      const notEncumbered = !activeEffect.statuses.has('encumbered');
       const notUnc = !activeEffect.statuses.has('unconscious');
       const notDead = !activeEffect.statuses.has('dead');
-      if (notEncumbered && notWounded && notUnc && notDead) {
+      if (notEncumbered && notUnc && notDead) {
         await applyEncumberedEffect(activeEffect.parent);
       }
     }

--- a/src/module/entities/TwodsixActiveEffect.ts
+++ b/src/module/entities/TwodsixActiveEffect.ts
@@ -88,7 +88,7 @@ function changesEncumbranceStat(activeEffect:TwodsixActiveEffect):boolean {
       if (change.key.includes('system.characteristics.strength.value')  ||
           change.key.includes('system.characteristics.strength.current') ||
           change.key.includes('system.characteristics.strength.mod') ||
-          change.key.includes('system.characteristics.endurance.value') ||
+          (change.key.includes('system.characteristics.endurance.value') && ['CEATOM', "BARBARIC"].includes(game.settings.get('twodsix', 'ruleset'))) ||
           change.key.includes('system.encumbrance.max') ||
           change.key.includes('system.encumbrance.value')) {
         return true;

--- a/src/module/entities/TwodsixActiveEffect.ts
+++ b/src/module/entities/TwodsixActiveEffect.ts
@@ -33,7 +33,7 @@ export class TwodsixActiveEffect extends ActiveEffect {
    * @param {object} options            Additional options which modify the creation request
    * @param {string} userId             The id of the User requesting the document update
    * @see {Document#_onCreate}
-   * @protected
+   * @override
    */
   async _onCreate(data: object, options: object, userId: string): void {
     await super._onCreate(data, options, userId);
@@ -49,9 +49,9 @@ export class TwodsixActiveEffect extends ActiveEffect {
    * @param {object} options            Additional options which modify the update request
    * @param {string} userId             The id of the User requesting the document update
    * @see {Document#_onUpdate}
-   * @protected
+   * @override
    */
-  async _onUpdate(changed, options, userId) {
+  async _onUpdate(changed: object, options: object, userId: string) {
     await super._onUpdate(changed, options, userId);
     if(game.userId === userId  && this.parent?.type === 'traveller') {
       await checkEncumbranceStatus(this);
@@ -64,7 +64,7 @@ export class TwodsixActiveEffect extends ActiveEffect {
    * @param {object} options            Additional options which modify the deletion request
    * @param {string} userId             The id of the User requesting the document update
    * @see {Document#_onDelete}
-   * @protected
+   * @override
    */
   async _onDelete(options: object, userId: string): void {
     await super._onDelete(options, userId);
@@ -74,6 +74,7 @@ export class TwodsixActiveEffect extends ActiveEffect {
 
   }
 }
+
 /**
  * Calls applyEncumberedEffect if active effect could change encumbered status
  * @param {TwodsixActiveEffect} activeEffect  The active effect being changed

--- a/src/module/entities/TwodsixActiveEffect.ts
+++ b/src/module/entities/TwodsixActiveEffect.ts
@@ -43,6 +43,22 @@ export class TwodsixActiveEffect extends ActiveEffect {
   }
 
   /**
+   * Perform follow-up operations after a Document of this type is updated.
+   * Post-update operations occur for all clients after the update is broadcast.
+   * @param {object} changed            The differential data that was changed relative to the documents prior values
+   * @param {object} options            Additional options which modify the update request
+   * @param {string} userId             The id of the User requesting the document update
+   * @see {Document#_onUpdate}
+   * @protected
+   */
+  async _onUpdate(changed, options, userId) {
+    await super._onUpdate(changed, options, userId);
+    if(game.userId === userId  && this.parent?.type === 'traveller') {
+      await checkEncumbranceStatus(this);
+    }
+  }
+
+  /**
    * Perform follow-up operations after a Document of this type is deleted.
    * Post-deletion operations occur for all clients after the deletion is broadcast.
    * @param {object} options            Additional options which modify the deletion request

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -224,8 +224,8 @@ export default class TwodsixActor extends Actor {
           await applyWoundedEffect(this);
         }
       }
-      if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') ) {
-        if (changed.system?.characteristics && (this.type === 'traveller') ) {
+      if (game.settings.get('twodsix', 'useEncumbranceStatusIndicators') && (this.type === 'traveller')) {
+        if (isEncumbranceChange(changed)) {
           await applyEncumberedEffect(this);
         }
       }
@@ -1414,4 +1414,11 @@ function buildUntrainedSkillData(): any {
   };
 }
 
-
+function isEncumbranceChange(changed:object): boolean {
+  if (changed.system?.characteristics?.strength) {
+    return true;
+  } else if (changed.system?.characteristics?.endurance && ['CEATOM', "BARBARIC"].includes(game.settings.get('twodsix', 'ruleset'))) {
+    return true;
+  }
+  return false;
+}

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -9,7 +9,6 @@ import {onPasteStripFormatting} from "../sheets/AbstractTwodsixItemSheet";
 import { getRollTypeSelectObject } from "../utils/sheetUtils";
 import { openPDFReference, deletePDFReference } from "../utils/sheetUtils";
 import { sortObj } from "../utils/utils";
-import { applyEncumberedEffect } from "../utils/showStatusIcons";
 import { TwodsixActiveEffect } from "../entities/TwodsixActiveEffect";
 
 export abstract class AbstractTwodsixActorSheet extends ActorSheet {
@@ -617,9 +616,6 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
       const selectedEffect:TwodsixActiveEffect = await fromUuid(event.currentTarget["dataset"].uuid);
       if (selectedEffect) {
         await selectedEffect.update({disabled: !selectedEffect.disabled});
-        if (this.actor?.type === 'traveller' && game.settings.get('twodsix', 'useEncumbranceStatusIndicators')) {
-          applyEncumberedEffect(this.actor); //a hack for encumbrance not resetting on change of effect
-        }
       }
     } else if (action === "create") {
       await this.actor.createEmbeddedDocuments("ActiveEffect", [{

--- a/src/module/utils/showStatusIcons.ts
+++ b/src/module/utils/showStatusIcons.ts
@@ -88,13 +88,15 @@ export async function applyEncumberedEffect(selectedActor: TwodsixActor): Promis
   let idToKeep = "";
   const maxEncumbrance = selectedActor.system.encumbrance.max; //selectedActor.getMaxEncumbrance()
 
-  //Determined whether encumbered
-  if (maxEncumbrance === 0 && selectedActor.system.encumbrance.value > 0) {
-    state = true;
-    ratio = 1;
-  } else if (maxEncumbrance > 0) {
-    ratio = /*selectedActor.getActorEncumbrance()*/ selectedActor.system.encumbrance.value / maxEncumbrance;
-    state = (ratio > parseFloat(game.settings.get('twodsix', 'encumbranceFraction'))); //remove await
+  //Determined whether encumbered if not dead
+  if (selectedActor.system.hits.value > 0) {
+    if (maxEncumbrance === 0 && selectedActor.system.encumbrance.value > 0) {
+      state = true;
+      ratio = 1;
+    } else if (maxEncumbrance > 0) {
+      ratio = /*selectedActor.getActorEncumbrance()*/ selectedActor.system.encumbrance.value / maxEncumbrance;
+      state = (ratio > parseFloat(game.settings.get('twodsix', 'encumbranceFraction'))); //remove await
+    }
   }
 
   // Delete encumbered AE's if uneeded or more than one
@@ -166,20 +168,20 @@ async function checkUnconsciousness(selectedActor: TwodsixActor, oldWoundState: 
   if (!isAlreadyUnconscious && !isAlreadyDead) {
     if (['CE', 'AC', 'OTHER'].includes(rulesSet)) {
       if (isUnconsciousCE(<Traveller>selectedActor.system)) {
-        setConditionState('unconscious', selectedActor, true);
+        await setConditionState('unconscious', selectedActor, true);
       }
     } else if (['CT'].includes(rulesSet)) {
       if (oldWoundState === undefined && [DAMAGECOLORS.minorWoundTint, DAMAGECOLORS.seriousWoundTint].includes(tintToApply)) {
-        setConditionState('unconscious', selectedActor, true); // Automatic unconsciousness or out of combat
+        await setConditionState('unconscious', selectedActor, true); // Automatic unconsciousness or out of combat
       }
     } else if (oldWoundState?.tint.css !== DAMAGECOLORS.seriousWoundTint && tintToApply === DAMAGECOLORS.seriousWoundTint) {
       if (['CEQ', 'CEATOM', 'BARBARIC'].includes(rulesSet)) {
-        setConditionState('unconscious', selectedActor, true); // Automatic unconsciousness or out of combat
+        await setConditionState('unconscious', selectedActor, true); // Automatic unconsciousness or out of combat
       } else {
         const setDifficulty = Object.values(TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))]).find(e => e.target=== 8); //always 8+
         const returnRoll = await selectedActor.characteristicRoll({ rollModifiers: {characteristic: 'END'}, difficulty: setDifficulty}, false);
         if (returnRoll && returnRoll.effect < 0) {
-          setConditionState('unconscious', selectedActor, true);
+          await setConditionState('unconscious', selectedActor, true);
         }
       }
     }
@@ -269,7 +271,7 @@ async function setWoundedState(targetActor: TwodsixActor, state: boolean, tint: 
     }
     //
     if (!currentEffectId) {
-      targetActor.createEmbeddedDocuments("ActiveEffect", [{
+      await targetActor.createEmbeddedDocuments("ActiveEffect", [{
         name: game.i18n.localize(effectType.wounded),
         img: "icons/svg/blood.svg",
         tint: tint,
@@ -279,7 +281,7 @@ async function setWoundedState(targetActor: TwodsixActor, state: boolean, tint: 
     } else {
       const currentEfffect = targetActor.effects.get(currentEffectId);
       if (currentEfffect.tint !== tint) {
-        targetActor.updateEmbeddedDocuments('ActiveEffect', [{ _id: currentEffectId, tint: tint, changes: [changeData] }]);
+        await targetActor.updateEmbeddedDocuments('ActiveEffect', [{ _id: currentEffectId, tint: tint, changes: [changeData] }]);
       }
     }
   }

--- a/src/module/utils/showStatusIcons.ts
+++ b/src/module/utils/showStatusIcons.ts
@@ -335,7 +335,7 @@ export function getHitsTint(selectedTraveller: TwodsixActor): string {
 
 export function getCDWoundTint(selectedTraveller: TwodsixActor): string {
   let returnVal = '';
-  if (selectedTraveller.characteristics.lifeblood.current <= 0) {
+  if (selectedTraveller.characteristics.lifeblood.current <= 0 && selectedTraveller.characteristics.stamina.current <= 0) {
     returnVal = DAMAGECOLORS.deadTint;
   } else if (selectedTraveller.characteristics.lifeblood.current < (selectedTraveller.characteristics.lifeblood.value / 2)) {
     returnVal = DAMAGECOLORS.seriousWoundTint;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Encumbrance can be double applied on status change


* **What is the new behavior (if this is a feature change)?**
Encumbrance applied only once


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
