### PR TITLE
fix: re-add CUSTOM calc mode back to applyActiveEffectsCustom

### DIFF
--- a/src/module/entities/TwodsixActor.ts
+++ b/src/module/entities/TwodsixActor.ts
@@ -1261,7 +1261,7 @@ export default class TwodsixActor extends Actor {
     // Organize non-disabled effect changes using derived data list by their application priority
     const changes = [];
     for ( const effect of this.appliedEffects ) {
-      changes.push(...effect.changes.filter( change => (derivedData.includes(change.key))).map(change => {
+      changes.push(...effect.changes.filter( change => (derivedData.includes(change.key) || change.mode === CONST.ACTIVE_EFFECT_MODES.CUSTOM)).map(change => {
         const c = foundry.utils.deepClone(change);
         c.effect = effect;
         c.priority = c.priority ?? (c.mode * 10 - 100); //Add -100 to force pritority of derived data earlier


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
With update to v13, applyActiveEffectCustom deleted calculations for CUSTOM calculations as part of workflow.


* **What is the new behavior (if this is a feature change)?**
CUSTOM AE calculations now included with applyActiveEffectCustom


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
