### PR TITLE
fix: add duplicate position button

### DIFF
--- a/src/module/sheets/TwodsixShipSheet.ts
+++ b/src/module/sheets/TwodsixShipSheet.ts
@@ -32,6 +32,7 @@ export class TwodsixShipSheet extends foundry.applications.api.HandlebarsApplica
     actions: {
       editPosition: this._onShipPositionEdit,
       deletePosition: this._onShipPositionDelete,
+      copyPosition: this._onShipPositionCopy,
       selectShipActor: this._onShipActorClick,
       executeAction: this._onExecuteAction,
       createPosition: this._onShipPositionCreate,
@@ -216,6 +217,15 @@ export class TwodsixShipSheet extends foundry.applications.api.HandlebarsApplica
         }
       });
       await this.actor.deleteEmbeddedDocuments("Item", [shipPositionId]);
+    }
+  }
+
+  static async _onShipPositionDelete(ev:Event, target:HTMLElement): Promise<void> {
+    if (target !== null) {
+      const shipPositionId:string = target.closest(".ship-position").dataset.id;
+      const positionItem:TwodsixItem = this.actor?.items?.get(shipPositionId);
+      const posData = foundry.utils.duplicate(positionItem);
+      await TwodsixItem.create(posData);
     }
   }
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -837,6 +837,8 @@
       "Defense": "Defense",
       "DeleteAction": "Delete Action",
       "DeletePosition": "Delete Position",
+      "CopyPosition": "Copy Ship Position to Sidebar",
+      "EditPosition": "Edit Position",
       "ConfirmDeletePosition": "Are you sure you want to delete this position?",
       "Designation": "Designation",
       "Displacement": "Displacement",

--- a/static/styles/twodsix.css
+++ b/static/styles/twodsix.css
@@ -2770,7 +2770,7 @@ a.ship-crew-tab.active, a.ship-positions-tab.active , a.ship-storage-tab.active,
   overflow: auto;
 }
 
-.ship-position-delete, .ship-position-edit {
+.ship-position-delete, .ship-position-edit, .ship-position-copy {
   float: right;
   margin-top: 4px;
   margin-right: 4px;

--- a/static/styles/twodsix_basic.css
+++ b/static/styles/twodsix_basic.css
@@ -2223,7 +2223,7 @@ a.ship-positions-tab.active, a.ship-crew-tab.active, a.ship-component-tab.active
   min-height: 12ch;
 }
 
-.ship-position-delete, .ship-position-edit {
+.ship-position-delete, .ship-position-edit, .ship-position-copy {
   float: right;
   margin-top: 4px;
   margin-right: 4px;

--- a/static/templates/actors/parts/ship/ship-positions.hbs
+++ b/static/templates/actors/parts/ship/ship-positions.hbs
@@ -9,8 +9,9 @@
           {{#each shipPosition.system.actors as |actor|}}
             <img src="{{actor.img}}" draggable="true" class="ship-position-actor-token" data-drag="actor" data-id="{{actor.id}}" width="40" height="40" alt="{{actor.name}}" data-tooltip="{{actor.name}}" data-action="selectShipActor">
           {{/each}}
-          <span class="fa fa-trash ship-position-delete" data-action="deletePosition"></span>
-          <span class="fa fa-wrench ship-position-edit" data-action="editPosition"></span>
+          <span class="fa-solid fa-copy ship-position-copy" data-action="copyPosition" data-tooltip='{{localize "TWODSIX.Ship.CopyPosition"}}'></span>
+          <span class="fa-solid fa-trash ship-position-delete" data-action="deletePosition" data-tooltip='{{localize "TWODSIX.Ship.DeletePosition"}}'></span>
+          <span class="fa-solid fa-wrench ship-position-edit" data-action="editPosition" data-tooltip='{{localize "TWODSIX.Ship.EditPosition"}}'></span>
 
         </div>
         <div class="ship-position-box">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
No way to duplicate ship position from ship sheet


* **What is the new behavior (if this is a feature change)?**
Add a button to duplicate a ship position to sidebar


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
