### PR TITLE
fix: damage roll for psionic use when effect negative

### DIFF
--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -787,8 +787,9 @@ export default class TwodsixItem extends Item {
         await this.sendPsiUseToChat(psiCost, rollMode, rollEffect);
 
         // Roll damage and post, if necessary
-        if (this.system.damage !== "" && this.system.damage !== "0" && game.settings.get("twodsix", "automateDamageRollOnHit")) {
-          const damagePayload = await this.rollDamage(rollMode || game.settings.get('core', 'rollMode'), ` ${rollEffect}`, true, showThrowDiag);
+        if (this.system.damage !== "" && this.system.damage !== "0" && game.settings.get("twodsix", "automateDamageRollOnHit") && rollEffect >=0 ) {
+          const bonusDamage:string = game.settings.get("twodsix", "addEffectToDamage") && rollEffect !== 0 ?  ` ${rollEffect}` : ``;
+          const damagePayload = await this.rollDamage(rollMode || game.settings.get('core', 'rollMode'), bonusDamage, true, showThrowDiag);
           if (damagePayload?.damageValue > 0) {
             const targetTokens = Array.from(game.user.targets);
             if (targetTokens.length > 0) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Damage roll is made for psionic abilities when roll effect is negative (failure)


* **What is the new behavior (if this is a feature change)?**
No damage roll when effect is negative


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
