### PR TITLE
fix: pdfDocument array missing initial empty entry

### DIFF
--- a/src/module/data/character-base.ts
+++ b/src/module/data/character-base.ts
@@ -55,7 +55,7 @@ export class TwodsixActorBaseData extends foundry.abstract.TypeDataModel {
     });
 
     /* References */
-    schema.docReference = new fields.ArrayField(new fields.StringField({...requiredBlankString}));
+    schema.docReference = new fields.ArrayField(new fields.StringField({...requiredBlankString}), {initial: [""]});
     schema.pdfReference = new fields.SchemaField({
       type: new fields.StringField({...requiredBlankString}),
       href: new fields.StringField({...requiredBlankString}),
@@ -93,6 +93,9 @@ export class TwodsixActorBaseData extends foundry.abstract.TypeDataModel {
   static migrateData(source:any) {
     if ("docReference" in source) {
       migrateStringToStringArray(source, "docReference");
+      if (source.docReference.length === 0) {
+        source.docReference = [""];
+      }
     }
     return super.migrateData(source);
   }

--- a/src/module/data/item-base.ts
+++ b/src/module/data/item-base.ts
@@ -14,7 +14,7 @@ export class TwodsixItemBaseData extends foundry.abstract.TypeDataModel {
     schema.description = new fields.HTMLField({...requiredBlankString});
     schema.type = new fields.StringField({...requiredBlankString}); //updated onCreate
     /* References */
-    schema.docReference = new fields.ArrayField(new fields.StringField({...requiredBlankString}));
+    schema.docReference = new fields.ArrayField(new fields.StringField({...requiredBlankString}), {initial: [""]});
     schema.pdfReference = new fields.SchemaField({
       type: new fields.StringField({...requiredBlankString}),
       href: new fields.StringField({...requiredBlankString}),
@@ -26,6 +26,9 @@ export class TwodsixItemBaseData extends foundry.abstract.TypeDataModel {
   static migrateData(source:any) {
     if ("docReference" in source) {
       migrateStringToStringArray(source, "docReference");
+      if (source.docReference.length === 0) {
+        source.docReference = [""];
+      }
     }
     return super.migrateData(source);
   }

--- a/src/module/data/vehicles.ts
+++ b/src/module/data/vehicles.ts
@@ -14,7 +14,7 @@ class TwodsixVehicleBaseData extends foundry.abstract.TypeDataModel {
     schema.name = new fields.StringField({...requiredBlankString});
     schema.techLevel = new fields.NumberField({ ...requiredInteger, initial: 0 });
     /* References */
-    schema.docReference = new fields.ArrayField(new fields.StringField({...requiredBlankString}));
+    schema.docReference = new fields.ArrayField(new fields.StringField({...requiredBlankString}), {initial: [""]});
     schema.pdfReference = new fields.SchemaField({
       type: new fields.StringField({...requiredBlankString}),
       href: new fields.StringField({...requiredBlankString}),
@@ -30,6 +30,9 @@ class TwodsixVehicleBaseData extends foundry.abstract.TypeDataModel {
   static migrateData(source:any) {
     if ("docReference" in source) {
       migrateStringToStringArray(source, "docReference");
+      if (source.docReference.length === 0) {
+        source.docReference = [""];
+      }
     }
     return super.migrateData(source);
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
pdfPager references not showing on newly created items and actors


* **What is the new behavior (if this is a feature change)?**
pdfPager references always have an initial value


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
