### PR TITLE
fix: Add group labels to cascaded 2e skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ foundry/*
 
 # AI instructions
 .github/copilot-instructions.md
+.claude/
 
 # Pack Management
 

--- a/packs-src/2e-skills/skills_Animals__Handling_jhEat8vvIUfncxE9.json
+++ b/packs-src/2e-skills/skills_Animals__Handling_jhEat8vvIUfncxE9.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Animals"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Animals__Training_RI3PxesCUxQ114HA.json
+++ b/packs-src/2e-skills/skills_Animals__Training_RI3PxesCUxQ114HA.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Routine",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Animals"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Animals__Veterinary_dILEC4XnXpv2Yktc.json
+++ b/packs-src/2e-skills/skills_Animals__Veterinary_dILEC4XnXpv2Yktc.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Animals"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Art__Holography_KTcMgcTuU0j8YzLX.json
+++ b/packs-src/2e-skills/skills_Art__Holography_KTcMgcTuU0j8YzLX.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Routine",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Art"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Art__Instrument_e0HzIGorUlmZP7ye.json
+++ b/packs-src/2e-skills/skills_Art__Instrument_e0HzIGorUlmZP7ye.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Art"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Art__Performer_uY3kaqQXB4lu0XDM.json
+++ b/packs-src/2e-skills/skills_Art__Performer_uY3kaqQXB4lu0XDM.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Routine",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Art"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Art__Visual_Media_AvkzYg8MhFhO2UMf.json
+++ b/packs-src/2e-skills/skills_Art__Visual_Media_AvkzYg8MhFhO2UMf.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Art"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Art__Write_2EVJ9yQQc1ujMG4G.json
+++ b/packs-src/2e-skills/skills_Art__Write_2EVJ9yQQc1ujMG4G.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Routine",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Art"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Athletics__Archery_qjooxt80LFojz6Jc.json
+++ b/packs-src/2e-skills/skills_Athletics__Archery_qjooxt80LFojz6Jc.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Athletics"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Athletics__Dexterity_Z5mxtWWZVjZ0Se0M.json
+++ b/packs-src/2e-skills/skills_Athletics__Dexterity_Z5mxtWWZVjZ0Se0M.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Athletics"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Athletics__Endurance_E5nUBZvvpNyzwNfq.json
+++ b/packs-src/2e-skills/skills_Athletics__Endurance_E5nUBZvvpNyzwNfq.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Athletics"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Athletics__Strength_l4DetJw1sQ5UlgfM.json
+++ b/packs-src/2e-skills/skills_Athletics__Strength_l4DetJw1sQ5UlgfM.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Athletics"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Drive__Hover_dNOMcJaVqsmLbAMG.json
+++ b/packs-src/2e-skills/skills_Drive__Hover_dNOMcJaVqsmLbAMG.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Drive"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Drive__Mole_cXXVUb5CTMpcnrBN.json
+++ b/packs-src/2e-skills/skills_Drive__Mole_cXXVUb5CTMpcnrBN.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Drive"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Drive__Tracked_rPpXUWwNtIGtJ329.json
+++ b/packs-src/2e-skills/skills_Drive__Tracked_rPpXUWwNtIGtJ329.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Drive"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Drive__Walker_f2jHOFeaVi4qJr3i.json
+++ b/packs-src/2e-skills/skills_Drive__Walker_f2jHOFeaVi4qJr3i.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Drive"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Drive__Wheeled_BvIE7o9LxxKvhFUT.json
+++ b/packs-src/2e-skills/skills_Drive__Wheeled_BvIE7o9LxxKvhFUT.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Drive"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Electronics__Comms_JCdjyJlMZKiMlZQx.json
+++ b/packs-src/2e-skills/skills_Electronics__Comms_JCdjyJlMZKiMlZQx.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Electronics"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Electronics__Computers_4hFbjpsz0OrZk51E.json
+++ b/packs-src/2e-skills/skills_Electronics__Computers_4hFbjpsz0OrZk51E.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Electronics"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Electronics__Remote_Ops_ZOtEhmCATyc0Eq97.json
+++ b/packs-src/2e-skills/skills_Electronics__Remote_Ops_ZOtEhmCATyc0Eq97.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Electronics"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Electronics__Sensors_Q8SW3HJKiGH61FLV.json
+++ b/packs-src/2e-skills/skills_Electronics__Sensors_Q8SW3HJKiGH61FLV.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Electronics"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Engineer__Jump_Drive_zbPBT52hlNRDeayr.json
+++ b/packs-src/2e-skills/skills_Engineer__Jump_Drive_zbPBT52hlNRDeayr.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Engineer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Engineer__Life_Support_tmZU0S7lsHilGFLk.json
+++ b/packs-src/2e-skills/skills_Engineer__Life_Support_tmZU0S7lsHilGFLk.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Engineer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Engineer__Manoeuvre_Drive_7UFUqHWAviZjCeap.json
+++ b/packs-src/2e-skills/skills_Engineer__Manoeuvre_Drive_7UFUqHWAviZjCeap.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Engineer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Engineer__Power_Plant_Zpaze0ZO5z1IIOA5.json
+++ b/packs-src/2e-skills/skills_Engineer__Power_Plant_Zpaze0ZO5z1IIOA5.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Engineer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Flyer__Airship_vMGV77QpjKwykx5F.json
+++ b/packs-src/2e-skills/skills_Flyer__Airship_vMGV77QpjKwykx5F.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Flyer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Flyer__Grav_X4RvY2cGuMt5GHRA.json
+++ b/packs-src/2e-skills/skills_Flyer__Grav_X4RvY2cGuMt5GHRA.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Flyer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Flyer__Ornithopter_Yn6Jd8Pe2DP6voDW.json
+++ b/packs-src/2e-skills/skills_Flyer__Ornithopter_Yn6Jd8Pe2DP6voDW.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Flyer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Flyer__Rotor_72uDIfCPG73o7PvE.json
+++ b/packs-src/2e-skills/skills_Flyer__Rotor_72uDIfCPG73o7PvE.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Flyer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Flyer__Wing_09eUMj6Vo70lepy0.json
+++ b/packs-src/2e-skills/skills_Flyer__Wing_09eUMj6Vo70lepy0.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Flyer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Gun_Combat__Archaic_zTReagNvq2ddZLYt.json
+++ b/packs-src/2e-skills/skills_Gun_Combat__Archaic_zTReagNvq2ddZLYt.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Gun Combat"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Gun_Combat__Energy_Longarm_oVGDIagn83n27cLp.json
+++ b/packs-src/2e-skills/skills_Gun_Combat__Energy_Longarm_oVGDIagn83n27cLp.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Gun Combat"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Gun_Combat__Energy_Shortarm_vYAxTWVKKFw6joAs.json
+++ b/packs-src/2e-skills/skills_Gun_Combat__Energy_Shortarm_vYAxTWVKKFw6joAs.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Gun Combat"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Gun_Combat__Slug_Longarm_gTtBu7R0HkPLXwa9.json
+++ b/packs-src/2e-skills/skills_Gun_Combat__Slug_Longarm_gTtBu7R0HkPLXwa9.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Gun Combat"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Gun_Combat__Slug_Shortarm_34qstFj1jz7tSPgt.json
+++ b/packs-src/2e-skills/skills_Gun_Combat__Slug_Shortarm_34qstFj1jz7tSPgt.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Gun Combat"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Gunner__Capital_Weapons_ATIKIt9xNCv3DcZE.json
+++ b/packs-src/2e-skills/skills_Gunner__Capital_Weapons_ATIKIt9xNCv3DcZE.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Gunner"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Gunner__Ortillery_22GNsBwEdgZ79Rb9.json
+++ b/packs-src/2e-skills/skills_Gunner__Ortillery_22GNsBwEdgZ79Rb9.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Gunner"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Gunner__Screens_6o5sJIUtgonSMZx5.json
+++ b/packs-src/2e-skills/skills_Gunner__Screens_6o5sJIUtgonSMZx5.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Gunner"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Gunner__Turrets_H1mGn2Im8ZUkqJTS.json
+++ b/packs-src/2e-skills/skills_Gunner__Turrets_H1mGn2Im8ZUkqJTS.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Gunner"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Heavy_Weapons__Artillery_WfHhhImNJrdz4Z8c.json
+++ b/packs-src/2e-skills/skills_Heavy_Weapons__Artillery_WfHhhImNJrdz4Z8c.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Heavy Weapons"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Heavy_Weapons__Man_Portable_zI0NvVk1AuSymODK.json
+++ b/packs-src/2e-skills/skills_Heavy_Weapons__Man_Portable_zI0NvVk1AuSymODK.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Heavy Weapons"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Heavy_Weapons__Vehicles_hA80vsTi1Ikxw1hN.json
+++ b/packs-src/2e-skills/skills_Heavy_Weapons__Vehicles_hA80vsTi1Ikxw1hN.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Heavy Weapons"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Language__Anglic_lQhnoL0dGyCZ2H5A.json
+++ b/packs-src/2e-skills/skills_Language__Anglic_lQhnoL0dGyCZ2H5A.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Language"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Melee__Blade_DiqU81YUe55rQiQt.json
+++ b/packs-src/2e-skills/skills_Melee__Blade_DiqU81YUe55rQiQt.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Melee"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Melee__Bludgeon_Mm3qmaPiwoXeCwBa.json
+++ b/packs-src/2e-skills/skills_Melee__Bludgeon_Mm3qmaPiwoXeCwBa.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Melee"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Melee__Natural_giRXRaFHVqAmxERm.json
+++ b/packs-src/2e-skills/skills_Melee__Natural_giRXRaFHVqAmxERm.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Melee"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Melee__Unarmed_6zhM1erS15PhUDij.json
+++ b/packs-src/2e-skills/skills_Melee__Unarmed_6zhM1erS15PhUDij.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Melee"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Pilot__Capital_Ships_GD9OyyRcYgzxV3Su.json
+++ b/packs-src/2e-skills/skills_Pilot__Capital_Ships_GD9OyyRcYgzxV3Su.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Pilot"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Pilot__Small_Craft_LEkkeeyL85v0x0F7.json
+++ b/packs-src/2e-skills/skills_Pilot__Small_Craft_LEkkeeyL85v0x0F7.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Pilot"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Pilot__Spacecraft_NG94Tq0NOidb2oFp.json
+++ b/packs-src/2e-skills/skills_Pilot__Spacecraft_NG94Tq0NOidb2oFp.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Pilot"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Profession__Belter_aDsYBluoHj5rityF.json
+++ b/packs-src/2e-skills/skills_Profession__Belter_aDsYBluoHj5rityF.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Profession"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Profession__Biologicals_TAvwRZTZiVM246hf.json
+++ b/packs-src/2e-skills/skills_Profession__Biologicals_TAvwRZTZiVM246hf.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Profession"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Profession__Civil_Engineering_YZSkfsTLXTXC7xbz.json
+++ b/packs-src/2e-skills/skills_Profession__Civil_Engineering_YZSkfsTLXTXC7xbz.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Profession"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Profession__Construction_1Le5yHY3XUDiweGR.json
+++ b/packs-src/2e-skills/skills_Profession__Construction_1Le5yHY3XUDiweGR.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Profession"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Profession__Hydroponics_RiSM8gkHi1NOLbGQ.json
+++ b/packs-src/2e-skills/skills_Profession__Hydroponics_RiSM8gkHi1NOLbGQ.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Profession"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Profession__Military_Engineering_itoM7Oqz9Oae1fmA.json
+++ b/packs-src/2e-skills/skills_Profession__Military_Engineering_itoM7Oqz9Oae1fmA.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Profession"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Profession__Polymers_Oqx4s8nXDo7ftzwU.json
+++ b/packs-src/2e-skills/skills_Profession__Polymers_Oqx4s8nXDo7ftzwU.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Profession"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Archaeology_m32rJWav6DxpcXcz.json
+++ b/packs-src/2e-skills/skills_Science__Archaeology_m32rJWav6DxpcXcz.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Astronomy_0V4Nu9mU6C5s0HzF.json
+++ b/packs-src/2e-skills/skills_Science__Astronomy_0V4Nu9mU6C5s0HzF.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Biology_bw8kCLJ4z4lsnl2f.json
+++ b/packs-src/2e-skills/skills_Science__Biology_bw8kCLJ4z4lsnl2f.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Chemistry_c2K9WiJ56Ere0gQK.json
+++ b/packs-src/2e-skills/skills_Science__Chemistry_c2K9WiJ56Ere0gQK.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Cosmology_Zj3nemlkhRyVPmpU.json
+++ b/packs-src/2e-skills/skills_Science__Cosmology_Zj3nemlkhRyVPmpU.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Cybernetics_0HT4PAH76QHKe02E.json
+++ b/packs-src/2e-skills/skills_Science__Cybernetics_0HT4PAH76QHKe02E.json
@@ -24,7 +24,8 @@
     "rolltype": "Normal",
     "trainingNotes": "",
     "name": "Skill Name",
-    "reference": ""
+    "reference": "",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Economics_A0UHP933QNu92zSx.json
+++ b/packs-src/2e-skills/skills_Science__Economics_A0UHP933QNu92zSx.json
@@ -24,7 +24,8 @@
     "rolltype": "Normal",
     "trainingNotes": "",
     "name": "Skill Name",
-    "reference": ""
+    "reference": "",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Genetics_TMqx2bJXImMXXrhH.json
+++ b/packs-src/2e-skills/skills_Science__Genetics_TMqx2bJXImMXXrhH.json
@@ -24,7 +24,8 @@
     "rolltype": "Normal",
     "trainingNotes": "",
     "name": "Skill Name",
-    "reference": ""
+    "reference": "",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__History_Gq8ahQlqLnXe3Cli.json
+++ b/packs-src/2e-skills/skills_Science__History_Gq8ahQlqLnXe3Cli.json
@@ -24,7 +24,8 @@
     "rolltype": "Normal",
     "trainingNotes": "",
     "name": "Skill Name",
-    "reference": ""
+    "reference": "",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Linguistics_SzN3qZehjbNIcvzH.json
+++ b/packs-src/2e-skills/skills_Science__Linguistics_SzN3qZehjbNIcvzH.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Philosophy_mgGVBrcsJ1VjAZPS.json
+++ b/packs-src/2e-skills/skills_Science__Philosophy_mgGVBrcsJ1VjAZPS.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Physics_zHBL1BfPzlPSDNFJ.json
+++ b/packs-src/2e-skills/skills_Science__Physics_zHBL1BfPzlPSDNFJ.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Planetology_fsN85URLm14czWA0.json
+++ b/packs-src/2e-skills/skills_Science__Planetology_fsN85URLm14czWA0.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Psionicology_zI1aQGhtwQtSWuqs.json
+++ b/packs-src/2e-skills/skills_Science__Psionicology_zI1aQGhtwQtSWuqs.json
@@ -24,7 +24,8 @@
     "rolltype": "Normal",
     "trainingNotes": "",
     "name": "Skill Name",
-    "reference": ""
+    "reference": "",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Robotics_CEUOmkrhvChnB4Qm.json
+++ b/packs-src/2e-skills/skills_Science__Robotics_CEUOmkrhvChnB4Qm.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Sophontology_jdQc8fllK414wI7Q.json
+++ b/packs-src/2e-skills/skills_Science__Sophontology_jdQc8fllK414wI7Q.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Science__Xenology_s0IE9Dlx3ifZUBjP.json
+++ b/packs-src/2e-skills/skills_Science__Xenology_s0IE9Dlx3ifZUBjP.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Science"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Seafarer__Ocean_Ships_FHtfZniiQkbR27oG.json
+++ b/packs-src/2e-skills/skills_Seafarer__Ocean_Ships_FHtfZniiQkbR27oG.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Seafarer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Seafarer__Personal_7IfGIUzFdffkQ2X2.json
+++ b/packs-src/2e-skills/skills_Seafarer__Personal_7IfGIUzFdffkQ2X2.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Seafarer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Seafarer__Sail_wsOHgn97OyNNlMgl.json
+++ b/packs-src/2e-skills/skills_Seafarer__Sail_wsOHgn97OyNNlMgl.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Seafarer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Seafarer__Submarine_tGOuw6OKBF0wltZd.json
+++ b/packs-src/2e-skills/skills_Seafarer__Submarine_tGOuw6OKBF0wltZd.json
@@ -17,7 +17,8 @@
     "reference": "",
     "key": "key",
     "difficulty": "Average",
-    "rolltype": "Normal"
+    "rolltype": "Normal",
+    "groupLabel": "Seafarer"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Tactics__Military_cENVR10Z7WR9P2yY.json
+++ b/packs-src/2e-skills/skills_Tactics__Military_cENVR10Z7WR9P2yY.json
@@ -24,7 +24,8 @@
     "rolltype": "Normal",
     "trainingNotes": "",
     "name": "Skill Name",
-    "reference": ""
+    "reference": "",
+    "groupLabel": "Tactics"
   },
   "flags": {
     "cf": {

--- a/packs-src/2e-skills/skills_Tactics__Naval_eTNBELZCOTRVdhuO.json
+++ b/packs-src/2e-skills/skills_Tactics__Naval_eTNBELZCOTRVdhuO.json
@@ -24,7 +24,8 @@
     "rolltype": "Normal",
     "trainingNotes": "",
     "name": "Skill Name",
-    "reference": ""
+    "reference": "",
+    "groupLabel": "Tactics"
   },
   "flags": {
     "cf": {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] We use semantic versioning (https://github.com/semantic-release/semantic-release to be specific), so follow https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Data corrections.

* **What is the current behavior?** (You can also link to an open issue here)

Cascaded skills in the 2e skills pack lack group labels.

* **What is the new behavior (if this is a feature change)?**

Cascaded skills in the 2e skills pack now have group labels.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

There are no breaking changes in this PR. 

* **Other information**:
