### PR TITLE
fix: psiPoints show zero on canceled skill roll

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -660,13 +660,11 @@ export default class TwodsixItem extends Item {
   }
 
   /**
-   * Perform post skill roll actions for using psiAbility (damage and use of psi points).
-   * @param {TwodsixDiceRoll} diceRollEffect Results effect of psionic skill check
-   * @param {DICE_ROLL_MODES} rollMode The rollMode (who roll is shared with)
-   * @param {boolean} showThrowDiag whether or not to show throw dialog for damage
-   * @returns {number} The number of psi points used
+   * Dialog to determine number of psi points used for action. Returns either a number or undefined (canceled points)
+   * @param {number} diceRollEffect Results effect of psionic skill check
+   * @returns {number|undefined} The number of psi points used or undefined if selection cancelled
    */
-  async processPsiAction(diceRollEffect:number, rollMode:DICE_ROLL_MODES, showThrowDiag:boolean): Promise<number> {
+  async processPsiPoints(diceRollEffect:number): Promise<number|undefined> {
     if(diceRollEffect < 0) {
       await (<TwodsixActor>this.actor).removePsiPoints(1);
       return 1;
@@ -678,25 +676,19 @@ export default class TwodsixItem extends Item {
           content: `<input name="psiCost" value="${this.system.psiCost}" type="number" min="1" max="10" step="1" autofocus>`,
           ok: {
             label: "TWODSIX.Items.Psionics.UsePoints",
-            callback: (event, button /*, dialog*/) => button.form.elements.psiCost.valueAsNumber
+            callback: (event, button /*, dialog*/) => Math.round(button.form.elements.psiCost.valueAsNumber)
           }
         });
       } catch {
         console.log("No psionic points selected");
-        return 0;
+        return;
       }
 
       if(isNaN(psiCost) || psiCost <= 0) {
-        return 0;
-      } else if (this.system.damage !== "" && this.system.damage !== "0" && game.settings.get("twodsix", "automateDamageRollOnHit")) {
-        const damagePayload = await this.rollDamage(rollMode || game.settings.get('core', 'rollMode'), ` ${diceRollEffect}`, true, showThrowDiag);
-        if (damagePayload?.damageValue > 0) {
-          const targetTokens = Array.from(game.user.targets);
-          if (targetTokens.length > 0) {
-            await (<TwodsixActor>targetTokens[0].actor).handleDamageData(damagePayload, <boolean>!game.settings.get('twodsix', 'autoDamageTarget'));
-          }
-        }
+        ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.PsiUsageGTZero"));
+        return;
       }
+
       await (<TwodsixActor>this.actor).removePsiPoints(psiCost);
       return psiCost;
     }
@@ -719,7 +711,7 @@ export default class TwodsixItem extends Item {
    * @param {number} rollEffect the effect of the skill roll,used for damage calcs if necessary
    * @private
    */
-  private sendPsiUseToChat(pointsUsed:number, rollMode:DICE_ROLL_MODES , rollEffect:number=0):Promise<void> {
+  private async sendPsiUseToChat(pointsUsed:number, rollMode:DICE_ROLL_MODES , rollEffect:number=0):Promise<void> {
     const picture = this.img;
     const capType = game.i18n.localize(`TYPES.Item.${this.type}`).capitalize();
     let msg = `<div style="display: inline-flex;"><img src="${picture}" alt="" class="chat-image"></img><span style="padding-left: 1ch;">`
@@ -748,7 +740,7 @@ export default class TwodsixItem extends Item {
       Object.assign(messageContent, {whisper: showToUsers});
     }
 
-    ChatMessage.create(messageContent);
+    await ChatMessage.create(messageContent);
   }
 
   /**
@@ -770,26 +762,41 @@ export default class TwodsixItem extends Item {
    * @private
    */
   private async doPsiAction(showThrowDiag: boolean): Promise<void> {
-    let psiCost = 0;
+    let psiCost: number|undefined;
     let rollEffect = 0;
     let rollMode = "gmroll";
     if ((<TwodsixActor>this.actor).system.characteristics.psionicStrength.current <= 0) {
       ui.notifications.warn(game.i18n.localize("TWODSIX.Warnings.NoPsiPoints"));
     } else {
       await this.drawItemTemplate();
+
       if (!game.settings.get('twodsix', 'psiTalentsRequireRoll')) {
-        psiCost = await this.processPsiAction(0, rollMode, showThrowDiag);
+        psiCost = await this.processPsiPoints(0);
       } else {
         const diceRoll = await this.skillRoll(showThrowDiag);
         if (diceRoll) {
           rollMode = diceRoll.rollSettings.rollMode;
-          psiCost = await this.processPsiAction(diceRoll.effect, rollMode, showThrowDiag);
           rollEffect = diceRoll.effect;
+          psiCost = await this.processPsiPoints(rollEffect);
         } else {
           return;
         }
       }
-      await this.sendPsiUseToChat(psiCost, rollMode, rollEffect);
+
+      if (psiCost !== undefined) {
+        await this.sendPsiUseToChat(psiCost, rollMode, rollEffect);
+
+        // Roll damage and post, if necessary
+        if (this.system.damage !== "" && this.system.damage !== "0" && game.settings.get("twodsix", "automateDamageRollOnHit")) {
+          const damagePayload = await this.rollDamage(rollMode || game.settings.get('core', 'rollMode'), ` ${rollEffect}`, true, showThrowDiag);
+          if (damagePayload?.damageValue > 0) {
+            const targetTokens = Array.from(game.user.targets);
+            if (targetTokens.length > 0) {
+              await (<TwodsixActor>targetTokens[0].actor).handleDamageData(damagePayload, <boolean>!game.settings.get('twodsix', 'autoDamageTarget'));
+            }
+          }
+        }
+      }
     }
   }
 

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -686,8 +686,8 @@ export default class TwodsixItem extends Item {
         return 0;
       }
 
-      if(isNaN(psiCost)) {
-        return;
+      if(isNaN(psiCost) || psiCost <= 0) {
+        return 0;
       } else if (this.system.damage !== "" && this.system.damage !== "0" && game.settings.get("twodsix", "automateDamageRollOnHit")) {
         const damagePayload = await this.rollDamage(rollMode || game.settings.get('core', 'rollMode'), ` ${diceRollEffect}`, true, showThrowDiag);
         if (damagePayload?.damageValue > 0) {
@@ -785,6 +785,8 @@ export default class TwodsixItem extends Item {
           rollMode = diceRoll.rollSettings.rollMode;
           psiCost = await this.processPsiAction(diceRoll.effect, rollMode, showThrowDiag);
           rollEffect = diceRoll.effect;
+        } else {
+          return;
         }
       }
       await this.sendPsiUseToChat(psiCost, rollMode, rollEffect);

--- a/src/module/hooks/itemPilesIntegration.ts
+++ b/src/module/hooks/itemPilesIntegration.ts
@@ -3,7 +3,7 @@
 Hooks.once("item-piles-ready", async function() {
   /// Called once Item Piles is ready to be used
   game.itempiles.API.addSystemIntegration({
-    "VERSION": "1.0.5",
+    "VERSION": "3.1.6",
 
     // The actor class type is the type of actor that will be used for the default item pile actor that is created on first item drop.
     "ACTOR_CLASS_TYPE": "traveller",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1684,7 +1684,9 @@
       "CantFindMeleeSkill": "Can't find Melee Combat skill",
       "CantFindMeleeWeapon": "Can't find an equipped melee weapon to parry",
       "CantFindShield": "Can't find an equipped shield to block",
-      "NoPsiPoints": "Must have at least one psionic point to use an ability"
+      "NoPsiPoints": "Must have at least one psionic point to use an ability",
+      "PsiUsageGTZero": "PSI Points used must be greater than zero"
+
     }
   },
   "TYPES": {


### PR DESCRIPTION
canceled skill rolls now don't display zero psi

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When cancelling a psi action skill roll, chat displays psi action used for zero points


* **What is the new behavior (if this is a feature change)?**
No chat message


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
