### PR TITLE
fix: stop deleting AE's on drop from compendium

### DIFF
--- a/src/module/settings/DebugSettings.ts
+++ b/src/module/settings/DebugSettings.ts
@@ -37,7 +37,7 @@ export default class DebugSettings extends AdvancedSettings {
     settings.dragDrop.push(booleanSetting('allowDropOnIcon', false));
     settings.dragDrop.push(booleanSetting('allowDragDropOfListsActor', false));
     settings.dragDrop.push(booleanSetting('allowDragDropOfListsShip', false));
-    settings.general.push(booleanSetting('useItemActiveEffects', false, false, 'world', deactivateActorAE));
+    settings.general.push(booleanSetting('useItemActiveEffects', true, false, 'world', deactivateActorAE));
     return settings;
   }
 }

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -236,18 +236,6 @@ export async function getItemDataFromDropData(dropData:Record<string, any>) {
     item = await pack?.getDocument(item._id);
   }
   const itemCopy = foundry.utils.duplicate(item);
-
-  //Delete Active effects if not used
-  if (!game.settings.get('twodsix', 'useItemActiveEffects') && itemCopy.isEmbedded !== true) {
-    const systemAEs = itemCopy.effects?.contents;
-    if (systemAEs?.length > 0) {
-      const idsToDelete = [];
-      for (const eff of systemAEs) {
-        idsToDelete.push(eff.id);
-      }
-      await itemCopy.deleteEmbeddedDocuments('ActiveEffect', idsToDelete);
-    }
-  }
   return itemCopy;
 }
 

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -235,7 +235,7 @@ export async function getItemDataFromDropData(dropData:Record<string, any>) {
     const pack = game.packs.get(item.pack);
     item = await pack?.getDocument(item._id);
   }
-  const itemCopy = foundry.utils.deepClone(item);
+  const itemCopy = foundry.utils.duplicate(item);
 
   //Delete Active effects if not used
   if (!game.settings.get('twodsix', 'useItemActiveEffects') && itemCopy.isEmbedded !== true) {

--- a/src/module/utils/showStatusIcons.ts
+++ b/src/module/utils/showStatusIcons.ts
@@ -164,7 +164,7 @@ export async function applyEncumberedEffect(selectedActor: TwodsixActor): Promis
 async function checkUnconsciousness(selectedActor: TwodsixActor, oldWoundState: TwodsixActiveEffect | undefined, tintToApply: string): Promise<void> {
   const isAlreadyUnconscious = selectedActor.effects.find(eff => eff.statuses.has('unconscious'));
   const isAlreadyDead = selectedActor.effects.find(eff => eff.statuses.has('dead'));
-  const rulesSet = game.settings.get('twodsix', 'ruleset').toString();
+  const rulesSet = game.settings.get('twodsix', 'ruleset'); //toString shouldn't be needed
   if (!isAlreadyUnconscious && !isAlreadyDead) {
     if (['CE', 'AC', 'OTHER'].includes(rulesSet)) {
       if (isUnconsciousCE(<Traveller>selectedActor.system)) {
@@ -179,7 +179,11 @@ async function checkUnconsciousness(selectedActor: TwodsixActor, oldWoundState: 
         await setConditionState('unconscious', selectedActor, true); // Automatic unconsciousness or out of combat
       } else {
         const setDifficulty = Object.values(TWODSIX.DIFFICULTIES[(game.settings.get('twodsix', 'difficultyListUsed'))]).find(e => e.target=== 8); //always 8+
-        const returnRoll = await selectedActor.characteristicRoll({ rollModifiers: {characteristic: 'END'}, difficulty: setDifficulty}, false);
+        const returnRoll = await selectedActor.characteristicRoll({
+          rollModifiers: {characteristic: 'END'},
+          difficulty: setDifficulty,
+          extraFlavor: game.i18n.localize("TWODSIX.Rolls.MakesUncRoll")
+        }, false);
         if (returnRoll && returnRoll.effect < 0) {
           await setConditionState('unconscious', selectedActor, true);
         }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -942,7 +942,8 @@
       "SelectSkill": "Select Skill",
       "SkillName": "Skill Name",
       "MakesOpposedRoll": "Makes an opposed / contested roll.",
-      "MakesChainRoll": "Makes a chain / assisted roll."
+      "MakesChainRoll": "Makes a chain / assisted roll.",
+      "MakesUncRoll": "Rolls to remain conscious."
     },
     "Settings": {
       "absoluteBonusValueForEachTimeIncrement": {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fixes


* **What is the current behavior?** (You can also link to an open issue here)
- Problem when dropping item from compendium when item AE setting is not active
- Item AE setting false by default
- No description when rolling consciousness check

* **What is the new behavior (if this is a feature change)?**
- Allow drop and keep AE's when item AE setting off
- Item AE setting default is true
- Add flavor message to unconsciousness rolls.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
