### PR TITLE
fix: button changes and component qty fixes

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -228,11 +228,13 @@ export default class TwodsixItem extends Item {
     };
 
     // Set characteristic from skill
-    const skill:TwodsixItem = this.actor?.items.get(weapon.skill) as TwodsixItem;
-    if (skill) {
-      tmpSettings.rollModifiers.characteristic = (<Skills>skill.system).characteristic || 'NONE';
-      tmpSettings.rollType = skill.system.rolltype || "Normal";
+    const skill:TwodsixItem | undefined  = this.actor?.items.get(weapon.skill) ?? (game.settings.get("twodsix", "hideUntrainedSkills") ? this.actor?.getUntrainedSkill() : undefined);
+    if (!skill) {
+      ui.notifications.error(game.i18n.localize("TWODSIX.Errors.NoSkillForSkillRoll"));
+      return;
     }
+    tmpSettings.rollModifiers.characteristic = (<Skills>skill.system).characteristic || 'NONE';
+    tmpSettings.rollType = skill.system.rolltype || "Normal";
 
     // Get fire mode parameters
     const { weaponType, isAutoFull, usedAmmo, numberOfAttacks } = this.getFireModeParams(rateOfFireCE, attackType, tmpSettings);

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -306,7 +306,7 @@ export default function registerHandlebarsHelpers(): void {
     if (actor) {
       const modes = [`<i class="fa-regular fa-circle-question"></i>`, `<i class="fa-regular fa-circle-xmark"></i>`, `<i class="fa-solid fa-circle-plus"></i>`, `<i class="fa-regular fa-circle-down"></i>`, `<i class="fa-regular fa-circle-up"></i>`, `<i class="fa-solid fa-shuffle"></i>`];
       if (foundry.utils.getProperty(actor.overrides, field) !== undefined) {
-        returnValue += field.includes('Armor') && actor.type === 'traveller' ? `- ` : ``;
+        returnValue += field.includes('Armor') ? `- ` : ``;
         const baseText = game.i18n.localize("TWODSIX.ActiveEffects.BaseValue");
         const modifierText = game.i18n.localize("TWODSIX.ActiveEffects.Modifiers");
         let baseValue = 0;

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -8,6 +8,7 @@ import TwodsixItem from "./entities/TwodsixItem";
 import TwodsixActor, { getPower, getWeight } from "./entities/TwodsixActor";
 import { getCharacteristicList } from "./utils/TwodsixRollSettings";
 import { simplifySkillName } from "./utils/utils";
+import { calcModFor } from "./utils/sheetUtils";
 
 export default function registerHandlebarsHelpers(): void {
 
@@ -315,9 +316,18 @@ export default function registerHandlebarsHelpers(): void {
             const coreSkill = actor.itemTypes.skills.find(sk => simplifySkillName(sk.name) === simplifiedName);
             baseValue = coreSkill?.system.value;
           }
+        } else if (field.includes('encumbrance.max')) {
+          baseValue = actor.getMaxEncumbrance();
+        } else if (field.includes('mod')) {
+          baseValue =  calcModFor(foundry.utils.getProperty(actor._source, field.replace('mod', 'value')));
         } else {
-          baseValue =  foundry.utils.getProperty(actor._source, field);
+          baseValue = foundry.utils.getProperty(actor._source, field);
         }
+
+        if (baseValue === foundry.utils.getProperty(actor, field)) {
+          baseValue = undefined;
+        }
+
         returnValue += `${baseText}: ${isNaN(baseValue) ? "?" : baseValue}. ${modifierText}: `;
         const workingEffects = actor.appliedEffects;
         for (const effect of workingEffects) {

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -318,7 +318,7 @@ export default function registerHandlebarsHelpers(): void {
         } else {
           baseValue =  foundry.utils.getProperty(actor._source, field);
         }
-        returnValue += `${baseText}: ${Number.isNaN(baseValue) ? "?" : baseValue}. ${modifierText}: `;
+        returnValue += `${baseText}: ${isNaN(baseValue) ? "?" : baseValue}. ${modifierText}: `;
         const workingEffects = actor.appliedEffects;
         for (const effect of workingEffects) {
           const realChanges = effect.changes.filter(ch => ch.key === field);

--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -2,7 +2,7 @@
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
 
 /*import { advantageDisadvantageTerm } from "./i18n";*/
-import { getKeyByValue } from "./utils/sheetUtils";
+import { getKeyByValue} from "./utils/utils";
 import { TWODSIX } from "./config";
 import TwodsixItem from "./entities/TwodsixItem";
 import TwodsixActor, { getPower, getWeight } from "./entities/TwodsixActor";
@@ -308,8 +308,17 @@ export default function registerHandlebarsHelpers(): void {
         returnValue += field.includes('Armor') && actor.type === 'traveller' ? `- ` : ``;
         const baseText = game.i18n.localize("TWODSIX.ActiveEffects.BaseValue");
         const modifierText = game.i18n.localize("TWODSIX.ActiveEffects.Modifiers");
-        const baseValue = foundry.utils.getProperty(actor._source, field);
-        returnValue += `${baseText}: ${baseValue > 0 ? baseValue : "?"}. ${modifierText}: `;
+        let baseValue = 0;
+        if (field.includes('skills')) {
+          const simplifiedName = field.replace('system.skills.', '');
+          if (simplifiedName) {
+            const coreSkill = actor.itemTypes.skills.find(sk => simplifySkillName(sk.name) === simplifiedName);
+            baseValue = coreSkill?.system.value;
+          }
+        } else {
+          baseValue =  foundry.utils.getProperty(actor._source, field);
+        }
+        returnValue += `${baseText}: ${Number.isNaN(baseValue) ? "?" : baseValue}. ${modifierText}: `;
         const workingEffects = actor.appliedEffects;
         for (const effect of workingEffects) {
           const realChanges = effect.changes.filter(ch => ch.key === field);

--- a/src/module/hooks/addGMControlButtons.ts
+++ b/src/module/hooks/addGMControlButtons.ts
@@ -4,7 +4,7 @@ import {TWODSIX} from "../config";
 import { getDifficultiesSelectObject, getRollTypeSelectObject } from "../utils/sheetUtils";
 //import {DICE_ROLL_MODES} from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs";
 import { _genUntranslatedCharacteristicList } from "../utils/TwodsixRollSettings";
-//import {getKeyByValue} from "./sheetUtils";
+//import {getKeyByValue} from "./utils";
 import { simplifySkillName, sortObj } from "../utils/utils.ts";
 
 Hooks.on("getSceneControlButtons", (controls) => {

--- a/src/module/hooks/addGMControlButtons.ts
+++ b/src/module/hooks/addGMControlButtons.ts
@@ -37,7 +37,7 @@ async function requestRoll(): Promise<void> {
       } else {
         flavor = flavor.replace("_TYPE_", game.i18n.localize("TWODSIX.Chat.Roll.normal"));
       }
-      flavor += `<section class="card-buttons"><button data-action="abilityCheck" data-tooltip="${game.i18n.localize("TWODSIX.Chat.Roll.AbilityCheck")}"><i class="fa-solid fa-dice"></i></button><section>`;
+      flavor += `<section class="card-buttons"><button type="button" data-action="abilityCheck" data-tooltip="${game.i18n.localize("TWODSIX.Chat.Roll.AbilityCheck")}"><i class="fa-solid fa-dice"></i></button><section>`;
       ChatMessage.create({
         flavor: flavor,
         flags: {

--- a/src/module/hooks/diceTrayIntegration.ts
+++ b/src/module/hooks/diceTrayIntegration.ts
@@ -1,7 +1,7 @@
 // DICE TRAY no longer supports custom buttons through a simple API as of V12
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
-/*import { getKeyByValue } from "../utils/sheetUtils";
+/*import { getKeyByValue } from "../utils/utils";
 import { simplifySkillName } from "../utils/utils";
 import {TWODSIX} from "../config";
 

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -548,8 +548,8 @@ export abstract class AbstractTwodsixActorSheet extends ActorSheet {
     const li = $(event.currentTarget).parents(".item");
     const itemSelected = this.actor.items.get(li.data("itemId"));
 
-    if (itemSelected) {
-      if (itemSelected.type === "skills") {
+    if (itemSelected && Number.isInteger(newValue)) {
+      if (itemSelected.type === "skills" ) {
         itemSelected.update({"system.value": newValue});
       } else if (itemSelected.type === "consumable") {
         itemSelected.update({"system.quantity": newValue});

--- a/src/module/sheets/TwodsixVehicleSheet.ts
+++ b/src/module/sheets/TwodsixVehicleSheet.ts
@@ -54,9 +54,15 @@ export class TwodsixVehicleSheet extends AbstractTwodsixActorSheet {
       } else {
         const li = $(event.currentTarget).parents(".item");
         const itemSelected:Component = this.actor.items.get(li.data("itemId"));
-        if (itemSelected) {
+        if (!itemSelected) {
+          return;
+        }
+        const type = $(event.currentTarget).data("type");
+        if (type === "status") {
           const newState = event.shiftKey ? (itemSelected.system.status === "off" ? "operational" : "off") : stateTransitions[itemSelected.system.status];
-          itemSelected?.update({"system.status": newState});
+          itemSelected.update({"system.status": newState});
+        } else if (type === "popup") {
+          itemSelected.update({"system.isExtended": !itemSelected.system.isExtended});
         }
       }
     }

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -5,7 +5,7 @@ import {TWODSIX} from "../config";
 import TwodsixActor from "../entities/TwodsixActor";
 import TwodsixItem from "../entities/TwodsixItem";
 import {advantageDisadvantageTerm} from "../i18n";
-import {getKeyByValue} from "./sheetUtils";
+import {getKeyByValue} from "./utils";
 import {TwodsixRollSettings} from "./TwodsixRollSettings";
 import Crit from "./crit";
 import { simplifySkillName, addSign, capitalizeFirstLetter } from "./utils";

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -371,12 +371,12 @@ export class TwodsixDiceRoll {
     }
 
     //Add buttons
-    flavorText += `<section class="card-buttons"><button data-action="expand" data-tooltip="${game.i18n.localize("TWODSIX.Rolls.ToggleDetails")}"><i class="fa-solid fa-circle-question" style="margin-left: 3px;"></i></button>`;
+    flavorText += `<section class="card-buttons"><button type="button" data-action="expand" data-tooltip="${game.i18n.localize("TWODSIX.Rolls.ToggleDetails")}"><i class="fa-solid fa-circle-question" style="margin-left: 3px;"></i></button>`;
     if (this.isSuccess() && !game.settings.get("twodsix", "automateDamageRollOnHit") && (this.item?.type === "weapon" || (this.item?.type === "component" && this.item?.system?.subtype === "armament"))) {
-      flavorText += `<button data-action="damage" data-tooltip="${game.i18n.localize("TWODSIX.Rolls.RollDamage")}"><i class="fa-solid fa-person-burst" style="margin-left: 3px;"></i></button>`;
+      flavorText += `<button type="button" data-action="damage" data-tooltip="${game.i18n.localize("TWODSIX.Rolls.RollDamage")}"><i class="fa-solid fa-person-burst" style="margin-left: 3px;"></i></button>`;
     } else if (this.rollSettings.skillRoll && this.item?.type !== "weapon" && !(this.item?.type === "component" && this.item?.system?.subtype === "armament")) {
-      flavorText += `<button data-action="chain" data-tooltip="${game.i18n.localize("TWODSIX.Rolls.RollChain")}"><i class="fa-solid fa-link" style="margin-left: 3px;"></i></button>`;
-      flavorText += `<button data-action="opposed" data-tooltip="${game.i18n.localize("TWODSIX.Rolls.RollOpposed")}"><i class="fa-solid fa-down-left-and-up-right-to-center" style="margin-left: 3px;"></i></button>`;
+      flavorText += `<button type="button" data-action="chain" data-tooltip="${game.i18n.localize("TWODSIX.Rolls.RollChain")}"><i class="fa-solid fa-link" style="margin-left: 3px;"></i></button>`;
+      flavorText += `<button type="button" data-action="opposed" data-tooltip="${game.i18n.localize("TWODSIX.Rolls.RollOpposed")}"><i class="fa-solid fa-down-left-and-up-right-to-center" style="margin-left: 3px;"></i></button>`;
     }
 
     flavorText +=`</section></section>`;

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -3,7 +3,8 @@
 
 import {CE_DIFFICULTIES, CEL_DIFFICULTIES, TWODSIX} from "../config";
 import type TwodsixItem from "../entities/TwodsixItem";
-import {getDifficultiesSelectObject, getKeyByValue, getRollTypeSelectObject} from "./sheetUtils";
+import {getDifficultiesSelectObject, getRollTypeSelectObject} from "./sheetUtils";
+import { getKeyByValue } from "./utils";
 import {DICE_ROLL_MODES} from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs";
 import {Gear, Skills} from "../../types/template";
 import TwodsixActor from "../entities/TwodsixActor";

--- a/src/module/utils/sheetUtils.ts
+++ b/src/module/utils/sheetUtils.ts
@@ -4,6 +4,7 @@
 import { TWODSIX } from "../config";
 import { advantageDisadvantageTerm } from "../i18n";
 import { camelCase } from "../settings/settingsUtils";
+import { simplifySkillName } from "./utils";
 
 // export function pseudoHex(value:number):string {
 //   switch (value) {
@@ -188,10 +189,6 @@ export function calcModFor(characteristic:number):number {
 //   return calcModFor(characteristic);
 // }
 
-export function getKeyByValue(object:{ [x:string]:unknown; }, value:unknown):string {
-  //TODO This assumes I always find the value. Bad form really.
-  return <string>Object.keys(object).find(key => JSON.stringify(object[key]) === JSON.stringify(value));
-}
 
 export function getDataFromDropEvent(event:DragEvent):Record<string, any> {
   try {
@@ -296,7 +293,7 @@ export async function deletePDFReference(event): Promise<void> {
 export function isDisplayableSkill(skill:Skills): boolean {
   if (skill.getFlag("twodsix", "untrainedSkill")) {
     return false;
-  } else if (skill.system.trainingNotes !== ""  || skill.system.value >= 0) {
+  } else if (skill.system.trainingNotes !== ""  || skill.system.value >= 0 || skill.actor?.system.skills[simplifySkillName(skill.name)] > 0) {
     return true;
   } else if (!game.settings.get('twodsix', 'hideUntrainedSkills')) {
     return true;

--- a/src/module/utils/utils.ts
+++ b/src/module/utils/utils.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck This turns off *all* typechecking, make sure to remove this once foundry-vtt-types are updated to cover v10.
-import { getKeyByValue } from "./sheetUtils";
 
 // https://stackoverflow.com/a/34749873
 /**
@@ -194,4 +193,9 @@ export function roundToDecimal(num:number, decimalPlaces:number): number {
 export function roundToMaxDecimals(num:number, maxDecimals:number): number {
   const decimalsToShow = Math.min(maxDecimals, Math.max(0, maxDecimals - Math.floor(Math.log10(Math.abs(num)))));
   return roundToDecimal(num, decimalsToShow);
+}
+
+export function getKeyByValue(object:{ [x:string]:unknown; }, value:unknown):string {
+  //TODO This assumes I always find the value. Bad form really.
+  return <string>Object.keys(object).find(key => JSON.stringify(object[key]) === JSON.stringify(value));
 }

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2725,7 +2725,7 @@ a.ship-crew-tab.active, a.ship-positions-tab.active , a.ship-storage-tab.active,
   margin-top: 1%;
   margin-left: 3%;
   /* margin-bottom: 32px; */
-  overflow-y: auto;
+  /*overflow-y: auto;*/
   /* height: 46%; */
   /* align-self: center; */
 }

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2199,7 +2199,7 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
 
 .storage-wrapper {
   margin-top: 1.0em;
-  overflow-y: auto;
+  /*overflow-y: auto;*/
   /* height: 290px; */
   margin-left: 15px;
 }

--- a/static/templates/actors/animal-sheet.html
+++ b/static/templates/actors/animal-sheet.html
@@ -19,7 +19,7 @@
                                          onClick="this.select();"/></div>
       {{#if settings.showInitiativeButton}}
         <div class = "initiative">
-          <button class="roll-initiative"><i class="fa-solid fa-dice" alt="2d6"></i>{{localize "TWODSIX.Rolls.RollInitiative"}}</button>
+          <button class="roll-initiative" type="button"><i class="fa-solid fa-dice" alt="2d6"></i>{{localize "TWODSIX.Rolls.RollInitiative"}}</button>
         </div>
       {{/if}}
       {{> "systems/twodsix/templates/actors/parts/actor/actor-reference.html"}}

--- a/static/templates/actors/battle-sheet.html
+++ b/static/templates/actors/battle-sheet.html
@@ -49,25 +49,12 @@
                 <span class="item-name centre">{{item.system.hits}}
                   <span class="combined-buttons" data-field="hits">
                     <button type="button" class="left-button adjust-counter" {{#iff item.system.hits "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-                    <button type="button" class="right-button adjust-counter" {{#iff item.system.hits "===" settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
+                    <button type="button" class="right-button adjust-counter" {{#iff item.system.hits "===" ../settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
                   </span>
                 </span>
                 <span class="item-name centre" >
-                  <span class="component-toggle" data-type="status">
-                    {{#iff item.system.status "===" 'operational'}} <i class="fa-solid fa-circle-check" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.operational"}}'></i>
-                    {{else}}
-                      {{#iff item.system.status "===" 'damaged'}} <i class="fa-solid fa-circle-exclamation" style="color: yellow;" data-tooltip='{{localize "TWODSIX.Items.Component.damaged"}}'></i>
-                    {{else}}
-                      {{#iff item.system.status "===" 'destroyed'}} <i class="fa-solid fa-circle-x" style="color: red;" data-tooltip='{{localize "TWODSIX.Items.Component.destroyed"}}'></i>
-                    {{else}}
-                      {{#iff item.system.status "===" 'off'}} <i class="fa-solid fa-power-off" style="color: grey;" data-tooltip='{{localize "TWODSIX.Items.Component.off"}}'></i>
-                    {{/iff}} {{/iff}} {{/iff}} {{/iff}}
-                  </span>
-                  {{#if item.system.isPopup}}
-                    <span class="component-toggle" data-type="popup">
-                      {{#if item.system.isExtended}}<i class="fa-solid fa-square-caret-up" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.extended"}}'></i>{{else}}<i class="fa-solid fa-square-caret-down" style="color: grey;" data-tooltip='{{localize "TWODSIX.Items.Component.retracted"}}'></i>{{/if}}
-                    </span>
-                  {{/if}}
+                  {{> "systems/twodsix/templates/actors/parts/common/component-status.html" item=item}}
+                  {{> "systems/twodsix/templates/actors/parts/common/popup-state.html" item=item}}
                 </span>
                 <span class="item-controls centre">
                   <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i
@@ -113,16 +100,7 @@
                   <span class="item-name centre">{{#iff item.system.rollModifier "!==" ""}}{{item.system.rollModifier}}{{else}}&mdash;{{/iff}}</span>
                   {{/if}}
 
-                  {{#iff item.system.ammunition.max "!==" 0}}
-                    <span class="item-name centre">{{item.system.ammunition.value}}
-                      <span class="combined-buttons" data-field="ammo">
-                        <button type="button" class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-                        <button type="button" class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
-                      </span>
-                    </span>
-                  {{else}}
-                    <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
-                  {{/iff}}
+                  {{> "systems/twodsix/templates/actors/parts/common/armament-qty.html" item=item}}
 
                   <span class="item-name centre">
                     {{#iff item.system.damage "!==" ""}}<span class="roll-damage orange">{{twodsix_limitLength item.system.damage 3}}{{else}}&mdash;{{/iff}}</span>

--- a/static/templates/actors/battle-sheet.html
+++ b/static/templates/actors/battle-sheet.html
@@ -48,8 +48,8 @@
                 <span class="item-name centre">{{#if item.system.hardened}}<i class="fa-solid fa-gem"></i>{{else}}&mdash;{{/if}}</span>
                 <span class="item-name centre">{{item.system.hits}}
                   <span class="combined-buttons" data-field="hits">
-                    <button class="left-button adjust-counter" {{#iff item.system.hits "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-                    <button class="right-button adjust-counter" {{#iff item.system.hits "===" settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
+                    <button type="button" class="left-button adjust-counter" {{#iff item.system.hits "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+                    <button type="button" class="right-button adjust-counter" {{#iff item.system.hits "===" settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
                   </span>
                 </span>
                 <span class="item-name centre" >
@@ -116,8 +116,8 @@
                   {{#iff item.system.ammunition.max "!==" 0}}
                     <span class="item-name centre">{{item.system.ammunition.value}}
                       <span class="combined-buttons" data-field="ammo">
-                        <button class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-                        <button class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
+                        <button type="button" class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+                        <button type="button" class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
                       </span>
                     </span>
                   {{else}}

--- a/static/templates/actors/npc-sheet.html
+++ b/static/templates/actors/npc-sheet.html
@@ -18,7 +18,7 @@
                   onClick="this.select();" autocomplete="off"/></div>
       {{#if settings.showInitiativeButton}}
         <div class = "initiative">
-          <button class="roll-initiative"><i class="fa-solid fa-dice" alt="2d6"></i>{{localize "TWODSIX.Rolls.RollInitiative"}}</button>
+          <button type="button" class="roll-initiative"><i class="fa-solid fa-dice" alt="2d6"></i>{{localize "TWODSIX.Rolls.RollInitiative"}}</button>
         </div>
       {{/if}}
       {{> "systems/twodsix/templates/actors/parts/actor/actor-reference.html"}}

--- a/static/templates/actors/parts/actor/actor-bgi-animal.html
+++ b/static/templates/actors/parts/actor/actor-bgi-animal.html
@@ -69,7 +69,9 @@
   {{else}}
     <span class="bgi-armor" data-tooltip='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fa-solid fa-user-shield"></i>:<input
             style="text-align: right;" name="system.primaryArmor.value" type="number" value="{{system.primaryArmor.value}}" placeholder='0'
-            data-tooltip="{{localize 'TWODSIX.Items.Armor.PrimaryArmor'}}"/>+<input name="system.secondaryArmor.value" type="number" value="{{system.secondaryArmor.value}}" placeholder='0' data-tooltip="{{localize 'TWODSIX.Items.Armor.SecondaryArmor'}}" /></span>
+            data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.PrimaryArmor') (twodsix_getTooltip actor 'system.primaryArmor.value')}}"/>+
+            <input name="system.secondaryArmor.value" type="number" value="{{system.secondaryArmor.value}}" placeholder='0' data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.SecondaryArmor') (twodsix_getTooltip actor 'system.secondaryArmor.value')}}" />
+    </span>
     <span class="bgi-armor bgi-radProtect" data-tooltip='{{localize "TWODSIX.Items.Armor.RadProt"}}'><i class="fa-solid fa-circle-radiation"></i>:<input
             name="system.radiationProtection.value" type="number" value="{{system.radiationProtection.value}}" placeholder='0' data-tooltip="{{localize 'TWODSIX.Items.Armor.RadProt'}}"/></span>
     <span class="bgi-secondary" data-tooltip='{{localize "TWODSIX.Items.Armor.SecondaryArmorProtectionTypes"}}'><label for="system.secondaryArmor.protectionTypes"><i class="fa-solid fa-shield-halved"></i>: </label>

--- a/static/templates/actors/parts/actor/actor-bgi-robot.html
+++ b/static/templates/actors/parts/actor/actor-bgi-robot.html
@@ -23,7 +23,8 @@
 {{else}}
   <span class="bgi-armor" data-tooltip='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fa-solid fa-user-shield"></i>:<input
       style="text-align: right;" name="system.primaryArmor.value" type="number" value="{{system.primaryArmor.value}}" placeholder='0'
-      data-tooltip="{{localize 'TWODSIX.Items.Armor.PrimaryArmor'}}"/>+<input name="system.secondaryArmor.value" type="number" value="{{system.secondaryArmor.value}}" placeholder='0' data-tooltip="{{localize 'TWODSIX.Items.Armor.SecondaryArmor'}}" />
+      data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.PrimaryArmor') (twodsix_getTooltip actor 'system.primaryArmor.value')}}"/>+
+      <input name="system.secondaryArmor.value" type="number" value="{{system.secondaryArmor.value}}" placeholder='0' data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.SecondaryArmor') (twodsix_getTooltip actor 'system.secondaryArmor.value')}}" />
   </span>
   <span class="bgi-armor bgi-radProtect" data-tooltip='{{localize "TWODSIX.Items.Armor.RadProt"}}'><i class="fa-solid fa-circle-radiation"></i>:<input
       name="system.radiationProtection.value" type="number" value="{{system.radiationProtection.value}}" placeholder='0' data-tooltip="{{localize 'TWODSIX.Items.Armor.RadProt'}}"/></span>

--- a/static/templates/actors/parts/actor/actor-consumable.html
+++ b/static/templates/actors/parts/actor/actor-consumable.html
@@ -6,11 +6,11 @@
     <span class="consumable-count">
       <span>{{currentCount}}/{{max}}</span>
       <span class="combined-buttons">
-        <button class="left-button adjust-consumable" {{#iff currentCount "<=" 0}}disabled{{/iff}} data-value="1">-</button>
-        <button class="right-button adjust-consumable" {{#iff currentCount ">=" max}}disabled{{/iff}} data-value="-1">+</button>
+        <button type="button" class="left-button adjust-consumable" {{#iff currentCount "<=" 0}}disabled{{/iff}} data-value="1">-</button>
+        <button type="button" class="right-button adjust-consumable" {{#iff currentCount ">=" max}}disabled{{/iff}} data-value="-1">+</button>
       </span>
     </span>
-    <button {{#iff currentCount '>=' max}}disabled{{/iff}} class="refill-button">
+    <button type="button" {{#iff currentCount '>=' max}}disabled{{/iff}} class="refill-button">
       {{twodsix_refillText subtype quantity}}
     </button>
     {{/with}}

--- a/static/templates/actors/parts/actor/actor-npc-consumable.html
+++ b/static/templates/actors/parts/actor/actor-npc-consumable.html
@@ -4,8 +4,8 @@
     <span class="consumable-count">
       <span>{{currentCount}}/{{max}}</span>
       <span class="combined-buttons">
-        <button class="left-button adjust-consumable" {{#iff currentCount "<=" 0}}disabled{{/iff}} data-value="1">-</button>
-        <button class="right-button adjust-consumable" {{#iff currentCount ">=" max}}disabled{{/iff}} data-value="-1">+</button>
+        <button type="button" class="left-button adjust-consumable" {{#iff currentCount "<=" 0}}disabled{{/iff}} data-value="1">-</button>
+        <button type="button" class="right-button adjust-consumable" {{#iff currentCount ">=" max}}disabled{{/iff}} data-value="-1">+</button>
       </span>
     </span>
     {{/with}}

--- a/static/templates/actors/parts/actor/actor-skill-item.html
+++ b/static/templates/actors/parts/actor/actor-skill-item.html
@@ -6,7 +6,7 @@
           <i class="fa-solid fa-dice" alt="d6"></i>
         </span>
         <span class="item-name rollable" data-label="{{item.name}}">{{item.name}}</span>
-        <input class= "item-value-edit" type="number" value="{{item.system.value}}"/>
+        <input class= "item-value-edit" type="text" value="{{item.system.value}}" data-dtype="Number"/>
         <span class="item-name centre" for="skill-modifier">{{twodsix_skillCharacteristic actor item.system.characteristic}}</span>
         <span class="item-name centre">{{{twodsix_adjustedSkillValue actor item}}}</span>
         <span class="total-output flex1 skill-mod">{{twodsix_skillTotal actor item}}</span>

--- a/static/templates/actors/parts/actor/actor-skills.html
+++ b/static/templates/actors/parts/actor/actor-skills.html
@@ -1,6 +1,6 @@
 {{#if settings.showInitiativeButton}}
   <div class = "initiative">
-    <button class="roll-initiative"><i class="fa-solid fa-dice" alt="2d6"></i>{{localize "TWODSIX.Rolls.RollInitiative"}}</button>
+    <button type = "button" class="roll-initiative"><i class="fa-solid fa-dice" alt="2d6"></i>{{localize "TWODSIX.Rolls.RollInitiative"}}</button>
   </div>
 {{/if}}
 

--- a/static/templates/actors/parts/common/armament-qty.html
+++ b/static/templates/actors/parts/common/armament-qty.html
@@ -1,0 +1,10 @@
+{{#iff item.system.ammunition.max "!==" 0}}
+  <span class="item-name centre">{{item.system.ammunition.value}}
+    <span class="combined-buttons" data-field="ammo">
+      <button type="button" class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+      <button type="button" class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
+    </span>
+  </span>
+{{else}}
+  <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
+{{/iff}}

--- a/static/templates/actors/parts/common/component-status.html
+++ b/static/templates/actors/parts/common/component-status.html
@@ -1,0 +1,10 @@
+<span class="component-toggle" data-type="status">
+  {{#iff item.system.status "===" 'operational'}} <i class="fa-solid fa-circle-check" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.operational"}}'></i>
+  {{else}}
+    {{#iff item.system.status "===" 'damaged'}} <i class="fa-solid fa-circle-exclamation" style="color: yellow;" data-tooltip='{{localize "TWODSIX.Items.Component.damaged"}}'></i>
+  {{else}}
+    {{#iff item.system.status "===" 'destroyed'}} <i class="fa-solid fa-circle-x" style="color: red;" data-tooltip='{{localize "TWODSIX.Items.Component.destroyed"}}'></i>
+  {{else}}
+    {{#iff item.system.status "===" 'off'}} <i class="fa-solid fa-power-off" style="color: grey;" data-tooltip='{{localize "TWODSIX.Items.Component.off"}}'></i>
+  {{/iff}} {{/iff}} {{/iff}} {{/iff}}
+</span>

--- a/static/templates/actors/parts/common/popup-state.html
+++ b/static/templates/actors/parts/common/popup-state.html
@@ -1,0 +1,5 @@
+{{#if item.system.isPopup}}
+  <span class="component-toggle" data-type="popup">
+    {{#if item.system.isExtended}}<i class="fa-solid fa-square-caret-up" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.extended"}}'></i>{{else}}<i class="fa-solid fa-square-caret-down" style="color: grey;" data-tooltip='{{localize "TWODSIX.Items.Component.retracted"}}'></i>{{/if}}
+  </span>
+{{/if}}

--- a/static/templates/actors/parts/ship/ship-component-double-item.html
+++ b/static/templates/actors/parts/ship/ship-component-double-item.html
@@ -7,38 +7,15 @@
         <a class="item-link orange" data-uuid="{{item.system.actorLink}}">{{item.name}}{{#if settings.allowDragDropOfListsShip}} <i class= '{{twodsix_getComponentIcon item.system.subtype}}' data-tooltip='{{localize (concat "TWODSIX.Items.Component." item.system.subtype)}}'></i>{{/if}}</a>
       {{/iff}}
       {{#iff item.system.subtype "===" "armament"}}
-          {{#iff item.system.ammunition.max "!==" 0}}
-            <span class="item-name centre">{{item.system.ammunition.value}}
-              <span class="combined-buttons" data-field="ammo">
-                <button type="button" class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-                <button type="button" class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
-              </span>
-            </span>
-          {{else}}
-            <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
-          {{/iff}}
+        {{> "systems/twodsix/templates/actors/parts/common/armament-qty.html"}}
       {{else}}
         <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
       {{/iff}}
       <span class="item-name centre">{{#iff item.system.techLevel ">" "0"}}{{item.system.techLevel}}{{else}}&mdash;{{/iff}}</span>
       <span class="item-name centre">{{item.system.rating}}</span>
       <span class="item-name centre" >
-        <span class="component-toggle" data-type="status">
-          {{#iff item.system.status "===" 'operational'}} <i class="fa-solid fa-circle-check" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.operational"}}'></i>
-          {{else}}
-            {{#iff item.system.status "===" 'damaged'}} <i class="fa-solid fa-circle-exclamation" style="color: yellow;" data-tooltip='{{localize "TWODSIX.Items.Component.damaged"}}'></i>
-          {{else}}
-            {{#iff item.system.status "===" 'destroyed'}} <i class="fa-solid fa-circle-x" style="color: red;" data-tooltip='{{localize "TWODSIX.Items.Component.destroyed"}}'></i>
-          {{else}}
-            {{#iff item.system.status "===" 'off'}} <i class="fa-solid fa-power-off" style="color: grey;" data-tooltip='{{localize "TWODSIX.Items.Component.off"}}'></i>
-          {{/iff}} {{/iff}} {{/iff}} {{/iff}}
-        </span>
-
-        {{#if item.system.isPopup}}
-          <span class="component-toggle" data-type="popup">
-            {{#if item.system.isExtended}}<i class="fa-solid fa-square-caret-up" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.extended"}}'></i>{{else}}<i class="fa-solid fa-square-caret-down" style="color: grey;" data-tooltip='{{localize "TWODSIX.Items.Component.retracted"}}'></i>{{/if}}
-          </span>
-        {{/if}}
+        {{> "systems/twodsix/templates/actors/parts/common/component-status.html"}}
+        {{> "systems/twodsix/templates/actors/parts/common/popup-state.html"}}
       </span>
       <span class="item-controls centre">
         <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i

--- a/static/templates/actors/parts/ship/ship-component-double-item.html
+++ b/static/templates/actors/parts/ship/ship-component-double-item.html
@@ -10,8 +10,8 @@
           {{#iff item.system.ammunition.max "!==" 0}}
             <span class="item-name centre">{{item.system.ammunition.value}}
               <span class="combined-buttons" data-field="ammo">
-                <button class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-                <button class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
+                <button type="button" class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+                <button type="button" class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
               </span>
             </span>
           {{else}}

--- a/static/templates/actors/parts/ship/ship-component-single-item.html
+++ b/static/templates/actors/parts/ship/ship-component-single-item.html
@@ -20,16 +20,7 @@
       {{/if}}
       <span class="item-name centre">{{getComponentPower item}}</span>
       {{#iff item.system.subtype "===" "armament"}}
-          {{#iff item.system.ammunition.max "!==" 0}}
-            <span class="item-name centre">{{item.system.ammunition.value}}
-              <span class="combined-buttons" data-field="ammo">
-                <button type="button" class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-                <button type="button" class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
-              </span>
-            </span>
-          {{else}}
-            <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
-          {{/iff}}
+        {{> "systems/twodsix/templates/actors/parts/common/armament-qty.html"}}
       {{else}}
         <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
       {{/iff}}
@@ -48,22 +39,8 @@
         </span>
       </span>
       <span class="item-name centre" >
-        <span class="component-toggle" data-type="status">
-          {{#iff item.system.status "===" 'operational'}} <i class="fa-solid fa-circle-check" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.operational"}}'></i>
-          {{else}}
-            {{#iff item.system.status "===" 'damaged'}} <i class="fa-solid fa-circle-exclamation" style="color: yellow;" data-tooltip='{{localize "TWODSIX.Items.Component.damaged"}}'></i>
-          {{else}}
-            {{#iff item.system.status "===" 'destroyed'}} <i class="fa-solid fa-circle-x" style="color: red;" data-tooltip='{{localize "TWODSIX.Items.Component.destroyed"}}'></i>
-          {{else}}
-            {{#iff item.system.status "===" 'off'}} <i class="fa-solid fa-power-off" style="color: grey;" data-tooltip='{{localize "TWODSIX.Items.Component.off"}}'></i>
-          {{/iff}} {{/iff}} {{/iff}} {{/iff}}
-        </span>
-
-        {{#if item.system.isPopup}}
-          <span class="component-toggle" data-type="popup">
-            {{#if item.system.isExtended}}<i class="fa-solid fa-square-caret-up" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.extended"}}'></i>{{else}}<i class="fa-solid fa-square-caret-down" style="color: grey;" data-tooltip='{{localize "TWODSIX.Items.Component.retracted"}}'></i>{{/if}}
-          </span>
-        {{/if}}
+        {{> "systems/twodsix/templates/actors/parts/common/component-status.html"}}
+        {{> "systems/twodsix/templates/actors/parts/common/popup-state.html"}}
       </span>
       <span class="item-controls centre">
         <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i

--- a/static/templates/actors/parts/ship/ship-component-single-item.html
+++ b/static/templates/actors/parts/ship/ship-component-single-item.html
@@ -23,8 +23,8 @@
           {{#iff item.system.ammunition.max "!==" 0}}
             <span class="item-name centre">{{item.system.ammunition.value}}
               <span class="combined-buttons" data-field="ammo">
-                <button class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-                <button class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
+                <button type="button" class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+                <button type="button" class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
               </span>
             </span>
           {{else}}
@@ -43,8 +43,8 @@
       <span class="item-name centre">{{#if item.system.hardened}}<i class="fa-solid fa-gem"></i>{{else}}&mdash;{{/if}}</span>
       <span class="item-name centre">{{item.system.hits}}
         <span class="combined-buttons" data-field="hits">
-          <button class="left-button adjust-counter" {{#iff item.system.hits "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-          <button class="right-button adjust-counter" {{#iff item.system.hits "===" settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
+          <button type="button" class="left-button adjust-counter" {{#iff item.system.hits "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+          <button type="button" class="right-button adjust-counter" {{#iff item.system.hits "===" settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
         </span>
       </span>
       <span class="item-name centre" >

--- a/static/templates/actors/parts/vehicle/vehicle-components.html
+++ b/static/templates/actors/parts/vehicle/vehicle-components.html
@@ -21,16 +21,7 @@
           <span class="item-name centre">{{#iff item.system.techLevel ">" "0"}}{{item.system.techLevel}}{{else}}&mdash;{{/iff}}</span>
           <span class="item-name centre">{{#iff item.system.rollModifier "!==" ""}}{{item.system.rollModifier}}{{else}}&mdash;{{/iff}}</span>
           {{#iff item.system.subtype "===" "armament"}}
-            {{#iff item.system.ammunition.max "!==" 0}}
-              <span class="item-name centre">{{item.system.ammunition.value}}
-                <span class="combined-buttons" data-field="ammo">
-                  <button type="button" class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-                  <button type="button" class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
-                </span>
-              </span>
-            {{else}}
-              <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
-            {{/iff}}
+            {{> "systems/twodsix/templates/actors/parts/common/armament-qty.html" item=item}}
           {{else}}
             <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
           {{/iff}}
@@ -44,15 +35,9 @@
               <button type="button" class="right-button adjust-counter" {{#iff item.system.hits "===" ../settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
             </span>
           </span>
-          <span class="item-name centre component-toggle">
-            {{#iff item.system.status "===" 'operational'}} <i class="fa-solid fa-circle-check" style="color: green;" data-tooltip='{{localize "TWODSIX.Items.Component.operational"}}'></i>
-            {{else}}
-              {{#iff item.system.status "===" 'damaged'}} <i class="fa-solid fa-circle-exclamation" style="color: yellow;" data-tooltip='{{localize "TWODSIX.Items.Component.damaged"}}'></i>
-            {{else}}
-              {{#iff item.system.status "===" 'destroyed'}} <i class="fa-solid fa-circle-x" style="color: red;" data-tooltip='{{localize "TWODSIX.Items.Component.destroyed"}}'></i>
-            {{else}}
-              {{#iff item.system.status "===" 'off'}} <i class="fa-solid fa-power-off" style="color: grey;" data-tooltip='{{localize "TWODSIX.Items.Component.off"}}'></i>
-            {{/iff}} {{/iff}} {{/iff}} {{/iff}}
+          <span class="item-name centre" >
+            {{> "systems/twodsix/templates/actors/parts/common/component-status.html" item=item}}
+            {{> "systems/twodsix/templates/actors/parts/common/popup-state.html" item=item}}
           </span>
           <span class="item-controls centre">
             <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}'><i

--- a/static/templates/actors/parts/vehicle/vehicle-components.html
+++ b/static/templates/actors/parts/vehicle/vehicle-components.html
@@ -20,15 +20,28 @@
           <span class="item-name">{{item.name}} <i class= '{{twodsix_getComponentIcon item.system.subtype}}' data-tooltip='{{localize (concat "TWODSIX.Items.Component." item.system.subtype)}}'></i></span>
           <span class="item-name centre">{{#iff item.system.techLevel ">" "0"}}{{item.system.techLevel}}{{else}}&mdash;{{/iff}}</span>
           <span class="item-name centre">{{#iff item.system.rollModifier "!==" ""}}{{item.system.rollModifier}}{{else}}&mdash;{{/iff}}</span>
-          <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
+          {{#iff item.system.subtype "===" "armament"}}
+            {{#iff item.system.ammunition.max "!==" 0}}
+              <span class="item-name centre">{{item.system.ammunition.value}}
+                <span class="combined-buttons" data-field="ammo">
+                  <button type="button" class="left-button adjust-counter" {{#iff item.system.ammunition.value "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+                  <button type="button" class="right-button adjust-counter" {{#iff item.system.ammunition.value "===" item.system.ammunition.max}}disabled{{/iff}} data-value="1" >+</button>
+                </span>
+              </span>
+            {{else}}
+              <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
+            {{/iff}}
+          {{else}}
+            <span class="item-name centre">{{#if item.system.availableQuantity}}{{item.system.availableQuantity}}/{{/if}}{{item.system.quantity}}</span>
+          {{/iff}}
 
           <span class="item-name centre">
               {{#iff item.system.damage "!==" ""}}<span class="roll-damage orange">{{twodsix_limitLength item.system.damage 3}}{{else}}&mdash;{{/iff}}</span>
           </span>
           <span class="item-name centre">{{item.system.hits}}
             <span class="combined-buttons" data-field="hits">
-              <button class="left-button adjust-counter" {{#iff item.system.hits "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
-              <button class="right-button adjust-counter" {{#iff item.system.hits "===" ../settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
+              <button type="button" class="left-button adjust-counter" {{#iff item.system.hits "===" 0}}disabled{{/iff}} data-value="-1" >-</button>
+              <button type="button" class="right-button adjust-counter" {{#iff item.system.hits "===" ../settings.maxComponentHits}}disabled{{/iff}} data-value="1" >+</button>
             </span>
           </span>
           <span class="item-name centre component-toggle">

--- a/static/templates/actors/robot-sheet.html
+++ b/static/templates/actors/robot-sheet.html
@@ -19,7 +19,7 @@
                                          onClick="this.select();" autocomplete="off"/></div>
       {{#if settings.showInitiativeButton}}
         <div class = "initiative">
-          <button class="roll-initiative"><i class="fa-solid fa-dice" alt="2d6"></i>{{localize "TWODSIX.Rolls.RollInitiative"}}</button>
+          <button type="button" class="roll-initiative"><i class="fa-solid fa-dice" alt="2d6"></i>{{localize "TWODSIX.Rolls.RollInitiative"}}</button>
         </div>
       {{/if}}
       {{> "systems/twodsix/templates/actors/parts/actor/actor-reference.html"}}

--- a/static/templates/items/parts/footer.html
+++ b/static/templates/items/parts/footer.html
@@ -1,8 +1,8 @@
 <div class="effects-footer">
   {{#if effects.size }}
-  <button class="edit-active-effect"><i class="fas fa-edit"></i> {{localize "TWODSIX.Items.Traits.EditEffect"}}</button>
-  <button class="delete-active-effect"><i class="fas fa-trash"></i> {{localize "TWODSIX.Items.Traits.DeleteEffect"}}</button>
+  <button type="button" class="edit-active-effect"><i class="fas fa-edit"></i> {{localize "TWODSIX.Items.Traits.EditEffect"}}</button>
+  <button type="button" class="delete-active-effect"><i class="fas fa-trash"></i> {{localize "TWODSIX.Items.Traits.DeleteEffect"}}</button>
   {{else}}
-  <button class="create-active-effect"><i class="fas fa-plus"></i> {{localize "TWODSIX.Items.Traits.CreateEffect"}}</button>
+  <button type="button" class="create-active-effect"><i class="fas fa-plus"></i> {{localize "TWODSIX.Items.Traits.CreateEffect"}}</button>
   {{/if}}
 </div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fixes and refactor


* **What is the current behavior?** (You can also link to an open issue here)
- Hitting enter on actor sheets defaults to init roll or item sheets to create AE
- Vehicle armaments don't show qty correctly
- battle sheet not using max hit setting
- Vehicle sheet doesn't have popup indicator
- Redundant HTML for component qty, status, and popup state
- Ship component headers not sticky
- error when rolling weapon attack with invalid skill id
- Animals and actors can't have skill AE's

* **What is the new behavior (if this is a feature change)?**
- Stop enter from auto rolling init and creating AE
- Vehicle armaments show qty correctly
- Battle sheet now uses max hit setting
- Vehicle sheet now has popup indicator for armaments
- Create partials for component qty, status and popup state
- Make component headers sticky
- Use untrained or show error when weapon skill id is invalid
- Allow actors and animals to have derived data AE's (notably skills)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
