### PR TITLE
fix:  max encumbrance so displays correctly when encumbered in CT

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -459,7 +459,16 @@ export default class TwodsixActor extends Actor {
     let maxEncumbrance = 0;
     const encumbFormula = game.settings.get('twodsix', 'maxEncumbrance');
     if (Roll.validate(encumbFormula)) {
-      const rollData = game.settings.get('twodsix', 'ruleset') === 'CT' && this._source ? this._source.system : this.getRollData();
+      const rollData = this.system;
+      if (game.settings.get('twodsix', 'ruleset') === 'CT') {
+        const encumberedEffect = this.effects.find(eff  => eff.statuses.has('encumbered'));
+        if (encumberedEffect) {
+          const delta = parseInt(encumberedEffect.changes[0].value) ?? 0;
+          rollData.characteristics.strength.value -= delta;
+          rollData.characteristics.dexterity.value -= delta;
+          rollData.characteristics.endurance.value -= delta;
+        }
+      }
       maxEncumbrance = Roll.safeEval(Roll.replaceFormulaData(encumbFormula, rollData, {missing: "0", warn: false}));
     }
     return Math.max(maxEncumbrance, 0);

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -459,7 +459,8 @@ export default class TwodsixActor extends Actor {
     let maxEncumbrance = 0;
     const encumbFormula = game.settings.get('twodsix', 'maxEncumbrance');
     if (Roll.validate(encumbFormula)) {
-      maxEncumbrance = Roll.safeEval(Roll.replaceFormulaData(encumbFormula, this.getRollData(), {missing: "0", warn: false}));
+      const rollData = game.settings.get('twodsix', 'ruleset') === 'CT' && this._source ? this._source.system : this.getRollData();
+      maxEncumbrance = Roll.safeEval(Roll.replaceFormulaData(encumbFormula, rollData, {missing: "0", warn: false}));
     }
     return Math.max(maxEncumbrance, 0);
   }

--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -466,7 +466,8 @@ export default class TwodsixActor extends Actor {
         const encumberedEffect:TwodsixActiveEffect = this.effects.find(eff  => eff.statuses.has('encumbered'));
         if (encumberedEffect) {
           for (const change of encumberedEffect.changes) {
-            foundry.utils.mergeObject(rollData, {[change.key]: foundry.utils.getProperty(this, change.key) - parseInt(change.value)});
+            const rollKey = change.key.replace('system.', '');
+            foundry.utils.mergeObject(rollData, {[rollKey]: foundry.utils.getProperty(this, change.key) - parseInt(change.value)});
           }
         }
       } else {

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -928,12 +928,12 @@ h2 {
 }
 
 .status-icons.npc {
-  position: relative !important;
-  top: -20.5ch;
-  /* height: -webkit-fill-available !important; */
+  position: absolute !important;
+  top: 2ch;
+  left: 1ch !important;
   align-content: flex-start;
-  /* flex-wrap: wrap; */
 }
+
 .condition-icon {
   height: auto;
   width: 3ch;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -549,8 +549,9 @@ img.character-info-mask {
 }
 
 .status-icons.npc {
-  position: relative !important;
-  top: -22.5ch;
+  position: absolute !important;
+  top: 2ch;
+  left: 1ch !important;
   align-content: flex-start;
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
max encumbrance includes AE STR change when encumbered
AE icons on NPC sheet not left-aligned

* **What is the new behavior (if this is a feature change)?**
Display max encumbrance without AE
AE Icons on NPC left justified

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
