### PR TITLE
feat: add optional features trait description

### DIFF
--- a/src/module/data/characters.ts
+++ b/src/module/data/characters.ts
@@ -112,6 +112,7 @@ export class RobotData extends TwodsixActorBaseData {
       value: new fields.NumberField({required: true, integer: true, initial: 0}),
       protectionTypes: new fields.ArrayField(new fields.StringField({blank: false}))
     });
+    schema.maxBuildPoints = new fields.NumberField({...requiredInteger, initial: 0});
     return schema;
   }
 }

--- a/src/module/data/item.ts
+++ b/src/module/data/item.ts
@@ -92,6 +92,7 @@ export class AugmentData extends GearData {
     const schema = super.defineSchema();
     schema.auglocation = new fields.StringField({required: true, blank: false, initial: "None" });
     schema.bonus = new fields.StringField({required: true, blank: true, initial: "stat increase" });
+    schema.buildPoints = new fields.NumberField({...requiredInteger, initial: 0});
     return schema;
   }
 }

--- a/src/module/entities/TwodsixItem.ts
+++ b/src/module/entities/TwodsixItem.ts
@@ -825,7 +825,10 @@ export default class TwodsixItem extends Item {
   public sendDescriptionToChat():Promise<void> {
     const picture = this.img;
     const capType = game.i18n.localize(`TYPES.Item.${this.type}`).capitalize();
-    const msg = `<div style="display: inline-flex;"><img src="${picture}" alt="" class="chat-image"></img><span style="align-self: center; text-align: center; padding-left: 1ch;"><strong>${capType}: ${this.name}</strong></span></div><div>${this.system["description"]}</div>`;
+    let msg = `<div style="display: inline-flex;"><img src="${picture}" alt="" class="chat-image"></img><span style="align-self: center; text-align: center; padding-left: 1ch;"><strong>${capType}: ${this.name}</strong></span></div><div>${this.system["description"]}</div>`;
+    if (this.system.features) {
+      msg += `<div>${game.i18n.localize("TWODSIX.Items.Component.Features")}: ${this.system.features}</div>`;
+    }
     ChatMessage.create({ content: msg, speaker: ChatMessage.getSpeaker({ actor: this.actor }) });
   }
 

--- a/src/module/settings/DisplaySettings.ts
+++ b/src/module/settings/DisplaySettings.ts
@@ -111,6 +111,7 @@ export default class DisplaySettings extends foundry.applications.api.Handlebars
     delete nonCargoTypes.cargo;
     settings.ship.push(arrayChoiceSetting('componentsIgnored', [], true, nonCargoTypes));
     settings.token.push(booleanSetting('showMovementColors', false));
+    settings.actor.push(booleanSetting('showTraitAE', true));
     return settings;
   }
 }

--- a/src/module/sheets/AbstractTwodsixActorSheet.ts
+++ b/src/module/sheets/AbstractTwodsixActorSheet.ts
@@ -451,14 +451,14 @@ export abstract class AbstractTwodsixActorSheet extends foundry.applications.api
     context.container = actor.itemTypes;
     const items = actor.items;
     const component = {};
-    const counters = { numberOfSkills: 0, skillRanks: 0 };
+    const counters = { numberOfSkills: 0, skillRanks: 0, buildPoints: 0 };
     const summaryStatus = {};
     const skillsList = [];
     const skillGroups = {};
     const statusOrder = {"operational": 1, "damaged": 2, "destroyed": 3, "off": 0};
 
     // Iterate through items, calculating derived data
-    items.forEach((item:TwodsixItem) => {
+    for (const item of items) {
       // item.img = item.img || CONST.DEFAULT_TOKEN; // apparent item.img is read-only..
       if (![...TWODSIX.WeightlessItems, "ship_position"].includes(item.type)) {
         item.prepareConsumable();
@@ -475,6 +475,11 @@ export abstract class AbstractTwodsixActorSheet extends foundry.applications.api
           item.system.parentName = parentItem.name;
           item.system.parentType = parentItem.type;
         }
+      }
+
+      //Calulate BuildPoints
+      if (["robot"].includes(actor.type)  && item.type === "augment") {
+        counters.buildPoints += item.system.buildPoints ?? 0;
       }
       //prepare ship summary status
       if (item.type === "component") {
@@ -493,7 +498,7 @@ export abstract class AbstractTwodsixActorSheet extends foundry.applications.api
           };
         }
       }
-    });
+    }
 
     // Prepare Containers for sheetData
     context.container.equipmentAndTools = actor.itemTypes.equipment.concat(actor.itemTypes.tool).concat(actor.itemTypes.computer);
@@ -511,6 +516,8 @@ export abstract class AbstractTwodsixActorSheet extends foundry.applications.api
       context.summaryStatus = sortObj(summaryStatus);
       context.storage = items.filter(i => ![...TWODSIX.WeightlessItems, "ship_position", "component"].includes(i.type));
       context.container.nonCargo = actor.itemTypes.component.filter( i => i.system.subtype !== "cargo");
+    } else if (["robot"].includes(actor.type)) {
+      context.buildPoints = counters.buildPoints;
     }
     context.effects = Array.from(actor.allApplicableEffects());
 

--- a/src/module/sheets/TwodsixTravellerSheet.ts
+++ b/src/module/sheets/TwodsixTravellerSheet.ts
@@ -96,7 +96,8 @@ export class TwodsixTravellerSheet extends foundry.applications.api.HandlebarsAp
       useCTAutofireRules: game.settings.get('twodsix', 'autofireRulesUsed') === TWODSIX.RULESETS.CT.key,
       useCELAutofireRules: game.settings.get('twodsix', 'autofireRulesUsed') === TWODSIX.RULESETS.CEL.key,
       useCUAutofireRules: game.settings.get('twodsix', 'autofireRulesUsed') === TWODSIX.RULESETS.CU.key,
-      showTotalArmor: game.settings.get('twodsix', 'showTotalArmor')
+      showTotalArmor: game.settings.get('twodsix', 'showTotalArmor'),
+      showTraitAE: game.settings.get('twodsix', 'showTraitAE')
     });
 
     context.ACTIVE_EFFECT_MODES = Object.entries(CONST.ACTIVE_EFFECT_MODES).reduce((ret, entry) => {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -307,7 +307,6 @@
       },
       "Location": "Location",
       "AnimalNotes": "Animal Notes",
-      "RobotNotes": "Robot Notes",
       "AttackWeapons": "Attacks / Weapons",
       "Reaction": "Reaction Roll",
       "Attack": "Attack",
@@ -322,6 +321,14 @@
       "KeepFighting": "Keep Fighting",
       "Advance": "Advance",
       "FightToTheDeath": "Fight to The Death!"
+    },
+    "Robot": {
+      "RobotNotes": "Robot Notes",
+      "BuildPoints": {
+        "BuildPoints": "Build Points/Slots",
+        "Used": "Used",
+        "Max": "Max"
+      }
     },
     "Chat": {
       "Roll": {
@@ -526,7 +533,8 @@
         "Legs": "Legs",
         "Torso": "Torso",
         "None": "None",
-        "ValueCr": "Value in Cr"
+        "ValueCr": "Value in Cr",
+        "BuildPoints": "Build Points / Slots"
       },
       "Component": {
         "Ammunition":"Ammunition",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1658,6 +1658,10 @@
       "componentDamageDM": {
         "hint": "The roll DM that is applied for each hit to a component.",
         "name": "Component Damage DM"
+      },
+      "showTraitAE": {
+        "hint": "List active effect formulas as part of trait short description (true) on Traveller Info tab.  Otherwise, show only the short description for the trait (false).",
+        "name": "Show Active Effects for Traits"
       }
     },
     "CloseAndCreateNew": "Close and create new",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -4775,3 +4775,17 @@ code {
   --color-code-bg: var(--color-cool-4);
   --color-code-border: var(--color-cool-3);
 }
+
+.augment-buildPoints {
+  border-top: inset;
+  text-align: center;
+  padding-top: 8px;
+  width: 98%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.augment-buildPoints input {
+  width: 4ch;
+}

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -3752,3 +3752,17 @@ textarea {
 .stat-ability-ship input, .stat-modifier-ship input, .stat-damage-ship input {
   min-width: 5ch;
 }
+
+.augment-buildPoints {
+  border-top: inset;
+  text-align: center;
+  padding-top: 8px;
+  width: 98%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.augment-buildPoints input {
+  width: 4ch;
+}

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -460,4 +460,5 @@ div.svelte-ip-m19fn7 {
   --color-scrollbar: transparent;
   --color-scrollbar-track: transparent;
   scrollbar-color: transparent transparent;
+  scrollbar-width: none;
 }

--- a/static/styles/twodsix_moduleFix.css
+++ b/static/styles/twodsix_moduleFix.css
@@ -456,7 +456,8 @@ div.svelte-ip-m19fn7 {
     display: flex;
 }
 
-.theatre-narrator-content, .theatre-control-group, .theatre-control-nav-bar, .no-scrollbar {
-  /*--color-scrollbar: transparent;*/
+.theatre-narrator-content, .theatre-control-group, .theatre-control-nav-bar, .theatre-narrator-backdrop, .no-scrollbar {
+  --color-scrollbar: transparent;
   --color-scrollbar-track: transparent;
+  scrollbar-color: transparent transparent;
 }

--- a/static/templates/actors/parts/actor/actor-info.hbs
+++ b/static/templates/actors/parts/actor/actor-info.hbs
@@ -24,11 +24,13 @@
           <span class="item-name showChat" data-action="showChat">{{item.name}}</span>
           <span class="item-name centre">{{item.system.value}}</span>
           <span class="item-name centre">{{item.system.shortdescr}}
+            {{#if @root/settings.showTraitAE}}
             <ul>
               {{#each item.effects.contents.[0].changes as |change|}}
               <li>{{change.key}} {{lookup @root.ACTIVE_EFFECT_MODES change.mode}} {{change.value}}</li>
               {{/each}}
             </ul>
+            {{/if}}
           </span>
           <span class="item-controls centre">
             <a class="item-control item-edit" data-tooltip='{{localize "TWODSIX.Actor.Items.EditItem"}}' data-action="itemEdit"><i

--- a/static/templates/actors/robot-sheet.hbs
+++ b/static/templates/actors/robot-sheet.hbs
@@ -40,7 +40,7 @@
       {{/unless}}{{/unless}}
     </div>
     <div class="npc-notes-container">
-      <span class="item-title-npc">{{localize "TWODSIX.Animal.RobotNotes"}}</span>
+      <span class="item-title-npc">{{localize "TWODSIX.Robot.RobotNotes"}}</span>
       {{#unless limited}}
       <div contenteditable="true" data-edit="system.notes" style="height: 85%; border-radius: 0 0 2ch 2ch !important; overflow-y: auto; padding-left: 2px;">{{{system.notes}}}</div>
      {{/unless}}
@@ -133,6 +133,13 @@
               </span>{{#unless @last}}{{#if ../settings.dontShowStatBlock}}, {{else}}<br>{{/if}}{{/unless}}
             </span>
          {{/each}}
+        </span>
+        <span>
+          <div class="augment-buildPoints">
+            <span>{{localize "TWODSIX.Robot.BuildPoints.BuildPoints"}}-</span>
+            <span>{{localize "TWODSIX.Robot.BuildPoints.Used"}}: {{buildPoints}}</span>
+            <span>{{localize "TWODSIX.Robot.BuildPoints.Max"}}: <input type="number" name= "system.maxBuildPoints" value= "{{system.maxBuildPoints}}" onClick="this.select();"/></span>
+          </div>
         </span>
       </div>
       {{/unless}}

--- a/static/templates/items/augment-sheet.hbs
+++ b/static/templates/items/augment-sheet.hbs
@@ -22,6 +22,11 @@
     <input class="form-input" type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number"/>
   </div>
 
+  <div class="item-weight">
+    <label for="system.buildPoints" class="resource-label">{{localize "TWODSIX.Items.Augmentation.BuildPoints"}}</label>
+    <input class="form-input" type="text" name="system.buildPoints" value="{{system.buildPoints}}" data-dtype="Number"/>
+  </div>
+
   <div class="item-short">
     <label for="system.shortdescr" class="resource-label">{{localize "TWODSIX.Items.Equipment.ShortDescription"}}</label>
     <input class="form-input" type="text" name="system.shortdescr" value="{{system.shortdescr}}"/>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
minor feature


* **What is the current behavior?** (You can also link to an open issue here)
- No feature/trait description include for item description send to chat
- Theater Inserts module shows scrollbars on canvas
- Traveller sheet info tab always shows trait AE details for Short Description 
- No Build point / slot tracking for Robots


* **What is the new behavior (if this is a feature change)?**
- Add feature description if feature/trait exists
- Remove Theater Insert scrollbars on canvas
- Add setting to omit the display of AE details for traits
- Add build point and slot usage to augments and robot sheet

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
