### PR TITLE
fix: code block in chat not following dark mode

### DIFF
--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -4770,3 +4770,8 @@ section#settings a:hover {
   padding: 0 0.5rem;
 }
 
+code {
+  color: var(--s2d6-select-light);
+  background: var(--color-cool-4);
+  border-color: var(--color-cool-3);
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
code view in chat not respecting dark mode


* **What is the new behavior (if this is a feature change)?**
code view in chat css format improved for dark mode


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
Issue could be a foundry one as both light and dark mode formatting applied in css