### PR TITLE
fix: make applying damage from chat card context function

### DIFF
--- a/src/module/hooks/addChatContext.ts
+++ b/src/module/hooks/addChatContext.ts
@@ -62,7 +62,7 @@ function applyChatCardDamage(li, multiplier) {
       if (["traveller", "robot", "animal"].includes(t.actor.type)) {
         const damage = Math.floor(effect * multiplier);
         if (damage > 0) {
-          t.actor.damageActor(Math.floor(effect * multiplier), transfer?.payload.armorPiercingValue ?? 0, transfer?.payload.damageType ?? "", true);
+          (<TwodsixActor>t.actor).damageActor({damageValue: damage, armorPiercingValue: transfer?.payload.armorPiercingValue ?? 0, damageType: transfer?.payload.damageType ?? ""}, true);
         } else if (multiplier < 0) {
           t.actor.healActor(effect);
         }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
can't apply damage from chat card context


* **What is the new behavior (if this is a feature change)?**
Applying damage for chat card context works.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
