### PR TITLE
feat: add basic DM modifier for component damage

### DIFF
--- a/src/module/settings/RulesetSettings.ts
+++ b/src/module/settings/RulesetSettings.ts
@@ -152,6 +152,7 @@ export default class RulesetSettings extends foundry.applications.api.Handlebars
     settings.roll.push(stringSetting('chainBonus', "", false, 'world'));
     settings.roll.push(booleanSetting("psiTalentsRequireRoll", false));
     settings.roll.push(booleanSetting("xd6RollStyle", false));
+    settings.ship.push(numberSetting('componentDamageDM', 0, false));
     return settings;
   }
 }

--- a/src/module/utils/TwodsixDiceRoll.ts
+++ b/src/module/utils/TwodsixDiceRoll.ts
@@ -200,6 +200,9 @@ export class TwodsixDiceRoll {
     // Add item related modifiers
     if (this.rollSettings.itemRoll) {
       returnValue.push("item");
+      if (this.rollSettings.rollModifiers.componentDamage) {
+        returnValue.push("componentDamage");
+      }
       if (this.rollSettings.rollModifiers.rof) {
         returnValue.push("rof");
       }
@@ -329,6 +332,7 @@ export class TwodsixDiceRoll {
           case "weaponsRange":
           case "dodgeParry":
           case "armorModifier":
+          case "componentDamage":
             flavorText += ` + ${description}`;
             flavorTable += `<tr><td>${game.i18n.localize("TWODSIX.Chat.Roll.Attack")}</td><td>${description}</td>`;
             break;

--- a/src/module/utils/TwodsixRollSettings.ts
+++ b/src/module/utils/TwodsixRollSettings.ts
@@ -142,6 +142,7 @@ export class TwodsixRollSettings {
       wounds: woundsValue,
       skillValue: skillValue ?? 0,
       item: anItem?.type === "component" ? (parseInt(gear?.rollModifier, 10) || 0) : gear?.skillModifier ?? 0 ,  //need to check for component that uses rollModifier (needs a refactor)
+      componentDamage: anItem?.type === "component" ? (gear?.hits * game.settings.get('twodsix', 'componentDamageDM') || 0) : 0 ,
       attachments: anItem?.system?.consumables?.length > 0 ? anItem?.getConsumableBonus("skillModifier") ?? 0 : 0,
       other: settings?.rollModifiers?.other ?? 0,
       encumbered: encumberedValue,
@@ -242,7 +243,8 @@ export class TwodsixRollSettings {
       showConditions: (game.settings.get('twodsix', 'useWoundedStatusIndicators') || game.settings.get('twodsix', 'useEncumbranceStatusIndicators')),
       showWounds: game.settings.get('twodsix', 'useWoundedStatusIndicators'),
       showEncumbered: game.settings.get('twodsix', 'useEncumbranceStatusIndicators'),
-      isPsionicAbility: this.isPsionicAbility
+      isPsionicAbility: this.isPsionicAbility,
+      isComponent: ["ShipAction", "ShipWeapon"].includes(this.flags.rollClass)
     };
 
     const buttons = [
@@ -260,6 +262,7 @@ export class TwodsixRollSettings {
           this.rollModifiers.chain = dialogData.skillRoll ? parseInt(formElements["rollModifiers.chain"]?.value || 0, 10) : this.rollModifiers.chain;
           this.rollModifiers.characteristic = dialogData.skillRoll ? formElements["rollModifiers.characteristic"]?.value : this.rollModifiers.characteristic;
           this.rollModifiers.item = dialogData.itemRoll ? parseInt(formElements["rollModifiers.item"]?.value || 0, 10) : this.rollModifiers.item;
+          this.rollModifiers.componentDamage = dialogData.isComponent ? parseInt(formElements["rollModifiers.componentDamage"]?.value || 0, 10) : this.rollModifiers.componentDamage;
           this.rollModifiers.rof = (dialogData.itemRoll && dialogData.rollModifiers.rof) ? parseInt(formElements["rollModifiers.rof"]?.value || 0, 10) : this.rollModifiers.rof;
           this.rollModifiers.dodgeParry = (dialogData.itemRoll && dialogData.rollModifiers.dodgeParry) ? parseInt(formElements["rollModifiers.dodgeParry"]?.value || 0, 10) : this.rollModifiers.dodgeParry;
           this.rollModifiers.weaponsHandling = (dialogData.itemRoll && dialogData.rollModifiers.weaponsHandling) ? parseInt(formElements["rollModifiers.weaponsHandling"]?.value || 0, 10) : this.rollModifiers.weaponsHandling;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -336,6 +336,7 @@
         "RollModifiers": "Roll Modifiers",
         "SkillModifier": "Skill Level",
         "ItemModifier": "Item Bonus",
+        "ComponentDamage": "Component Damage",
         "AbilityModifier": "Ability Level",
         "Rof": "Rate-of-Fire",
         "Wounds": "Wounds",
@@ -1632,6 +1633,10 @@
       "showCommonFundsMCr": {
         "hint": "Use MCr units to display ship common funds",
         "name": "Display ship common funds as MCr"
+      },
+      "componentDamageDM": {
+        "hint": "The roll DM that is applied for each hit to a component.",
+        "name": "Component Damage DM"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/templates/chat/throw-dialog.hbs
+++ b/static/templates/chat/throw-dialog.hbs
@@ -47,6 +47,14 @@
           <input type="number" name="rollModifiers.item" value="{{rollModifiers.item}}" placeholder="0" onClick="this.select();" />
           ({{itemLabel}})
         </div>
+
+        {{#iff rollModifiers.componentDamage "!==" 0}}
+          <div class="form-group">
+            <label>{{localize "TWODSIX.Chat.Roll.ComponentDamage"}}</label>
+            <input type="number" name="rollModifiers.componentDamage" value="{{rollModifiers.componentDamage}}" placeholder="0" onClick="this.select();" />
+          </div>
+        {{/iff}}
+
         {{#iff rollModifiers.rof "!==" 0}}
           <div class="form-group">
             <label>{{localize "TWODSIX.Chat.Roll.Rof"}}</label>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
DM for damaged ship components must be added manually


* **What is the new behavior (if this is a feature change)?**
Optional multiplier (setting) is added to add a DM based on the number of component hits


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
