### PR TITLE
fix: Allow Token Action HUD to work with v13

### DIFF
--- a/src/module/sheets/TwodsixItemSheet.ts
+++ b/src/module/sheets/TwodsixItemSheet.ts
@@ -61,13 +61,13 @@ export class TwodsixItemSheet extends foundry.applications.api.HandlebarsApplica
   static TABS = {
     primary: {
       tabs: [
-        {id: "description", group: "primary", icon: "fa-solid fa-book", label: "TWODSIX.Items.Equipment.Description"},
-        {id: "modifiers", group: "primary", icon: "fa-solid fa-dice", label: "TWODSIX.Items.Weapon.Modifiers"},
-        {id: "attack", group: "primary", icon: "fa-solid fa-burst", label: "TWODSIX.Items.Weapon.Attack"},
-        {id: "magazine", group: "primary", icon: "fa-solid fa-battery-full", label: "TWODSIX.Items.Weapon.Consumables"},
-        {id: "displacement", group: "primary", icon: "fa-solid fa-weight-hanging", label: "TWODSIX.Items.Component.Displacement"},
-        {id: "power", group: "primary", icon: "fa-solid fa-bolt", label: "TWODSIX.Items.Component.Power"},
-        {id: "price", group: "primary", icon: "fa-solid fa-coins", label: "TWODSIX.Items.Component.Price"}
+        {id: "description", icon: "fa-solid fa-book", label: "TWODSIX.Items.Equipment.Description"},
+        {id: "modifiers", icon: "fa-solid fa-dice", label: "TWODSIX.Items.Weapon.Modifiers"},
+        {id: "attack", icon: "fa-solid fa-burst", label: "TWODSIX.Items.Weapon.Attack"},
+        {id: "magazine", icon: "fa-solid fa-battery-full", label: "TWODSIX.Items.Weapon.Consumables"},
+        {id: "displacement", icon: "fa-solid fa-weight-hanging", label: "TWODSIX.Items.Component.Displacement"},
+        {id: "power", icon: "fa-solid fa-bolt", label: "TWODSIX.Items.Component.Power"},
+        {id: "price", icon: "fa-solid fa-coins", label: "TWODSIX.Items.Component.Price"}
       ],
       initial: "description"
     }

--- a/src/module/utils/ItemTemplate.ts
+++ b/src/module/utils/ItemTemplate.ts
@@ -100,7 +100,9 @@ export default class ItemTemplate extends foundry.canvas.placeables.MeasuredTemp
     this.layer.preview?.addChild(this);
 
     // Hide the sheet that originated the preview
-    this.actorSheet?.minimize();
+    if (this.actorSheet?.state > 0) {
+      this.actorSheet?.minimize();
+    }
 
     // Activate interactivity
     return this.activatePreviewListeners(initialLayer);
@@ -146,7 +148,9 @@ export default class ItemTemplate extends foundry.canvas.placeables.MeasuredTemp
     canvas.app.view.oncontextmenu = null;
     canvas.app.view.onwheel = null;
     this.#initialLayer.activate();
-    await this.actorSheet?.maximize();
+    if (this.actorSheet?.state > 0) {
+      await this.actorSheet.maximize();
+    }
   }
 
   /* -------------------------------------------- */

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -4744,3 +4744,7 @@ section#settings a:hover {
 .scrollable {
   --scroll-margin: 0.2rem;
 }
+
+.package-title .title {
+  text-align: -webkit-match-parent;
+}

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -424,3 +424,8 @@ div.pdf-app section.window-content {
 #forien-quest-log .actions i, .window-app.forien-quest-preview .actions i {
 	color: 	var(--s2d6-default-color);
 }
+
+/******* Token Action HUD ********/
+.tah-groups {
+  flex-direction: row;
+}

--- a/static/templates/misc/navigation-tabs.hbs
+++ b/static/templates/misc/navigation-tabs.hbs
@@ -1,9 +1,11 @@
-<nav class="sheet-tabs tabs" aria-roledescription="{{localize 'SHEETS.FormNavLabel'}}">
+<nav class="sheet-tabs tabs{{#if verticalTabs}} vertical{{/if}}"
+aria-roledescription="{{localize 'SHEETS.FormNavLabel'}}">
   {{#each tabs as |tab|}}
-  <a class="{{tab.cssClass}}" data-action="tab" data-group="{{tab.group}}" data-tab="{{tab.id}}"
+  <a data-action="tab" data-group="{{tab.group}}" data-tab="{{tab.id}}"
+      {{#if tab.cssClass}}class="{{tab.cssClass}}"{{/if}}
       {{#if tab.tooltip}}data-tooltip="{{tab.tooltip}}"{{/if}}>
       {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
-      {{#if tab.label}}<label>{{localize tab.label}}</label>{{/if}}
+      {{#if tab.label}}<span>{{localize tab.label}}</span>{{/if}}
   </a>
   {{/each}}
 </nav>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fixes


* **What is the current behavior?** (You can also link to an open issue here)
TAH displays groups in columns rather than rows
Using an item with a template causes an error
New tab code for AppV2 is not quite correct


* **What is the new behavior (if this is a feature change)?**
Force TAH to display in rows if using module fix
Gate sheet min and max when using TAH
Refactor tab code for items

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO


* **Other information**:
