### PR TITLE
fix: default item damage formula

### DIFF
--- a/src/module/data/item.ts
+++ b/src/module/data/item.ts
@@ -12,7 +12,7 @@ export class WeaponData extends GearData {
     const schema = super.defineSchema();
     schema.target = makeTargetTemplate();
     schema.range = new fields.StringField({...requiredBlankString});
-    schema.damage = new fields.StringField({required: true, blank: true, initial: "3d6" });
+    schema.damage = new fields.StringField({required: true, blank: true, initial: "" });
     schema.damageBonus = new fields.NumberField({required: true, nullable: true, integer: true, initial: 0});
     schema.magazineSize = new fields.NumberField({...requiredInteger, initial: 0});
     schema.ammo = new fields.NumberField({...requiredInteger, initial: 0}); //;new fields.StringField({...requiredBlankString});

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -74,7 +74,7 @@ export default class TwodsixItem extends Item {
       }
     }
 
-    if (this.type === 'weapon'  && !Object.hasOwn(data, "system")) {
+    if (this.type === 'weapon'  && !Object.keys(data.system ?? {}).includes('damage')) {
       Object.assign(updates, {"system.damage": game.settings.get('twodsix', 'defaultWeaponDamage')});
     }
 

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -74,7 +74,7 @@ export default class TwodsixItem extends Item {
       }
     }
 
-    if (this.type === 'weapon') {
+    if (this.type === 'weapon'  && !Object.hasOwn(data, "system")) {
       Object.assign(updates, {"system.damage": game.settings.get('twodsix', 'defaultWeaponDamage')});
     }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
drag-dropping weapon resets damage formula to default


* **What is the new behavior (if this is a feature change)?**
drag-drop preserves damage formula


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
