### PR TITLE
fix: changing item type in compendium throws error

### DIFF
--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -190,9 +190,19 @@ export class TwodsixItemSheet extends AbstractTwodsixItemSheet {
     duplicateItem.system.priorType = this.item.type;
     duplicateItem.system.type = newType;
     duplicateItem.type = newType;
-    const newItem = await TwodsixItem.create(duplicateItem, {renderSheet: true, parent: this.item.parent});
+    const options = {renderSheet: true};
+    if (this.item.pack) {
+      options.pack = this.item.pack;
+    } else {
+      options.parent = this.item.parent;
+    }
+    const newItem = await TwodsixItem.create(duplicateItem, options);
     if (newItem) {
-      this.item.delete();
+      if (this.item.pack) {
+        this.item.delete({pack: this.item.pack});
+      } else {
+        this.item.delete();
+      }
     }
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Changing item type in a world compendium causes error and item is moved to item sidebar rather than staying in pack


* **What is the new behavior (if this is a feature change)?**
Compendium item type changes are preserved in pack.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
