### PR TITLE
refactor: precompute actor field tooltips with AE's

### DIFF
--- a/src/module/handlebars.ts
+++ b/src/module/handlebars.ts
@@ -8,7 +8,6 @@ import TwodsixItem from "./entities/TwodsixItem";
 import TwodsixActor, { getPower, getWeight } from "./entities/TwodsixActor";
 import { getCharacteristicList } from "./utils/TwodsixRollSettings";
 import { simplifySkillName } from "./utils/utils";
-import { calcModFor } from "./utils/sheetUtils";
 
 export default function registerHandlebarsHelpers(): void {
 
@@ -251,50 +250,6 @@ export default function registerHandlebarsHelpers(): void {
 
   Handlebars.registerHelper('twodsix_showTimeframe', () => {
     return game.settings.get('twodsix', 'showTimeframe');
-  });
-
-  Handlebars.registerHelper('twodsix_getTooltip', (actor:TwodsixActor, field:string) => {
-    let returnValue = ``;
-    if (actor) {
-      const modes = [`<i class="fa-regular fa-circle-question"></i>`, `<i class="fa-regular fa-circle-xmark"></i>`, `<i class="fa-solid fa-circle-plus"></i>`, `<i class="fa-regular fa-circle-down"></i>`, `<i class="fa-regular fa-circle-up"></i>`, `<i class="fa-solid fa-shuffle"></i>`];
-      if (foundry.utils.getProperty(actor.overrides, field) !== undefined) {
-        returnValue += field.includes('Armor') ? `- ` : ``;
-        const baseText = game.i18n.localize("TWODSIX.ActiveEffects.BaseValue");
-        const modifierText = game.i18n.localize("TWODSIX.ActiveEffects.Modifiers");
-        let baseValue = 0;
-        if (field.includes('skills')) {
-          const simplifiedName = field.replace('system.skills.', '');
-          if (simplifiedName) {
-            const coreSkill = actor.itemTypes.skills.find(sk => simplifySkillName(sk.name) === simplifiedName);
-            baseValue = coreSkill?.system.value;
-          }
-        } else if (field.includes('encumbrance.max')) {
-          baseValue = actor.getMaxEncumbrance();
-        } else if (field.includes('mod')) {
-          baseValue =  calcModFor(foundry.utils.getProperty(actor._source, field.replace('mod', 'value')));
-        } else {
-          baseValue = foundry.utils.getProperty(actor._source, field);
-        }
-
-        if (baseValue === foundry.utils.getProperty(actor, field)) {
-          baseValue = undefined;
-        }
-
-        returnValue += `${baseText}: ${isNaN(baseValue) ? "?" : baseValue}. ${modifierText}: `;
-        const workingEffects = actor.appliedEffects;
-        for (const effect of workingEffects) {
-          const realChanges = effect.changes.filter(ch => ch.key === field);
-          if (realChanges.length > 0) {
-            returnValue += `${effect.name}: `;
-            for (const change of realChanges) {
-              returnValue += `${modes[change.mode]}(${change.value}), `;
-            }
-          }
-        }
-        returnValue = returnValue.slice(0, -2);
-      }
-    }
-    return returnValue;
   });
 
   Handlebars.registerHelper('twodsix_hideItem', (display:boolean, itemLocation:string) => {

--- a/static/templates/actors/animal-sheet.hbs
+++ b/static/templates/actors/animal-sheet.hbs
@@ -54,9 +54,9 @@
               <span class="item" data-item-id="{{item.id}}" style = "display: inline-block;">
                 <span class="item-name rollable" data-label="{{item.name}}" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-action="skillTalentRoll">{{item.name}}</span>
                 <input style="width: 4ch;"  type="number"
-                  {{disabled (twodsix_getTooltip actor (concat 'system.skills.' (skillName item.name)))}}
+                  {{disabled (lookup @root.tooltips.skills (skillName item.name))}}
                   value="{{twodsix_skillTotal ../actor item}}"
-                  data-tooltip="{{twodsix_getTooltip actor (concat 'system.skills.' (skillName item.name))}}"
+                  data-tooltip="{{lookup @root.tooltips.skills (skillName item.name)}}"
                   class= "item-value-edit" value="{{item.system.value}}" data-action="selectItem"
                 />
                 <span class="item-controls centre">

--- a/static/templates/actors/parts/actor/actor-animal-robot-damage.hbs
+++ b/static/templates/actors/parts/actor/actor-animal-robot-damage.hbs
@@ -1,15 +1,19 @@
 {{#if settings.useHits}}
     <span class="bgi-char-narrow bgi-hits-value" ><i class="fa-solid fa-heart-pulse" data-tooltip='{{localize "TWODSIX.Actor.Hits"}}'></i>:
       <input type="number" value="{{system.characteristics.lifeblood.value}}" min="0"
-        {{disabled (twodsix_getTooltip actor 'system.characteristics.lifeblood.value')}}
-        data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.lifeblood.value'}}"
+        {{disabled tooltips.characteristics.lifeblood.value}}
+        data-tooltip="{{tooltips.characteristics.lifeblood.value}}"
         name="system.characteristics.lifeblood.value"
       />-
     </span>
     <span class="bgi-char-wide bgi-hits-damage" data-tooltip='{{localize "TWODSIX.Actor.Hits"}}'>
     <input type="number" name="system.characteristics.lifeblood.damage" value="{{system.characteristics.lifeblood.damage}}" min="0" max="{{system.characteristics.lifeblood.value}}"/></span>
-    <span class="bgi-char-wide bgi-radiationDose" ><i class="fa-solid fa-radiation" data-tooltip='{{localize "TWODSIX.Actor.RadiationExposure"}}'></i>:<input
-      name="system.radiationDose.value" value={{system.radiationDose.value}} min="0" type="number" data-tooltip="{{twodsix_getTooltip actor 'system.radiationDose.value'}}"/></span><br>
+    <span class="bgi-char-wide bgi-radiationDose" >
+      <i class="fa-solid fa-radiation" data-tooltip='{{localize "TWODSIX.Actor.RadiationExposure"}}'></i>:<input
+      {{disabled tooltips.radiationDose.value}}
+      name="system.radiationDose.value" value={{system.radiationDose.value}} min="0" type="number"
+      data-tooltip="{{tooltips.radiationDose.value}}" />
+    </span><br>
   {{else if settings.lifebloodInsteadOfCharacteristics}}
     <span class="bgi-char-narrow bgi-endurance-value" data-tooltip='{{localize "TWODSIX.Actor.Endurance"}}'>
       {{#iff system.characteristics.endurance.value "===" system.characteristics.endurance.current}}
@@ -20,8 +24,8 @@
         <i class="fa-solid fa-battery-half"></i>
       {{/iff}}:
       <input type="number" value="{{system.characteristics.endurance.value}}" min="0"
-        {{disabled (twodsix_getTooltip actor 'system.characteristics.endurance.value')}}
-        data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.endurance.value'}}"
+        {{disabled tooltips.characteristics.endurance.value}}
+        data-tooltip="{{tooltips.characteristics.endurance.value}}"
         name="system.characteristics.endurance.value"
       />-
     </span>
@@ -29,8 +33,8 @@
             name="system.characteristics.endurance.damage" value="{{system.characteristics.endurance.damage}}" min="0" max="{{system.characteristics.endurance.value}}"/></span>
     <span class="bgi-char-narrow bgi-lifeblood-value"><i class="fa-solid fa-heart-pulse" data-tooltip='{{localize "TWODSIX.Actor.Lifeblood"}}'></i>:
       <input type="number" value="{{system.characteristics.strength.value}}" min="0"
-        {{disabled (twodsix_getTooltip actor 'system.characteristics.strength.value')}}
-        data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.strength.value'}}"
+        {{disabled tooltips.characteristics.strength.value}}
+        data-tooltip="{{tooltips.characteristics.strength.value}}"
         name="system.characteristics.strength.value"
       />-
     </span>
@@ -38,7 +42,10 @@
         <input type="number" name="system.characteristics.strength.damage" value="{{system.characteristics.strength.damage}}" min="0" max="{{system.characteristics.strength.value}}"/></span>
     {{#if settings.showContaminationBelowLifeblood}}
       <span class="bgi-char-wide bgi-radiationDose" ><i class="fa-solid fa-radiation" data-tooltip='{{localize "TWODSIX.Actor.Contamination"}}'></i>:<input
-        name="system.radiationDose.value" value={{system.radiationDose.value}} type="number" min="0" data-tooltip="{{twodsix_getTooltip actor 'system.radiationDose.value'}}"/></span>
+        {{disabled tooltips.radiationDose.value}}
+        name="system.radiationDose.value" value={{system.radiationDose.value}} type="number" min="0"
+        data-tooltip="{{tooltips.radiationDose.value}}"/>
+      </span>
     {{/if}}
     <br>
   {{else}}
@@ -52,8 +59,8 @@
         <i class="fa-solid fa-battery-half" data-tooltip='{{localize "TWODSIX.Actor.Stamina"}}'></i>
       {{/iff}}:
       <input type="number" value="{{system.characteristics.stamina.value}}" min="0"
-        {{disabled (twodsix_getTooltip actor 'system.characteristics.stamina.value')}}
-        data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.stamina.value'}}"
+        {{disabled tooltips.characteristics.stamina.value}}
+        data-tooltip="{{tooltips.characteristics.stamina.value}}"
         name="system.characteristics.stamina.value"
       />-
     </span>
@@ -61,8 +68,8 @@
             name="system.characteristics.stamina.damage" value="{{system.characteristics.stamina.damage}}" min="0" max="{{system.characteristics.stamina.value}}"/></span>
     <span class="bgi-char-narrow bgi-lifeblood-value" data-tooltip='{{localize "TWODSIX.Actor.Lifeblood"}}'><i class="fa-solid fa-heart-pulse"></i>:
       <input type="number" value="{{system.characteristics.lifeblood.value}}" min="0"
-        {{disabled (twodsix_getTooltip actor 'system.characteristics.lifeblood.value')}}
-        data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.lifeblood.value'}}"
+        {{disabled tooltips.characteristics.lifeblood.value}}
+        data-tooltip="{{tooltips.characteristics.lifeblood.value}}"
         name="system.characteristics.lifeblood.value"
       />-
     </span>
@@ -70,5 +77,8 @@
         <input type="number" name="system.characteristics.lifeblood.damage" value="{{system.characteristics.lifeblood.damage}}" min="0" max="{{system.characteristics.lifeblood.value}}"/></span>
     {{/if}}
     <span class="bgi-char-wide bgi-radiationDose" data-tooltip='{{localize "TWODSIX.Actor.RadiationExposure"}}'><i class="fa-solid fa-radiation"></i>:<input
-            name="system.radiationDose.value" value={{system.radiationDose.value}} type="number" min="0" data-tooltip="{{twodsix_getTooltip actor 'system.radiationDose.value'}}"/></span><br>
+      {{disabled tooltips.radiationDose.value}}
+      name="system.radiationDose.value" value={{system.radiationDose.value}} type="number" min="0"
+      data-tooltip="{{tooltips.radiationDose.value}}"/>
+      </span><br>
   {{/if}}

--- a/static/templates/actors/parts/actor/actor-animal-robot-protection.hbs
+++ b/static/templates/actors/parts/actor/actor-animal-robot-protection.hbs
@@ -1,23 +1,28 @@
 {{#if settings.useCTData}}
     <span class="bgi-armorType" data-tooltip='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fa-solid fa-user-shield"></i>:<select name="system.armorType">{{selectOptions config.CT_ARMOR_TYPES selected=system.armorType localize=true inverted=false}}</select></span>
-    <span class="bgi-armorDM">{{localize "TWODSIX.Items.Armor.armorDM"}}:<input name="system.armorDM" type="number" value="{{system.armorDM}}"
-      placeholder='0' data-tooltip="{{twodsix_getTooltip actor 'system.armorDM'}}" step="1"/></span><br>
+    <span class="bgi-armorDM">{{localize "TWODSIX.Items.Armor.armorDM"}}:<input name="system.armorDM" type="number"
+      {{disabled tooltips.armorDM}} value="{{system.armorDM}}"
+      placeholder='0' data-tooltip="{{tooltips.armorDM}}" step="1"/>
+    </span><br>
 {{else}}
   <span class="bgi-armor" data-tooltip='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fa-solid fa-user-shield"></i>:
     {{#unless settings.useCUData}}
       <input style="text-align: right; padding-left: 0;" type="number" value="{{system.primaryArmor.value}}" placeholder='0'
-      {{disabled (twodsix_getTooltip actor 'system.primaryArmor.value')}} name="system.primaryArmor.value" data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.PrimaryArmor') (twodsix_getTooltip actor 'system.primaryArmor.value')}}"/>+
+      {{disabled tooltips.primaryArmor.value}} name="system.primaryArmor.value"
+      data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.PrimaryArmor') tooltips.primaryArmor.value}}"/>+
     {{/unless}}
-    <input {{disabled (twodsix_getTooltip actor 'system.secondaryArmor.value')}} name="system.secondaryArmor.value" type="number" value="{{system.secondaryArmor.value}}" placeholder='0'
+    <input {{disabled tooltips.secondaryArmor.value}} name="system.secondaryArmor.value" type="number" value="{{system.secondaryArmor.value}}" placeholder='0'
       {{#if settings.useCUData}}
-        data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.Armor') (twodsix_getTooltip actor 'system.secondaryArmor.value')}}"
+        data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.Armor') tooltips.secondaryArmor.value}}"
       {{else}}
-        data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.SecondaryArmor') (twodsix_getTooltip actor 'system.secondaryArmor.value')}}"
+        data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.SecondaryArmor') tooltips.secondaryArmor.value}}"
       {{/if}} />
   </span>
   <span class="bgi-armor bgi-radProtect" data-tooltip='{{localize "TWODSIX.Items.Armor.RadProt"}}'><i class="fa-solid fa-circle-radiation"></i>:<input
-      {{disabled (twodsix_getTooltip actor 'system.radiationProtection.value')}} name="system.radiationProtection.value"
-      type="number" value="{{system.radiationProtection.value}}" placeholder='0' data-tooltip="{{localize 'TWODSIX.Items.Armor.RadProt'}}"/></span>
+      {{disabled tooltips.radiationProtection.value}} name="system.radiationProtection.value"
+      type="number" value="{{system.radiationProtection.value}}" placeholder='0'
+      data-tooltip="{{tooltips.radiationProtection.value}}"/>
+  </span>
   <span class="bgi-secondary" {{#unless settings.useCUData}} data-tooltip='{{localize "TWODSIX.Items.Armor.SecondaryArmorProtectionTypes"}}' {{else}} data-tooltip='{{localize "TWODSIX.Items.Armor.ArmorProtectionTypes"}}'{{/unless}}>
     <label for="system.secondaryArmor.protectionTypes"><i class="fa-solid fa-shield-halved"></i>: </label>
     <multi-select class="actor-sheet" name="system.secondaryArmor.protectionTypes">{{selectOptions settings.damageTypes selected=system.secondaryArmor.protectionTypes localize=true}}</multi-select>

--- a/static/templates/actors/parts/actor/actor-bgi-animal.hbs
+++ b/static/templates/actors/parts/actor/actor-bgi-animal.hbs
@@ -51,13 +51,22 @@
   <span class="bgi-reaction">
     <span class="roll-reaction orange" style="align-self: center;" data-action="rollReaction"><i class="fa-solid fa-person-circle-question" data-tooltip='{{localize "TWODSIX.Animal.Reaction"}}'></i>:</span>
     <span>{{localize "TWODSIX.Animal.Attack"}}:
-    <input name="system.reaction.attack" type="number" value="{{system.reaction.attack}}" data-tooltip="{{twodsix_getTooltip actor 'system.reaction.attack'}}"/>
+      <input name="system.reaction.attack" type="number"
+        {{disabled tooltips.reaction.attack}}
+        value="{{system.reaction.attack}}"
+        data-tooltip="{{tooltips.reaction.attack}}"/>
     </span>
     <span>{{localize "TWODSIX.Animal.Flee"}}:
-    <input name="system.reaction.flee" type="number" value="{{system.reaction.flee}}" data-tooltip="{{twodsix_getTooltip actor 'system.reaction.flee'}}"/>
+      <input name="system.reaction.flee" type="number"
+        {{disabled tooltips.reaction.flee}}
+        value="{{system.reaction.flee}}"
+        data-tooltip="{{tooltips.reaction.flee}}"/>
     </span>
     <span class="roll-morale orange" style="align-self: center;" data-action="rollMorale"><i class="fa-solid fa-hand-fist" data-tooltip='{{localize "TWODSIX.Animal.MoraleRoll"}}'></i>:</span>
-    <input name="system.moraleDM" type="text" value="{{system.moraleDM}}" data-tooltip="{{twodsix_getTooltip actor 'system.moraleDM'}}" placeholder='{{localize "TWODSIX.Items.Component.DM"}}'/>
+      <input name="system.moraleDM" type="text"
+        {{disabled tooltips.moraleDM}}
+        value="{{system.moraleDM}}"
+        data-tooltip="{{tooltips.moraleDM}}" placeholder='{{localize "TWODSIX.Items.Component.DM"}}'/>
     </span>
   <br>
   {{/if}}

--- a/static/templates/actors/parts/actor/actor-bgi-cd.hbs
+++ b/static/templates/actors/parts/actor/actor-bgi-cd.hbs
@@ -11,8 +11,8 @@
 <span class="bgi-age" data-tooltip='{{localize "TWODSIX.Actor.Age"}}'>
   <i class="fa-solid fa-calendar-days"></i>:
   <input type="number" value="{{system.age.value}}" min="0"
-    {{disabled (twodsix_getTooltip actor 'system.age.value')}}
-    data-tooltip="{{twodsix_getTooltip actor 'system.age.value'}}"
+    {{disabled tooltips.age.value}}
+    data-tooltip="{{tooltips.age.value}}"
     name="system.age.value"
     placeholder="0" data-dtype="Number" />
 </span>
@@ -34,29 +34,32 @@
 <!-- Protection Information-->
 {{#if settings.useCTData}}
     <span class="bgi-armorType" data-tooltip='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fa-solid fa-user-shield"></i>:<input name="system.armorType" type="text" value="{{localize (concat 'TWODSIX.Chat.Roll.ArmorTypes.' system.armorType)}}"
-      placeholder='0' readonly data-tooltip="{{twodsix_getTooltip actor 'system.armorType'}}"/>
+      placeholder='0' readonly data-tooltip="{{tooltips.armorType}}"/>
       {{#if system.reflectOn}}<i class="fa-solid fa-arrow-trend-up" data-tooltip="{{localize 'TWODSIX.Items.Armor.WearingReflec'}}"></i>{{/if}}
     </span>
     <span class="bgi-armorDM">{{localize "TWODSIX.Items.Armor.armorDM"}}:<input type="number" value="{{system.armorDM}}"
-      placeholder='0' readonly data-tooltip="{{twodsix_getTooltip actor 'system.armorDM'}}"/></span><br>
+      placeholder='0' readonly data-tooltip="{{tooltips.armorDM}}"/></span><br>
 {{else}}
   <span class="bgi-armor" data-tooltip='{{localize "TWODSIX.Items.Armor.Armor"}}'><i class="fa-solid fa-user-shield"></i>:
     {{#unless settings.useCUData}}
-      <input style="text-align: right; padding-left: 0;" type="number" value="{{system.primaryArmor.value}}" placeholder='0' readonly data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.PrimaryArmor') (twodsix_getTooltip actor 'system.primaryArmor.value')}}"/>
+      <input style="text-align: right; padding-left: 0;" type="number" value="{{system.primaryArmor.value}}" placeholder='0' readonly
+      data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.PrimaryArmor') tooltips.primaryArmor.value}}"/>
       {{#unless settings.showTotalArmor}}
         +<input type="number" value="{{system.secondaryArmor.value}}"
-            placeholder='0' readonly data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.SecondaryArmor') system.protectionTypes}}"/>
+            placeholder='0' disabled data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.SecondaryArmor') system.protectionTypes}}"/>
       {{else}}
         /<input type="number" value="{{system.totalArmor}}"
-            placeholder='0' readonly data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.TotalArmor') system.protectionTypes}}"/>
+            placeholder='0' disabled data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.TotalArmor') system.protectionTypes}}"/>
       {{/unless}}
     {{else}}
       <input name="system.secondaryArmor.value" type="number" value="{{system.secondaryArmor.value}}"
-        placeholder='0' readonly data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.ArmorProtectionTypes') system.protectionTypes}}"/>
+        placeholder='0' disabled data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.ArmorProtectionTypes') system.protectionTypes}}"/>
     {{/unless}}
   </span>
   <span class="bgi-armor bgi-radProtect" data-tooltip='{{localize "TWODSIX.Items.Armor.RadProt"}}'><i class="fa-solid fa-circle-radiation"></i>:<input
-          type="number" value="{{system.radiationProtection.value}}" placeholder='0' min="0" readonly data-tooltip="{{twodsix_getTooltip actor 'system.radiationProtection.value'}}"/></span>
+          {{disabled tooltips.radiationProtection.value}}
+          type="number" value="{{system.radiationProtection.value}}" placeholder='0' min="0" readonly
+          data-tooltip="{{tooltips.radiationProtection.value}}"/></span>
 {{/if}}
 <span class={{#if settings.useCTData}}"bgi-encumbrance-wide"{{else}}"bgi-encumbrance"{{/if}} data-tooltip='{{localize "TWODSIX.Items.Encumbrance"}}'>
   {{#iff system.encumbrance.value ">" system.encumbrance.max}}
@@ -67,8 +70,8 @@
   {{/iff}}
   {{else}}
   <i class="fa-solid fa-weight-hanging"></i>
-  {{/iff}}:<input style="text-align: right;" type="number" value="{{system.encumbrance.value}}" placeholder='0' readonly data-tooltip="{{twodsix_getTooltip actor 'system.encumbrance.value'}}"/>
-      /{{#if (eq system.encumbrance.max settings.Infinity)}}<i class="fa-solid fa-infinity"></i>{{else}}<input type="number" value="{{system.encumbrance.max}}" placeholder='0' readonly data-tooltip="{{twodsix_getTooltip actor 'system.encumbrance.max'}}"/>{{/if}}
+  {{/iff}}:<input style="text-align: right;" type="number" value="{{system.encumbrance.value}}" placeholder='0' disabled data-tooltip="{{twooltips.encumbrance.value}}"/>
+      /{{#if (eq system.encumbrance.max settings.Infinity)}}<i class="fa-solid fa-infinity"></i>{{else}}<input type="number" value="{{system.encumbrance.max}}" placeholder='0' disabled data-tooltip="{{tooltips.encumbrance.max}}"/>{{/if}}
 </span>
 {{#unless settings.useCTData}}<br>{{/unless}}
 
@@ -80,8 +83,8 @@
     {{else}}
         <i class="fa-solid fa-battery-empty" style="color:brown;"></i>
     {{/iff}}:<input type="number" value="{{system.characteristics.stamina.value}}" min="0"
-      {{disabled (twodsix_getTooltip actor 'system.characteristics.stamina.value')}}
-      data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.stamina.value'}}"
+      {{disabled tooltips.characteristics.stamina.value}}
+      data-tooltip="{{tooltips.characteristics.stamina.value}}"
       name="system.characteristics.stamina.value"
     />-
   </span>
@@ -89,15 +92,19 @@
         name="system.characteristics.stamina.damage" value="{{system.characteristics.stamina.damage}}" min="0" max="{{system.characteristics.stamina.value}}"/></span>
 <span class="bgi-char-narrow bgi-lifeblood-value" data-tooltip='{{localize "TWODSIX.Actor.Lifeblood"}}'>
   <i class="fa-solid fa-heart-pulse"></i>:<input type="number" value="{{system.characteristics.lifeblood.value}}" min="0"
-    {{disabled (twodsix_getTooltip actor 'system.characteristics.lifeblood.value')}}
-    data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.lifeblood.value'}}"
+    {{disabled tooltips.characteristics.lifeblood.value}}
+    data-tooltip="{{tooltips.characteristics.lifeblood.value}}"
     name="system.characteristics.lifeblood.value"/>-
 </span>
 <span class="bgi-char-wide bgi-lifeblood-damage" data-tooltip='{{localize "TWODSIX.Actor.Lifeblood"}}'>
     <input type="number" name="system.characteristics.lifeblood.damage" value="{{system.characteristics.lifeblood.damage}}" min="0" max="{{system.characteristics.lifeblood.value}}"/></span>
 {{/if}}
 <span class="bgi-char-wide bgi-radiationDose" data-tooltip='{{localize "TWODSIX.Actor.RadiationExposure"}}'><i class="fa-solid fa-radiation"></i>:<input
-        name="system.radiationDose.value" value={{system.radiationDose.value}} min="0" type="number" data-tooltip="{{twodsix_getTooltip actor 'system.radiationDose.value'}}"/></span><br>
+    name="system.radiationDose.value"
+    {{disabled tooltips.radiationDose.value}}
+    value={{system.radiationDose.value}} min="0" type="number"
+    data-tooltip="{{tooltips.radiationDose.value}}"/>
+</span><br>
 
 <!-- Movement -->
 {{> "systems/twodsix/templates/actors/parts/actor/actor-movement.hbs"}}

--- a/static/templates/actors/parts/actor/actor-bgi-std.hbs
+++ b/static/templates/actors/parts/actor/actor-bgi-std.hbs
@@ -1,8 +1,8 @@
 <span class="bgi-age">
   {{localize "TWODSIX.Actor.Age"}}:
   <input type="number" value="{{system.age.value}}" min="0"
-    {{disabled (twodsix_getTooltip actor 'system.age.value')}}
-    data-tooltip="{{twodsix_getTooltip actor 'system.age.value'}}"
+    {{disabled tooltips.age.value}}
+    data-tooltip="{{tooltips.age.value}}"
     name="system.age.value"
     placeholder="0" data-dtype="Number" />
 </span>
@@ -28,16 +28,16 @@
 {{#unless limited}}
   {{#if settings.useCTData}}
     <span class="bgi-armorType">{{localize "TWODSIX.Items.Armor.Armor"}}:<input type="text" value="{{localize (concat 'TWODSIX.Chat.Roll.ArmorTypes.' system.armorType)}}"
-      placeholder='0' readonly data-tooltip="{{twodsix_getTooltip actor 'system.armorType'}}"/>
+      placeholder='0' diasbled data-tooltip="{{tooltips.armorType}}"/>
       {{#if system.reflectOn}}<i class="fa-solid fa-arrow-trend-up" data-tooltip="{{localize 'TWODSIX.Items.Armor.WearingReflec'}}"></i>{{/if}}
     </span>
     <span class="bgi-armorDM">{{localize "TWODSIX.Items.Armor.armorDM"}}:<input type="number" value="{{system.armorDM}}"
-      placeholder='0' readonly data-tooltip="{{twodsix_getTooltip actor 'system.armorDM'}}"/></span><br>
+      placeholder='0' disabled data-tooltip="{{tooltips.armorDM}}"/></span><br>
   {{else}}
     <span class="bgi-armor">{{localize "TWODSIX.Items.Armor.Armor"}}:
       {{#unless settings.useCUData}}
         <input style="text-align: right; padding-left: 0;" type="number" value="{{system.primaryArmor.value}}"
-        placeholder='0' readonly data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.PrimaryArmor') (twodsix_getTooltip actor 'system.primaryArmor.value')}}"/>
+        placeholder='0' readonly data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.PrimaryArmor') tooltips.primaryArmor.value}}"/>
         {{#unless settings.showTotalArmor}}
           +<input type="number" value="{{system.secondaryArmor.value}}"
           placeholder='0' readonly data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.SecondaryArmor') system.protectionTypes}}"/>
@@ -49,13 +49,20 @@
         placeholder='0' readonly data-tooltip="{{concat (localize 'TWODSIX.Items.Armor.ArmorProtectionTypes') system.protectionTypes}}"/>
       {{/unless}}
     </span>
-    <span class="bgi-armor bgi-radProtect">{{localize "TWODSIX.Items.Armor.RadProt"}}:<input type="number" value="{{system.radiationProtection.value}}"
-          placeholder='0' readonly data-tooltip="{{twodsix_getTooltip actor 'system.radiationProtection.value'}}"/></span><br>
+    <span class="bgi-armor bgi-radProtect">{{localize "TWODSIX.Items.Armor.RadProt"}}:<input type="number"
+      value="{{system.radiationProtection.value}}"
+      placeholder='0' disabled data-tooltip="{{tooltips.radiationProtection.value}}"/>
+    </span><br>
   {{/if}}
   <span class={{#if settings.useCTData}}"bgi-encumbrance-wide"{{else}}"bgi-encumbrance"{{/if}} data-tooltip="{{localize 'TWODSIX.Items.Encumbrance'}}">{{localize "TWODSIX.Items.Enc"}}:<input style="text-align: right;"
-      type="number" value="{{system.encumbrance.value}}" placeholder='0' readonly data-tooltip="{{twodsix_getTooltip actor 'system.encumbrance.value'}}"/>/{{#if (eq system.encumbrance.max settings.Infinity)}}<i class="fa-solid fa-infinity"></i>{{else}}<input name="system.encumbrance.max" type="number" value="{{system.encumbrance.max}}" placeholder='0' readonly data-tooltip="{{twodsix_getTooltip actor 'system.encumbrance.max'}}"/>{{/if}}</span>
+    type="number" value="{{system.encumbrance.value}}" placeholder='0' disabled
+    data-tooltip="{{tooltips.encumbrance.value}}"/>/{{#if (eq system.encumbrance.max settings.Infinity)}}<i class="fa-solid fa-infinity"></i>{{else}}<input name="system.encumbrance.max" type="number" value="{{system.encumbrance.max}}" placeholder='0' disabled
+    data-tooltip="{{tooltips.encumbrance.max}}"/>{{/if}}</span>
   <span class="bgi-radExposure" data-tooltip="{{localize 'TWODSIX.Actor.RadiationExposure'}}">{{localize 'TWODSIX.Actor.Rads'}}:<input name="system.radiationDose.value" style="text-align: right;"
-        type="number" value="{{system.radiationDose.value}}" placeholder='0' min="0" onClick="this.select();" data-tooltip="{{twodsix_getTooltip actor 'system.radiationDose.value'}}"/></span><br>
+    {{disabled tooltips.radiationDose.value}}
+    type="number" value="{{system.radiationDose.value}}" placeholder='0' min="0" onClick="this.select();"
+    data-tooltip="{{tooltips.radiationDose.value}}"/>
+  </span><br>
 
   <!-- Movement -->
   {{> "systems/twodsix/templates/actors/parts/actor/actor-movement.hbs"}}

--- a/static/templates/actors/parts/actor/actor-characteristics-atom.hbs
+++ b/static/templates/actors/parts/actor/actor-characteristics-atom.hbs
@@ -5,8 +5,8 @@
     {{>"systems/twodsix/templates/actors/parts/actor/actor-stat-1.hbs"}}
     <span class="stat-ability">
       <input type="number" min="0" value="{{system.characteristics.endurance.value}}" placeholder="0"
-        {{disabled (twodsix_getTooltip actor 'system.characteristics.endurance.value')}}
-        data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.endurance.value'}}"
+        {{disabled tooltips.characteristics.endurance.value}}
+        data-tooltip="{{tooltips.characteristics.endurance.value}}"
         name="system.characteristics.endurance.value" data-dtype="Number" onClick="this.select();"/>
   </span>
     <span class="stat-modifier"><input readonly type="text" value="-"/></span>
@@ -21,8 +21,8 @@
     {{>"systems/twodsix/templates/actors/parts/actor/actor-stat-1.hbs"}}
     <span class="stat-ability">
       <input type="number" min="0" value="{{system.characteristics.strength.value}}" placeholder="0"
-        {{disabled (twodsix_getTooltip actor 'system.characteristics.strength.value')}}
-        data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.strength.value'}}"
+        {{disabled tooltips.characteristics.strength.value}}
+        data-tooltip="{{tooltips.characteristics.strength.value}}"
         name="system.characteristics.strength.value" data-dtype="Number" onClick="this.select();"/>
     </span>
     <span class="stat-modifier"><input readonly type="text" value="-"/></span>
@@ -38,8 +38,8 @@
       {{>"systems/twodsix/templates/actors/parts/actor/actor-stat-1.hbs"}}
       <span class="stat-ability">
         <input type="number" min="0" value="{{system.characteristics.psionicStrength.value}}" placeholder="0"
-          {{disabled (twodsix_getTooltip actor 'system.characteristics.psionicStrength.value')}}
-            data-tooltip="{{twodsix_getTooltip actor 'system.characteristics.psionicStrength.value'}}"
+          {{disabled tooltips.characteristics.psionicStrength.value}}
+            data-tooltip="{{tooltips.characteristics.psionicStrength.value}}"
             name="system.characteristics.psionicStrength.value" data-dtype="Number" onClick="this.select();"
         />
       </span>

--- a/static/templates/actors/parts/actor/actor-characteristics-rotate.hbs
+++ b/static/templates/actors/parts/actor/actor-characteristics-rotate.hbs
@@ -16,13 +16,13 @@
       <span class="special-ability">
         <input type="number" min="0" placeholder="0" data-dtype="Number"
           data-label="system.characteristics.{{key}}.value" value="{{char.value}}"
-          {{disabled (twodsix_getTooltip actor (concat 'system.characteristics.' key '.value'))}}
-          data-tooltip="{{twodsix_getTooltip actor (concat 'system.characteristics.' key '.value')}}"
+          {{disabled (lookup (lookup @root.tooltips.characteristics key) 'value')}}
+          data-tooltip="{{lookup (lookup @root.tooltips.characteristics key) 'value'}}"
           name="system.characteristics.{{key}}.value"
           onClick="this.select();"
         />
       </span>
-      <span class="special-modifier"><input readonly type="text" data-tooltip="{{twodsix_getTooltip actor (concat 'system.characteristics.' key '.mod')}}"
+      <span class="special-modifier"><input readonly type="text" data-tooltip="{{lookup (lookup @root.tooltips.characteristics key) 'mod'}}"
                                         value="{{numberFormat char.mod decimals=0 sign=true}}"/></span>
       <span class="special-damage"><input type="number" max="{{char.value}}" min="0"
                                       name="system.characteristics.{{key}}.damage" value="{{char.damage}}"

--- a/static/templates/actors/parts/actor/actor-characteristics-rotate.hbs
+++ b/static/templates/actors/parts/actor/actor-characteristics-rotate.hbs
@@ -22,11 +22,20 @@
           onClick="this.select();"
         />
       </span>
-      <span class="special-modifier"><input readonly type="text" data-tooltip="{{lookup (lookup @root.tooltips.characteristics key) 'mod'}}"
-                                        value="{{numberFormat char.mod decimals=0 sign=true}}"/></span>
+      <span class="special-modifier">
+        <input readonly type="text"
+          {{#if @root.settings.useCTData}}
+            value= &mdash;
+          {{else}}
+            data-tooltip="{{lookup (lookup @root.tooltips.characteristics key) 'mod'}}"
+            value="{{numberFormat char.mod decimals=0 sign=true}}"
+          {{/if}}
+        />
+      </span>
       <span class="special-damage"><input type="number" max="{{char.value}}" min="0"
-                                      name="system.characteristics.{{key}}.damage" value="{{char.damage}}"
-                                      placeholder="0" data-dtype="Number" onClick="this.select();"/></span>
+        name="system.characteristics.{{key}}.damage" value="{{char.damage}}"
+        placeholder="0" data-dtype="Number" onClick="this.select();"/>
+      </span>
     </div>
     {{/if}}
     {{/with}}

--- a/static/templates/actors/parts/actor/actor-characteristics-table.hbs
+++ b/static/templates/actors/parts/actor/actor-characteristics-table.hbs
@@ -23,8 +23,8 @@
               <span class="stat-ability-table">
                 <input type="number" min="0" placeholder="0" data-dtype="Number"
                   data-label="system.characteristics.{{key}}.value" value="{{char.value}}"
-                  {{disabled (twodsix_getTooltip ../actor (concat 'system.characteristics.' key '.value'))}}
-                  data-tooltip="{{twodsix_getTooltip ../actor (concat 'system.characteristics.' key '.value')}}"
+                  {{disabled (lookup (lookup @root.tooltips.characteristics key) "value")}}
+                  data-tooltip="{{lookup (lookup @root.tooltips.characteristics key) 'value'}}"
                   name="system.characteristics.{{key}}.value"
                   onClick="this.select();"
                 />
@@ -38,8 +38,18 @@
         <td {{#iff this.actor.type "===" "traveller"}} style="font-size: smaller;"{{/iff}}>{{localize "TWODSIX.Damage.Mod"}}</td>
         {{#each system.characteristics as |char key|}}
           {{#if char.displayChar}}
-          <td><span class="stat-modifier-table"><input readonly type="text" data-tooltip="{{twodsix_getTooltip ../actor (concat 'system.characteristics.' key '.mod')}}"
-            value="{{numberFormat char.mod decimals=0 sign=true}}"/></span></td>
+          <td>
+            <span class="stat-modifier-table">
+              <input readonly type="text"
+                {{#if @root.settings.useCTData}}
+                  value= &mdash;
+                {{else}}
+                  data-tooltip="{{lookup (lookup @root.tooltips.characteristics key) 'mod'}}"
+                  value="{{numberFormat char.mod decimals=0 sign=true}}"
+                {{/if}}
+              />
+            </span>
+          </td>
           {{/if}}
         {{/each}}
       </tr>

--- a/static/templates/actors/parts/actor/actor-characteristics.hbs
+++ b/static/templates/actors/parts/actor/actor-characteristics.hbs
@@ -15,14 +15,22 @@
       {{>"systems/twodsix/templates/actors/parts/actor/actor-stat-1.hbs"}}
       <span class="stat-ability" >
         <input type="number" min="0" value="{{char.value}}" data-label="system.characteristics.{{key}}.value"
-          {{disabled (twodsix_getTooltip actor (concat 'system.characteristics.' key '.value'))}}
-          data-tooltip="{{twodsix_getTooltip actor (concat 'system.characteristics.' key '.value')}}"
+          {{disabled (lookup (lookup @root.tooltips.characteristics key) 'value')}}
+          data-tooltip="{{lookup (lookup @root.tooltips.characteristics key) 'value'}}"
           name="system.characteristics.{{key}}.value"
           placeholder="0" data-dtype="Number" onClick="this.select();"
         />
       </span>
-      <span class="stat-modifier"><input readonly type="text" data-tooltip="{{twodsix_getTooltip actor (concat 'system.characteristics.' key '.mod')}}"
-                                        value="{{numberFormat char.mod decimals=0 sign=true}}"/></span>
+      <span class="stat-modifier">
+        <input readonly type="text"
+          {{#if @root.settings.useCTData}}
+            value= &mdash;
+          {{else}}
+            data-tooltip="{{lookup (lookup @root.tooltips.characteristics key) 'mod'}}"
+            value="{{numberFormat char.mod decimals=0 sign=true}}"
+          {{/if}}
+        />
+      </span>
       <span class="stat-damage"><input type="number" max="{{char.value}}" min="0"
                                       name="system.characteristics.{{key}}.damage" value="{{char.damage}}"
                                       placeholder="0" data-dtype="Number" onClick="this.select();"/></span>

--- a/static/templates/actors/parts/actor/actor-info.hbs
+++ b/static/templates/actors/parts/actor/actor-info.hbs
@@ -118,7 +118,8 @@
   <div class="char-xp">
     <span class="item-title">{{localize "TWODSIX.Actor.Info.XP"}}</span>
       {{#if settings.useProseMirror}}
-        <prose-mirror class="actor-editor" name="system.xpNotes" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.xpNotes}}" collaborate="true" toggled="false" {{disabled (twodsix_getTooltip actor 'system.xpNotes')}}>
+        <prose-mirror class="actor-editor" name="system.xpNotes" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.xpNotes}}" collaborate="true" toggled="false"
+          {{disabled tooltips.xpNotes}}>
           {{{richText.xpNotes}}}
         </prose-mirror>
       {{else}}
@@ -133,7 +134,8 @@
   <div class="char-description">
     <span class="item-title">{{localize "TWODSIX.Actor.Info.DESCRIPTION"}}</span>
     {{#if settings.useProseMirror}}
-      <prose-mirror class="actor-editor" name="system.description" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.description}}" collaborate="true" toggled="false" {{disabled (twodsix_getTooltip actor 'system.description')}}>
+      <prose-mirror class="actor-editor" name="system.description" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.description}}" collaborate="true" toggled="false"
+      {{disabled tooltips.description}}>
         {{{richText.description}}}
       </prose-mirror>
     {{else}}
@@ -143,7 +145,8 @@
   <div class="char-contacts">
     <span class="item-title">{{localize "TWODSIX.Actor.Info.CONTACTS"}}</span>
     {{#if settings.useProseMirror}}
-      <prose-mirror class="actor-editor" name="system.contacts" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.contacts}}" collaborate="true" toggled="false" {{disabled (twodsix_getTooltip actor 'system.contacts')}}>
+      <prose-mirror class="actor-editor" name="system.contacts" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.contacts}}" collaborate="true" toggled="false"
+      {{disabled tooltips.contacts}}>
         {{{richText.contacts}}}
       </prose-mirror>
     {{else}}
@@ -153,7 +156,8 @@
   <div class="char-bio">
     <span class="item-title">{{localize "TWODSIX.Actor.Info.BIOGRAPHY"}}</span>
     {{#if settings.useProseMirror}}
-      <prose-mirror class="actor-editor" name="system.bio" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.bio}}" collaborate="true" toggled="false"  {{disabled (twodsix_getTooltip actor 'system.bio')}}>
+      <prose-mirror class="actor-editor" name="system.bio" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.bio}}" collaborate="true" toggled="false"
+      {{disabled tooltips.bio}}>
         {{{richText.bio}}}
       </prose-mirror>
     {{else}}

--- a/static/templates/actors/parts/actor/actor-movement.hbs
+++ b/static/templates/actors/parts/actor/actor-movement.hbs
@@ -1,7 +1,7 @@
 <span class="bgi-movement" data-tooltip='{{localize "TWODSIX.Actor.Movement.MovementRate"}}'><i class="fa-solid fa-person-walking"></i>:
   <input type="number" value="{{system.movement.walk}}"
-    {{disabled (twodsix_getTooltip actor 'system.movement.walk')}}
-    data-tooltip="{{twodsix_getTooltip actor 'system.movement.walk'}}"
+    {{disabled tooltips.movement.walk}}
+    data-tooltip="{{tooltips.movement.walk}}"
     name="system.movement.walk"
   />
   <select name="system.movement.units" >

--- a/static/templates/actors/parts/actor/actor-notes.hbs
+++ b/static/templates/actors/parts/actor/actor-notes.hbs
@@ -1,7 +1,8 @@
 <div class="notes-container">
   <span class="item-title">{{localize "TWODSIX.Actor.Notes.NOTES"}}</span>
   {{#if settings.useProseMirror}}
-  <prose-mirror class="actor-editor" name="system.notes" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.notes}}" collaborate="true" toggled="false" {{disabled (twodsix_getTooltip actor 'system.notes')}}>
+  <prose-mirror class="actor-editor" name="system.notes" data-document-u-u-i-d="{{actor.uuid}}" value="{{system.notes}}" collaborate="true" toggled="false"
+  {{disabled tooltips.notes}}>
     {{{richText.notes}}}
   </prose-mirror>
   {{else}}

--- a/static/templates/actors/parts/ship/ship-characteristics.hbs
+++ b/static/templates/actors/parts/ship/ship-characteristics.hbs
@@ -6,13 +6,13 @@
       <i class="fa-solid fa-dice" alt="d6"></i> {{localize "TWODSIX.Ship.Morale"}}</span>
     <span class="stat-ability-ship" >
       {{localize "TWODSIX.Damage.Max"}}:
-      <input type="number" min="0" name="system.characteristics.{{key}}.value" data-tooltip="{{twodsix_getTooltip actor (concat 'system.characteristics.' key '.value')}}"
+      <input type="number" min="0" name="system.characteristics.{{key}}.value"
                                       data-label="system.characteristics.{{key}}.value" value="{{char.value}}"
                                       placeholder="0" data-dtype="Number" onClick="this.select();"/>
     </span>
     <span class="stat-modifier-ship">
       {{localize "TWODSIX.Damage.Mod"}}:
-      <input readonly type="text" data-tooltip="{{twodsix_getTooltip actor (concat 'system.characteristics.' key '.mod')}}"
+      <input readonly type="text"
                                       value="{{numberFormat char.mod decimals=0 sign=true}}"/>
     </span>
     <span class="stat-damage-ship">

--- a/static/templates/actors/robot-sheet.hbs
+++ b/static/templates/actors/robot-sheet.hbs
@@ -53,9 +53,9 @@
               <span class="item" data-item-id="{{item.id}}">
                 <span class="item-name rollable" data-label="{{item.name}}" data-tooltip="{{twodsix_invertSkillRollShiftClick}}" data-action="skillTalentRoll">{{item.name}}</span>
                 <input style="width: 4ch;"  type="number"
-                  {{disabled (twodsix_getTooltip actor (concat 'system.skills.' (skillName item.name)))}}
+                  {{disabled (lookup @root.tooltips.skills (skillName item.name))}}
                   value="{{twodsix_skillTotal ../actor item}}"
-                  data-tooltip="{{twodsix_getTooltip actor (concat 'system.skills.' (skillName item.name))}}"
+                  data-tooltip="{{lookup @root.tooltips.skills (skillName item.name)}}"
                   class= "item-value-edit" value="{{item.system.value}}" data-action="selectItem"
                   name="{{concat 'system.skills.' (skillName item.name)}}"/>
                 <span class="item-controls centre">


### PR DESCRIPTION
Moves tooltip computation for actor fields from Handlebars helpers to precomputed context in AbstractTwodsixActorSheet, improving performance and maintainability. Removes the twodsix_getTooltip Handlebars helper and updates all affected templates to use the new context.tooltips structure for tooltips and disabled states. This change centralizes tooltip logic and prepares for further UI improvements.

* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
refactor


* **What is the current behavior?** (You can also link to an open issue here)
AE tooltips based on handlebar helper


* **What is the new behavior (if this is a feature change)?**
AE tooltips defined in _prepareContext


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
